### PR TITLE
fix: isolate per-device failures in Lotek pull_observations (GUNDI-5601)

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -10,6 +10,9 @@ from app.services.state import IntegrationStateManager
 
 DEFAULT_TIMEOUT = (3.1, 20)
 DEFAULT_LOOKBACK_DAYS = 60
+# Statuses from the login endpoint that mean the credentials themselves were refused.
+# Lotek answers a bad login with 400; 401/403 are included in case that ever changes.
+CREDENTIAL_REJECTION_STATUSES = frozenset({400, 401, 403})
 
 
 logger = logging.getLogger(__name__)
@@ -126,11 +129,15 @@ async def get_token_from_api(integration, auth):
             response.raise_for_status()
         except httpx.HTTPStatusError as ex:
             msg = f'Lotek login failed for user {auth.username}. Caught exception: {ex}'
-            # A rejected login is an integration-wide credentials problem, not a
-            # per-device blip. Raising the Unauthorized subclass lets callers fail the
-            # whole run instead of retrying the same bad login once per device. Lotek
-            # answers a bad login with 400, so match on the login call, not the status.
-            raise LotekUnauthorizedException(message=msg, error=ex, status_code=ex.response.status_code)
+            status_code = ex.response.status_code
+            if status_code in CREDENTIAL_REJECTION_STATUSES:
+                # A rejected login is an integration-wide credentials problem, not a
+                # per-device blip, and callers abort the whole run on it. Lotek answers
+                # a bad login with 400. Server errors and rate limits are NOT credential
+                # problems — reporting them as such would tell operators their password
+                # is wrong when Lotek is merely down.
+                raise LotekUnauthorizedException(message=msg, error=ex, status_code=status_code)
+            raise LotekException(message=msg, error=ex, status_code=status_code)
         else:
             data = response.json()
             return data.get('access_token', None)

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -34,7 +34,18 @@ class LotekException(Exception):
 
 
 class LotekUnauthorizedException(LotekException):
+    """The login endpoint refused the credentials. Integration-wide and fatal:
+    callers abort the whole run rather than repeat the failure per device."""
     def __init__(self, message: str = "Unauthorized", error: Optional[Exception] = None, status_code: int = 401):
+        super().__init__(message=message, error=error, status_code=status_code)
+
+
+class LotekTokenExpiredException(LotekException):
+    """A 401 on a data call with a (possibly stale) cached token. The cached token
+    is cleared before raising, so a retry re-authenticates; if it persists it is a
+    per-device problem, NOT proof of refused credentials. Deliberately not a
+    subclass of LotekUnauthorizedException so it never triggers the fatal path."""
+    def __init__(self, message: str = "Token expired", error: Optional[Exception] = None, status_code: int = 401):
         super().__init__(message=message, error=error, status_code=status_code)
 
 
@@ -163,7 +174,7 @@ async def get_devices(integration, auth):
                 "pull_observations",
                 "token"
             )
-            raise LotekUnauthorizedException(message=f"401 Response from Lotek API", error=ex)
+            raise LotekTokenExpiredException(message=f"401 Response from Lotek API", error=ex)
         else:
             msg = f'Lotek get_devices failed for user {auth.username}. Caught exception: {ex}'
             raise LotekException(status_code=ex.response.status_code, message=msg, error=ex)
@@ -208,7 +219,7 @@ async def get_positions(device_id, auth, integration, start_datetime=None, end_d
                     "pull_observations",
                     "token"
                 )
-                raise LotekUnauthorizedException(message=f"401 Response from Lotek API", error=ex)
+                raise LotekTokenExpiredException(message=f"401 Response from Lotek API", error=ex)
 
             msg = f'Lotek get_positions failed for user {auth.username}. Caught exception: {ex}'
             logger.exception(

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -126,7 +126,11 @@ async def get_token_from_api(integration, auth):
             response.raise_for_status()
         except httpx.HTTPStatusError as ex:
             msg = f'Lotek login failed for user {auth.username}. Caught exception: {ex}'
-            raise LotekException(message=msg, error=ex, status_code=ex.response.status_code)
+            # A rejected login is an integration-wide credentials problem, not a
+            # per-device blip. Raising the Unauthorized subclass lets callers fail the
+            # whole run instead of retrying the same bad login once per device. Lotek
+            # answers a bad login with 400, so match on the login call, not the status.
+            raise LotekUnauthorizedException(message=msg, error=ex, status_code=ex.response.status_code)
         else:
             data = response.json()
             return data.get('access_token', None)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -22,6 +22,22 @@ logger = logging.getLogger(__name__)
 state_manager = IntegrationStateManager()
 
 
+# Lotek read timeouts are the common transient failure; retrying them costs one extra
+# request but saves a device from being skipped for a whole cycle. Unauthorized is here
+# because the client clears the cached token before raising, so a retry re-authenticates.
+RETRYABLE_ERRORS = (LotekUnauthorizedException, httpx.TimeoutException, httpx.TransportError)
+RETRY_ATTEMPTS = 3
+RETRY_WAIT_INITIAL = 1.0
+RETRY_WAIT_JITTER = 5.0
+RETRY_WAIT_MAX = 32.0
+
+
+def describe_exception(exc):
+    # httpx timeout exceptions carry an empty message, which used to render as a bare
+    # "Exception: " in the activity log and told operators nothing.
+    return str(exc) or type(exc).__name__
+
+
 def generate_batches(iterable, n=settings.OBSERVATIONS_BATCH_SIZE):
     for i in range(0, len(iterable), n):
         yield iterable[i: i + n]
@@ -144,8 +160,10 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     lookback = timedelta(days=action_config.default_lookback_days)
     default_start = present_time - lookback
     observations_extracted = 0
+    failed_devices = []
     for device in device_list:
         cdip_positions = []
+        device_failed = False
         try:
             saved_state = await state_manager.get_state(str(integration.id), "pull_observations", device.nDeviceID)
             state = client.IntegrationState.parse_obj({"updated_at": saved_state.get("updated_at") or default_start})
@@ -158,12 +176,16 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         while lower_date < present_time:
             upper_date = min(present_time, lower_date + timedelta(days=7))
             try:
-                async for attempt in stamina.retry_context(on=LotekUnauthorizedException, attempts=3, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0):
+                async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
                     with attempt:
                         positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
                 logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
-            except httpx.HTTPError as e:
-                message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration.id} Exception: {e}"
+            except LotekUnauthorizedException:
+                # Credentials are an integration-wide problem: every remaining device
+                # would fail the same way, so fail fast instead of N identical errors.
+                raise
+            except (httpx.HTTPError, LotekException) as e:
+                message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration.id} Exception: {describe_exception(e)}"
                 logger.exception(message)
                 await log_action_activity(
                     integration_id=str(integration.id),
@@ -171,9 +193,17 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                     title=message,
                     level=LogLevel.ERROR
                 )
-                raise LotekException(message=message, error=e)
+                device_failed = True
+                break
             cdip_positions.extend(filter_and_transform_positions(positions, integration, action_config))
             lower_date = upper_date
+
+        if device_failed:
+            # Drop whatever chunks did succeed and leave the cursor untouched, so the
+            # whole window is re-fetched next run rather than partly sent now and sent
+            # again later. Keep going: one unreachable device must not stop the others.
+            failed_devices.append(device.nDeviceID)
+            continue
 
         if cdip_positions:
             logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
@@ -211,4 +241,18 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             device.nDeviceID
         )
 
-    return {'observations_extracted': observations_extracted}
+    if failed_devices:
+        message = (
+            f"Pulled observations with {len(failed_devices)} device(s) failing for integration "
+            f"{integration.id}: {', '.join(failed_devices)}. Their cursors were left untouched "
+            f"and will be retried on the next run."
+        )
+        logger.warning(message)
+        await log_action_activity(
+            integration_id=str(integration.id),
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+
+    return {'observations_extracted': observations_extracted, 'devices_failed': failed_devices}

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -10,7 +10,7 @@ import app.settings.integration as settings
 from datetime import datetime, timezone, timedelta
 
 from app.services.errors import ConfigurationNotFound
-from app.actions.client import LotekException, LotekUnauthorizedException
+from app.actions.client import LotekException, LotekTokenExpiredException, LotekUnauthorizedException
 from app.services.utils import find_config_for_action
 from app.actions.configurations import AuthenticateConfig, PullObservationsConfig
 from app.actions.core import action_title
@@ -23,9 +23,11 @@ state_manager = IntegrationStateManager()
 
 
 # Lotek read timeouts are the common transient failure; retrying them costs one extra
-# request but saves a device from being skipped for a whole cycle. Unauthorized is here
+# request but saves a device from being skipped for a whole cycle. Token expiry is here
 # because the client clears the cached token before raising, so a retry re-authenticates.
-RETRYABLE_ERRORS = (LotekUnauthorizedException, httpx.TransportError)  # TransportError covers timeouts
+# A refused login (LotekUnauthorizedException) is deliberately NOT retryable: it is
+# fatal to the run, and retrying a rejected password risks account lockout.
+RETRYABLE_ERRORS = (LotekTokenExpiredException, httpx.TransportError)  # TransportError covers timeouts
 RETRY_ATTEMPTS = 3
 RETRY_WAIT_INITIAL = 1.0
 RETRY_WAIT_JITTER = 5.0
@@ -75,9 +77,14 @@ async def action_auth(integration, action_config: AuthenticateConfig):
     logger.info(f"Executing auth action with integration {integration} and action_config {action_config}...")
     try:
         token = await client.get_token_from_api(integration, action_config)
-    except LotekException as e:
+    except LotekUnauthorizedException as e:
         logger.exception(f"Auth unsuccessful for integration {integration.id}. Exception: {e}")
         return {"valid_credentials": False, "message": "Invalid credentials"}
+    except LotekException as e:
+        # Login 5xx/429: Lotek is down or throttling, not a credentials problem —
+        # don't send the operator off to reset a working password.
+        logger.exception(f"Auth action failed for integration {integration.id}. Exception: {e}")
+        return {"error": "An internal error occurred while trying to test credentials. Please try again later."}
     except httpx.HTTPError as e:
         logger.exception(f"Auth action failed for integration {integration.id}. Exception: {e}")
         return {"error": "An internal error occurred while trying to test credentials. Please try again later."}
@@ -143,7 +150,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
     auth = get_auth_config(integration)
     try:
-        async for attempt in stamina.retry_context(on=LotekUnauthorizedException, attempts=3, wait_initial=1.0, wait_jitter=5.0, wait_max=32.0):
+        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
                 device_list = await client.get_devices(integration, auth)
     except Exception as e:
@@ -190,18 +197,6 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         if device_failed:
             failed_devices.append(device.nDeviceID)
 
-    if device_list and len(failed_devices) == len(device_list) and observations_extracted == 0:
-        # Every device failed and nothing was delivered: report the run as failed rather
-        # than returning normally, otherwise a wholly broken integration keeps publishing
-        # action_complete and looks healthy in the portal. A device that delivered part
-        # of its window before failing still counts as progress, so it stays a warning.
-        raise LotekException(
-            message=(
-                f"All {len(device_list)} device(s) failed for integration {integration.id}. "
-                f"See the per-device errors in this action's activity log."
-            )
-        )
-
     if failed_devices:
         listed = ', '.join(failed_devices[:MAX_DEVICES_IN_SUMMARY])
         if len(failed_devices) > MAX_DEVICES_IN_SUMMARY:
@@ -217,6 +212,19 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             action_id="pull_observations",
             title=message,
             level=LogLevel.WARNING
+        )
+
+    if device_list and len(failed_devices) == len(device_list) and observations_extracted == 0:
+        # Every device failed and nothing was delivered: report the run as failed rather
+        # than returning normally, otherwise a wholly broken integration keeps publishing
+        # action_complete and looks healthy in the portal. A device that delivered part
+        # of its window before failing still counts as progress, so it stays a warning.
+        # This comes after the summary so the worst case keeps its device-naming log.
+        raise LotekException(
+            message=(
+                f"All {len(device_list)} device(s) failed for integration {integration.id}. "
+                f"See the per-device errors in this action's activity log."
+            )
         )
 
     return {'observations_extracted': observations_extracted, 'devices_failed': failed_devices}
@@ -248,6 +256,9 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
                 with attempt:
                     positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
             logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
+            # Transform inside the try: a malformed payload is a per-device, fetch-class
+            # failure and must get the same device/date-window log and isolation.
+            cdip_positions.extend(filter_and_transform_positions(positions, integration, action_config))
         except LotekUnauthorizedException:
             # Credentials are an integration-wide problem: every remaining device
             # would fail the same way, so fail fast instead of N identical errors.
@@ -267,9 +278,23 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
             )
             device_failed = True
             break
-        cdip_positions.extend(filter_and_transform_positions(positions, integration, action_config))
         last_successful_upper = upper_date
         lower_date = upper_date
+
+    if not cdip_positions and not device_failed:
+        # Purely informational; must never affect the device's outcome. A pubsub blip
+        # here must not mark a healthy quiet device as failed or stall its cursor.
+        message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
+        logger.info(message)
+        try:
+            await log_action_activity(
+                integration_id=str(integration.id),
+                action_id="pull_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
+        except Exception as e:
+            logger.warning(f"Could not publish activity log for device {device.nDeviceID}: {describe_exception(e)}")
 
     observations_sent = 0
     try:
@@ -279,15 +304,6 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
                 logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
                 await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
                 observations_sent += len(batch)
-        elif not device_failed:
-            message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
-            logger.info(message)
-            await log_action_activity(
-                integration_id=str(integration.id),
-                action_id="pull_observations",
-                title=message,
-                level=LogLevel.WARNING
-            )
     except Exception as e:
         # Handled here rather than in the caller so batches already delivered keep
         # counting toward the run's total — otherwise a send/checkpoint failure after a

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -272,21 +272,40 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
         lower_date = upper_date
 
     observations_sent = 0
-    if cdip_positions:
-        logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
-        for i, batch in enumerate(generate_batches(cdip_positions)):
-            logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
-            await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
-            observations_sent += len(batch)
-    elif not device_failed:
-        message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
-        logger.info(message)
+    try:
+        if cdip_positions:
+            logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
+            for i, batch in enumerate(generate_batches(cdip_positions)):
+                logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
+                await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
+                observations_sent += len(batch)
+        elif not device_failed:
+            message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
+            logger.info(message)
+            await log_action_activity(
+                integration_id=str(integration.id),
+                action_id="pull_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
+    except Exception as e:
+        # Handled here rather than in the caller so batches already delivered keep
+        # counting toward the run's total — otherwise a send/checkpoint failure after a
+        # successful delivery reports "nothing delivered". Cursor stays untouched below,
+        # so the un-delivered remainder is re-fetched next run (re-sends are tolerated,
+        # silent skips are not).
+        message = (
+            f"Error delivering observations for device {device.nDeviceID}. Integration ID: "
+            f"{integration.id} Exception: {describe_exception(e)}"
+        )
+        logger.exception(message)
         await log_action_activity(
             integration_id=str(integration.id),
             action_id="pull_observations",
             title=message,
-            level=LogLevel.WARNING
+            level=LogLevel.ERROR
         )
+        return observations_sent, True
 
     # Advance state by the queried window (upload time), not recorded_at. Queries are by
     # upload date, so wall clock is the correct cursor, and it must advance even when a
@@ -295,11 +314,25 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
     # re-sending what already landed; if nothing succeeded, leave the cursor alone.
     checkpoint = present_time if not device_failed else last_successful_upper
     if checkpoint is not None:
-        await state_manager.set_state(
-            str(integration.id),
-            "pull_observations",
-            {"updated_at": checkpoint.isoformat()},
-            device.nDeviceID
-        )
+        try:
+            await state_manager.set_state(
+                str(integration.id),
+                "pull_observations",
+                {"updated_at": checkpoint.isoformat()},
+                device.nDeviceID
+            )
+        except Exception as e:
+            message = (
+                f"Error saving cursor for device {device.nDeviceID}. Integration ID: "
+                f"{integration.id} Exception: {describe_exception(e)}"
+            )
+            logger.exception(message)
+            await log_action_activity(
+                integration_id=str(integration.id),
+                action_id="pull_observations",
+                title=message,
+                level=LogLevel.ERROR
+            )
+            return observations_sent, True
 
     return observations_sent, device_failed

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -30,6 +30,8 @@ RETRY_ATTEMPTS = 3
 RETRY_WAIT_INITIAL = 1.0
 RETRY_WAIT_JITTER = 5.0
 RETRY_WAIT_MAX = 32.0
+# A Lotek-wide outage can fail every device; don't put hundreds of ids in a log title.
+MAX_DEVICES_IN_SUMMARY = 20
 
 
 def describe_exception(exc):
@@ -162,94 +164,52 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     observations_extracted = 0
     failed_devices = []
     for device in device_list:
-        cdip_positions = []
-        device_failed = False
         try:
-            saved_state = await state_manager.get_state(str(integration.id), "pull_observations", device.nDeviceID)
-            state = client.IntegrationState.parse_obj({"updated_at": saved_state.get("updated_at") or default_start})
-        except pydantic.ValidationError as e:
-            logger.debug(f"Failed to parse saved state for device {device.nDeviceID}, using default state. Error: {e}")
-            state = client.IntegrationState(updated_at=default_start)
-
-        # Hard limit on query window; 2h overlap buffer to catch late-arriving uploads.
-        lower_date = max(default_start, state.updated_at - timedelta(hours=2))
-        while lower_date < present_time:
-            upper_date = min(present_time, lower_date + timedelta(days=7))
-            try:
-                async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
-                    with attempt:
-                        positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
-                logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
-            except LotekUnauthorizedException:
-                # Credentials are an integration-wide problem: every remaining device
-                # would fail the same way, so fail fast instead of N identical errors.
-                raise
-            except Exception as e:
-                # Deliberately broad: malformed data from Lotek surfaces as KeyError or
-                # pydantic.ValidationError out of the client's parsing, and those must
-                # not take down the devices behind this one either. CancelledError is a
-                # BaseException, so the action timeout still unwinds normally.
-                message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration.id} Exception: {describe_exception(e)}"
-                logger.exception(message)
-                await log_action_activity(
-                    integration_id=str(integration.id),
-                    action_id="pull_observations",
-                    title=message,
-                    level=LogLevel.ERROR
-                )
-                device_failed = True
-                break
-            cdip_positions.extend(filter_and_transform_positions(positions, integration, action_config))
-            lower_date = upper_date
-
-        if device_failed:
-            # Drop whatever chunks did succeed and leave the cursor untouched, so the
-            # whole window is re-fetched next run rather than partly sent now and sent
-            # again later. Keep going: one unreachable device must not stop the others.
-            failed_devices.append(device.nDeviceID)
-            continue
-
-        if cdip_positions:
-            logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
-            for i, batch in enumerate(generate_batches(cdip_positions)):
-                try:
-                    logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
-                    await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
-                except httpx.HTTPError as e:
-                    msg = f'Sensors API returned error for integration_id: {str(integration.id)}. Exception: {e}'
-                    logger.exception(msg, extra={
-                        'needs_attention': True,
-                        'integration_id': integration.id,
-                        'action_id': "pull_observations"
-                    })
-                    raise e
-                else:
-                    observations_extracted += len(batch)
-        else:
-            message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
-            logger.info(message)
+            sent, device_failed = await _pull_device_observations(
+                device, integration, auth, action_config, present_time, default_start
+            )
+        except LotekUnauthorizedException:
+            raise
+        except Exception as e:
+            # Sending to Gundi and checkpointing can fail too, and a device that fetched
+            # fine but failed downstream must not take the rest of the batch with it.
+            message = (
+                f"Failed to process device {device.nDeviceID} for integration "
+                f"{integration.id}: {describe_exception(e)}"
+            )
+            logger.exception(message)
             await log_action_activity(
                 integration_id=str(integration.id),
                 action_id="pull_observations",
                 title=message,
-                level=LogLevel.WARNING
+                level=LogLevel.ERROR
             )
+            failed_devices.append(device.nDeviceID)
+            continue
+        observations_extracted += sent
+        if device_failed:
+            failed_devices.append(device.nDeviceID)
 
-        # Advance state by the queried window (upload time), not recorded_at.
-        # Queries are by upload date, so wall clock is the correct cursor,
-        # and it must advance even when a device returns no positions.
-        await state_manager.set_state(
-            str(integration.id),
-            "pull_observations",
-            {"updated_at": present_time.isoformat()},
-            device.nDeviceID
+    if device_list and len(failed_devices) == len(device_list) and observations_extracted == 0:
+        # Every device failed and nothing was delivered: report the run as failed rather
+        # than returning normally, otherwise a wholly broken integration keeps publishing
+        # action_complete and looks healthy in the portal. A device that delivered part
+        # of its window before failing still counts as progress, so it stays a warning.
+        raise LotekException(
+            message=(
+                f"All {len(device_list)} device(s) failed for integration {integration.id}. "
+                f"See the per-device errors in this action's activity log."
+            )
         )
 
     if failed_devices:
+        listed = ', '.join(failed_devices[:MAX_DEVICES_IN_SUMMARY])
+        if len(failed_devices) > MAX_DEVICES_IN_SUMMARY:
+            listed += f" and {len(failed_devices) - MAX_DEVICES_IN_SUMMARY} more"
         message = (
-            f"Pulled observations with {len(failed_devices)} device(s) failing for integration "
-            f"{integration.id}: {', '.join(failed_devices)}. Their cursors were left untouched "
-            f"and will be retried on the next run."
+            f"Pulled observations with {len(failed_devices)} of {len(device_list)} device(s) "
+            f"failing for integration {integration.id}: {listed}. They will be retried on the "
+            f"next run."
         )
         logger.warning(message)
         await log_action_activity(
@@ -260,3 +220,86 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         )
 
     return {'observations_extracted': observations_extracted, 'devices_failed': failed_devices}
+
+
+async def _pull_device_observations(device, integration, auth, action_config, present_time, default_start):
+    """Fetch, deliver and checkpoint one device.
+
+    Returns (observations_sent, device_failed). Raises only for integration-wide
+    problems; per-device problems are reported through the returned flag so the
+    caller can keep going.
+    """
+    cdip_positions = []
+    device_failed = False
+    last_successful_upper = None
+    try:
+        saved_state = await state_manager.get_state(str(integration.id), "pull_observations", device.nDeviceID)
+        state = client.IntegrationState.parse_obj({"updated_at": saved_state.get("updated_at") or default_start})
+    except pydantic.ValidationError as e:
+        logger.debug(f"Failed to parse saved state for device {device.nDeviceID}, using default state. Error: {e}")
+        state = client.IntegrationState(updated_at=default_start)
+
+    # Hard limit on query window; 2h overlap buffer to catch late-arriving uploads.
+    lower_date = max(default_start, state.updated_at - timedelta(hours=2))
+    while lower_date < present_time:
+        upper_date = min(present_time, lower_date + timedelta(days=7))
+        try:
+            async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+                with attempt:
+                    positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
+            logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
+        except LotekUnauthorizedException:
+            # Credentials are an integration-wide problem: every remaining device
+            # would fail the same way, so fail fast instead of N identical errors.
+            raise
+        except Exception as e:
+            # Deliberately broad: malformed data from Lotek surfaces as KeyError or
+            # pydantic.ValidationError out of the client's parsing, and those must
+            # not take down the devices behind this one either. CancelledError is a
+            # BaseException, so the action timeout still unwinds normally.
+            message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration.id} Exception: {describe_exception(e)}"
+            logger.exception(message)
+            await log_action_activity(
+                integration_id=str(integration.id),
+                action_id="pull_observations",
+                title=message,
+                level=LogLevel.ERROR
+            )
+            device_failed = True
+            break
+        cdip_positions.extend(filter_and_transform_positions(positions, integration, action_config))
+        last_successful_upper = upper_date
+        lower_date = upper_date
+
+    observations_sent = 0
+    if cdip_positions:
+        logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
+        for i, batch in enumerate(generate_batches(cdip_positions)):
+            logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
+            await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
+            observations_sent += len(batch)
+    elif not device_failed:
+        message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
+        logger.info(message)
+        await log_action_activity(
+            integration_id=str(integration.id),
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+
+    # Advance state by the queried window (upload time), not recorded_at. Queries are by
+    # upload date, so wall clock is the correct cursor, and it must advance even when a
+    # device returns no positions. When a chunk failed, checkpoint only as far as the
+    # last window that actually succeeded so the failed window is retried without
+    # re-sending what already landed; if nothing succeeded, leave the cursor alone.
+    checkpoint = present_time if not device_failed else last_successful_upper
+    if checkpoint is not None:
+        await state_manager.set_state(
+            str(integration.id),
+            "pull_observations",
+            {"updated_at": checkpoint.isoformat()},
+            device.nDeviceID
+        )
+
+    return observations_sent, device_failed

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -25,7 +25,7 @@ state_manager = IntegrationStateManager()
 # Lotek read timeouts are the common transient failure; retrying them costs one extra
 # request but saves a device from being skipped for a whole cycle. Unauthorized is here
 # because the client clears the cached token before raising, so a retry re-authenticates.
-RETRYABLE_ERRORS = (LotekUnauthorizedException, httpx.TimeoutException, httpx.TransportError)
+RETRYABLE_ERRORS = (LotekUnauthorizedException, httpx.TransportError)  # TransportError covers timeouts
 RETRY_ATTEMPTS = 3
 RETRY_WAIT_INITIAL = 1.0
 RETRY_WAIT_JITTER = 5.0
@@ -184,7 +184,11 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                 # Credentials are an integration-wide problem: every remaining device
                 # would fail the same way, so fail fast instead of N identical errors.
                 raise
-            except (httpx.HTTPError, LotekException) as e:
+            except Exception as e:
+                # Deliberately broad: malformed data from Lotek surfaces as KeyError or
+                # pydantic.ValidationError out of the client's parsing, and those must
+                # not take down the devices behind this one either. CancelledError is a
+                # BaseException, so the action timeout still unwinds normally.
                 message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration.id} Exception: {describe_exception(e)}"
                 logger.exception(message)
                 await log_action_activity(

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -10,6 +10,7 @@ from app.actions.client import (
     get_positions,
     LotekDevice,
     LotekException,
+    LotekTokenExpiredException,
     LotekUnauthorizedException, LotekPosition,
 )
 
@@ -88,7 +89,9 @@ async def test_get_devices_unauthorized_raises(mocker, lotek_integration, auth_c
     mocker.patch("app.actions.client.state_manager.delete_state", return_value=None)
     mocker.patch("app.actions.client.httpx.AsyncClient", return_value=mock_client)
 
-    with pytest.raises(LotekUnauthorizedException):
+    # 401 with a cached token means the token expired, not that credentials were
+    # refused; it must not carry the type that aborts the whole run.
+    with pytest.raises(LotekTokenExpiredException):
         await get_devices(lotek_integration, auth_config)
 
 
@@ -129,7 +132,7 @@ async def test_get_positions_unauthorized_raises(mocker, lotek_integration, auth
 
     from_date = datetime.now(timezone.utc)
     to_date = datetime.now(timezone.utc)
-    with pytest.raises(LotekUnauthorizedException):
+    with pytest.raises(LotekTokenExpiredException):
         await get_positions(1, auth_config, lotek_integration, from_date, to_date, True)
 
 

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -144,3 +144,30 @@ async def test_get_positions_http_error_raises_lotek_exception(mocker, lotek_int
     to_date = datetime.now(timezone.utc)
     with pytest.raises(LotekException):
         await get_positions(1, auth_config, lotek_integration, from_date, to_date, True)
+
+
+@pytest.mark.parametrize("status", [400, 401, 403])
+@pytest.mark.asyncio
+async def test_get_token_from_api_rejected_login_is_unauthorized(mocker, lotek_integration, auth_config, status):
+    # Only a genuine credentials rejection should be Unauthorized, because callers
+    # abort the whole run on it. Lotek answers a bad login with 400.
+    resp = httpx.Response(status, json={"error": "invalid_grant"}, request=httpx.Request("POST", lotek_integration.base_url))
+    mock_client = _make_mock_client(response=resp, method="post")
+    mocker.patch("app.actions.client.httpx.AsyncClient", return_value=mock_client)
+
+    with pytest.raises(LotekUnauthorizedException):
+        await get_token_from_api(lotek_integration, auth_config)
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503])
+@pytest.mark.asyncio
+async def test_get_token_from_api_server_failure_is_not_unauthorized(mocker, lotek_integration, auth_config, status):
+    # A Lotek outage or rate limit is not a credentials problem; reporting it as one
+    # would tell operators their credentials are wrong when the server is just down.
+    resp = httpx.Response(status, json={"error": "server"}, request=httpx.Request("POST", lotek_integration.base_url))
+    mock_client = _make_mock_client(response=resp, method="post")
+    mocker.patch("app.actions.client.httpx.AsyncClient", return_value=mock_client)
+
+    with pytest.raises(LotekException) as excinfo:
+        await get_token_from_api(lotek_integration, auth_config)
+    assert not isinstance(excinfo.value, LotekUnauthorizedException)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -589,3 +589,171 @@ async def test_action_pull_observations_error(mocker, lotek_integration, pull_co
         level=LogLevel.ERROR,
         title=f"Error fetching devices from Lotek. Integration ID: {str(lotek_integration.id)} Exception: 500: Lotek get_devices failed for user test_user. | Error: "
     )
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_isolates_persistent_401_on_one_device(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A 401 that persists for one device after re-auth retries is a device problem
+    # (or an auth flake), not proof of refused credentials — it must not abort the
+    # run. Only a refused login (LotekUnauthorizedException from the login endpoint)
+    # aborts. This is the GUNDI-5601 starvation bug via a third path.
+    from app.actions.client import LotekTokenExpiredException
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    queried = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        queried.append(device_id)
+        if device_id == "2":
+            raise LotekTokenExpiredException(message="401 Response from Lotek API")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert queried[-1] == "3", "devices after the 401 device were never queried"
+    assert result["devices_failed"] == ["2"]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_does_not_retry_rejected_login_at_get_devices(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A definitively refused login must fail immediately, not be retried with waits.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+
+    attempts = []
+
+    async def get_devices(integration, auth):
+        attempts.append(1)
+        raise LotekUnauthorizedException(message="Lotek login failed", status_code=400)
+
+    mocker.patch("app.actions.client.get_devices", new=get_devices)
+
+    with pytest.raises(LotekUnauthorizedException):
+        await action_pull_observations(lotek_integration, pull_config)
+
+    assert len(attempts) == 1, f"refused login was retried {len(attempts)} times"
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_quiet_device_unaffected_by_logging_failure(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # The "No positions fetched" entry is informational; a pubsub blip while logging
+    # it must not mark a healthy quiet device as failed or stall its cursor.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[]))
+    mocker.patch("app.actions.handlers.log_action_activity",
+                 new=AsyncMock(side_effect=RuntimeError("pubsub down")))
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result["devices_failed"] == []
+    assert [c.args[-1] for c in mock_set_state.call_args_list] == ["1"], "cursor was not advanced"
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_delivers_partial_chunks_when_transform_fails(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A transform failure on a later chunk is a per-device failure like any other:
+    # chunks already fetched must still be delivered and checkpointed.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mock_send = mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+    pull_config.default_lookback_days = 30
+
+    windows = []
+
+    async def get_positions(device_id, auth, integration, lower, upper, geo_only):
+        if lower not in windows:
+            windows.append(lower)
+        if windows.index(lower) == 2:
+            return None  # malformed response: filter_and_transform will blow up iterating
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result["devices_failed"] == ["1"]
+    assert mock_send.call_count >= 1, "chunks fetched before the transform failure were discarded"
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_emits_summary_before_all_failed_raise(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # In the worst case (everything failed) the summary naming the devices is the
+    # most valuable diagnostic — it must be emitted before the raise, not skipped.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+
+    with pytest.raises(LotekException):
+        await action_pull_observations(lotek_integration, pull_config)
+
+    warnings = [c.kwargs["title"] for c in mock_log_action_activity.call_args_list
+                if c.kwargs.get("level") == LogLevel.WARNING and "failing" in c.kwargs["title"]]
+    assert warnings, "summary was not emitted before the all-failed raise"
+    assert "2 of 2" in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_action_auth_reports_server_error_as_internal_not_invalid_credentials(
+    mocker, lotek_integration, auth_config
+):
+    # A Lotek 500 on login is not the operator's fault; saying "Invalid credentials"
+    # sends them to reset a working password.
+    mocker.patch("app.actions.client.get_token_from_api",
+                 new=AsyncMock(side_effect=LotekException(message="login 500", status_code=500)))
+    result = await action_auth(lotek_integration, auth_config)
+    assert "error" in result
+    assert result.get("valid_credentials") is not False
+
+
+@pytest.mark.asyncio
+async def test_action_auth_reports_rejected_login_as_invalid_credentials(
+    mocker, lotek_integration, auth_config
+):
+    mocker.patch("app.actions.client.get_token_from_api",
+                 new=AsyncMock(side_effect=LotekUnauthorizedException(message="login 400", status_code=400)))
+    result = await action_auth(lotek_integration, auth_config)
+    assert result == {"valid_credentials": False, "message": "Invalid credentials"}

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -241,6 +241,162 @@ async def test_action_pull_observations_continues_after_malformed_device_data(
 
 
 @pytest.mark.asyncio
+async def test_action_pull_observations_aborts_when_login_is_rejected(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A rejected login is integration-wide. It reaches the handler from inside
+    # get_positions (cached token expires mid-run), and must not be retried once per
+    # device against a rejecting endpoint.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+
+    logins = []
+
+    async def get_token_from_api(integration, auth):
+        logins.append(auth.username)
+        response = httpx.Response(400, request=httpx.Request("POST", "https://lotek/user/login"))
+        raise LotekUnauthorizedException(
+            message="Lotek login failed", error=httpx.HTTPStatusError("bad", request=response.request, response=response),
+            status_code=400,
+        )
+
+    mocker.patch("app.actions.client.get_token_from_api", new=get_token_from_api)
+    mocker.patch("app.services.state.IntegrationStateManager.delete_state", new=AsyncMock(return_value=None))
+
+    with pytest.raises(LotekUnauthorizedException):
+        await action_pull_observations(lotek_integration, pull_config)
+
+    assert len(logins) <= RETRY_ATTEMPTS, f"login retried per device: {len(logins)} attempts"
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_continues_when_one_device_send_fails(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # Failing to deliver one device's observations must not stop the other devices
+    # either — the batch is only as isolated as its least-guarded step.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[lotek_position]))
+
+    sent_for = []
+
+    async def send_observations_to_gundi(observations, integration_id):
+        sent_for.append(observations[0]["source"])
+        if len(sent_for) == 1:
+            raise httpx.ConnectError("gundi unreachable")
+
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=send_observations_to_gundi)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert len(sent_for) == 2, "second device was never attempted"
+    assert result["devices_failed"] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_continues_when_one_device_checkpoint_fails(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A Redis hiccup while checkpointing one device must not abort the run.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[lotek_position]))
+
+    checkpointed = []
+
+    async def set_state(self, integration_id, action_id, state, source_id="no-source"):
+        checkpointed.append(source_id)
+        if source_id == "1":
+            raise RuntimeError("redis down")
+
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=set_state)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert "2" in checkpointed, "second device was never processed"
+    assert result["devices_failed"] == ["1"]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_fails_when_every_device_fails(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A wholly broken integration must not report success, or the portal shows it green.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
+
+    with pytest.raises(LotekException):
+        await action_pull_observations(lotek_integration, pull_config)
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_keeps_successful_chunks_when_later_chunk_fails(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # With a lookback wider than one chunk, data already fetched should be delivered and
+    # checkpointed up to the last good window instead of being thrown away every run.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mock_send = mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+    pull_config.default_lookback_days = 30
+
+    windows = []
+
+    async def get_positions(device_id, auth, integration, lower, upper, geo_only):
+        if lower not in windows:
+            windows.append(lower)
+        # the third window fails every time, so retries are exhausted on it
+        if windows.index(lower) == 2:
+            raise httpx.ReadTimeout("")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert mock_send.call_count >= 1, "successful chunks were discarded"
+    assert result["devices_failed"] == ["1"]
+    # cursor advanced only as far as the last chunk that actually succeeded
+    checkpoint = mock_set_state.call_args_list[0].args[2]["updated_at"]
+    assert checkpoint < present_time_isoformat_upper_bound()
+
+
+def present_time_isoformat_upper_bound():
+    return datetime.now(timezone.utc).isoformat()
+
+
+@pytest.mark.asyncio
 async def test_action_pull_observations_does_not_advance_state_for_failed_device(
     mocker, lotek_integration, pull_config, mock_redis, lotek_position
 ):
@@ -285,7 +441,9 @@ async def test_action_pull_observations_logs_exception_type_when_message_is_empt
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
 
-    await action_pull_observations(lotek_integration, pull_config)
+    # the only device fails and delivers nothing, so the run is reported as failed
+    with pytest.raises(LotekException):
+        await action_pull_observations(lotek_integration, pull_config)
 
     titles = [call.kwargs["title"] for call in mock_log_action_activity.call_args_list]
     error_titles = [t for t in titles if "Error fetching positions" in t]

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -757,3 +757,36 @@ async def test_action_auth_reports_rejected_login_as_invalid_credentials(
                  new=AsyncMock(side_effect=LotekUnauthorizedException(message="login 400", status_code=400)))
     result = await action_auth(lotek_integration, auth_config)
     assert result == {"valid_credentials": False, "message": "Invalid credentials"}
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_retries_token_expiry_and_recovers(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A single token expiry must be retried (the client cleared the cached token, so
+    # the retry re-authenticates), not treated as a device failure for the cycle.
+    from app.actions.client import LotekTokenExpiredException
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    attempts = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        attempts.append(device_id)
+        if len(attempts) == 1:
+            raise LotekTokenExpiredException(message="401 Response from Lotek API")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert len(attempts) == 2, "token expiry was not retried"
+    assert result == {"observations_extracted": 1, "devices_failed": []}

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 from gundi_core.schemas.v2 import LogLevel
-from app.actions.handlers import action_auth, filter_and_transform_positions, action_pull_observations
+from app.actions.handlers import (
+    RETRY_ATTEMPTS,
+    action_auth,
+    action_pull_observations,
+    filter_and_transform_positions,
+)
 from app.actions.client import LotekDevice, LotekException, LotekUnauthorizedException
 
 
@@ -94,7 +99,7 @@ async def test_invalid_position_filtered_and_logs_warning_when_no_valid_observat
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
     result = await action_pull_observations(lotek_integration, pull_config)
-    assert result == {'observations_extracted': 0}
+    assert result == {'observations_extracted': 0, 'devices_failed': []}
     mock_log_action_activity.assert_any_call(
         integration_id=str(lotek_integration.id),
         action_id="pull_observations",
@@ -130,7 +135,191 @@ async def test_action_pull_observations_success(mocker, lotek_integration, pull_
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     result = await action_pull_observations(lotek_integration, pull_config)
-    assert result == {'observations_extracted': 0}
+    assert result == {'observations_extracted': 0, 'devices_failed': []}
+
+def _devices(*device_ids):
+    return [
+        LotekDevice(nDeviceID=device_id, strSpecialID="special", dtCreated=datetime.now(), strSatellite="satellite")
+        for device_id in device_ids
+    ]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_continues_after_one_device_fails(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A device whose positions can't be fetched must not stop the devices behind it.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mock_send = mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    queried = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        queried.append(device_id)
+        if device_id == "2":
+            raise httpx.ReadTimeout("Lotek timed out")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    # Device 2 exhausts its retries and is given up on, but device 3 is still reached.
+    assert queried[0] == "1"
+    assert queried[-1] == "3"
+    assert queried.count("2") == RETRY_ATTEMPTS
+    assert result == {"observations_extracted": 2, "devices_failed": ["2"]}
+    assert mock_send.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_continues_after_lotek_error_status(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # get_positions raises LotekException (not an httpx error) for non-400/401 statuses.
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    queried = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        queried.append(device_id)
+        if device_id == "2":
+            raise LotekException(message="Lotek get_positions failed", status_code=500)
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert queried == ["1", "2", "3"]
+    assert result == {"observations_extracted": 2, "devices_failed": ["2"]}
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_does_not_advance_state_for_failed_device(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A failed device must re-query the same window next run, so its cursor stays put.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    async def get_positions(device_id, *args, **kwargs):
+        if device_id == "2":
+            raise httpx.ReadTimeout("Lotek timed out")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    await action_pull_observations(lotek_integration, pull_config)
+
+    advanced_devices = [call.args[-1] for call in mock_set_state.call_args_list]
+    assert "1" in advanced_devices
+    assert "2" not in advanced_devices
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_logs_exception_type_when_message_is_empty(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # httpx timeouts stringify to "", which produced logs ending in a bare "Exception: ".
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+
+    await action_pull_observations(lotek_integration, pull_config)
+
+    titles = [call.kwargs["title"] for call in mock_log_action_activity.call_args_list]
+    error_titles = [t for t in titles if "Error fetching positions" in t]
+    assert error_titles, "expected a per-device error to be logged"
+    assert "ReadTimeout" in error_titles[0]
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_retries_transient_timeout(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A single transient timeout should be retried, not treated as a dead device.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    attempts = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        attempts.append(device_id)
+        if len(attempts) == 1:
+            raise httpx.ReadTimeout("")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert len(attempts) == 2, "the transient timeout should have been retried"
+    assert result == {"observations_extracted": 1, "devices_failed": []}
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_aborts_on_auth_failure(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Bad credentials affect every device, so the run must stop instead of
+    # repeating the same failure once per device.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+
+    queried = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        queried.append(device_id)
+        raise LotekUnauthorizedException(message="401 Response from Lotek API")
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    with pytest.raises(LotekUnauthorizedException):
+        await action_pull_observations(lotek_integration, pull_config)
+
+    assert set(queried) == {"1"}, "should not have moved on to other devices"
+
 
 @pytest.mark.asyncio
 async def test_action_pull_observations_error(mocker, lotek_integration, pull_config, mock_redis):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -209,6 +209,38 @@ async def test_action_pull_observations_continues_after_lotek_error_status(
 
 
 @pytest.mark.asyncio
+async def test_action_pull_observations_continues_after_malformed_device_data(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # Lotek returning a malformed record raises out of the client's parsing (KeyError /
+    # ValidationError), which is neither an httpx error nor a LotekException.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    queried = []
+
+    async def get_positions(device_id, *args, **kwargs):
+        queried.append(device_id)
+        if device_id == "2":
+            raise KeyError("Latitude")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert queried[-1] == "3"
+    assert result == {"observations_extracted": 2, "devices_failed": ["2"]}
+
+
+@pytest.mark.asyncio
 async def test_action_pull_observations_does_not_advance_state_for_failed_device(
     mocker, lotek_integration, pull_config, mock_redis, lotek_position
 ):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,6 +1,6 @@
 import pytest
 import httpx
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 from gundi_core.schemas.v2 import LogLevel
@@ -287,7 +287,7 @@ async def test_action_pull_observations_continues_when_one_device_send_fails(
     mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
     mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
-    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[lotek_position]))
 
     sent_for = []
@@ -303,6 +303,65 @@ async def test_action_pull_observations_continues_when_one_device_send_fails(
 
     assert len(sent_for) == 2, "second device was never attempted"
     assert result["devices_failed"] == ["1"]
+    # the failed device's cursor must stay put: checkpointing fetched-but-undelivered
+    # data would silently skip it forever
+    advanced = [call.args[-1] for call in mock_set_state.call_args_list]
+    assert "1" not in advanced
+    assert "2" in advanced
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_counts_data_delivered_before_downstream_failure(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    # A single device that DID deliver a batch and then failed at checkpointing must
+    # not trip the "all devices failed and nothing delivered" raise: the data landed.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state",
+                 new=AsyncMock(side_effect=RuntimeError("redis down")))
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[lotek_position]))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result == {"observations_extracted": 1, "devices_failed": ["1"]}
+
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_summary_names_failed_devices(
+    mocker, lotek_integration, pull_config, mock_redis, lotek_position
+):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
+    mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+
+    async def get_positions(device_id, *args, **kwargs):
+        if device_id == "2":
+            raise httpx.ReadTimeout("")
+        return [lotek_position]
+
+    mocker.patch("app.actions.client.get_positions", new=get_positions)
+
+    await action_pull_observations(lotek_integration, pull_config)
+
+    warnings = [c.kwargs["title"] for c in mock_log_action_activity.call_args_list
+                if c.kwargs.get("level") == LogLevel.WARNING and "failing" in c.kwargs["title"]]
+    assert warnings, "no failure summary was logged"
+    assert "1 of 2" in warnings[0]
+    assert "2" in warnings[0]
 
 
 @pytest.mark.asyncio
@@ -387,13 +446,14 @@ async def test_action_pull_observations_keeps_successful_chunks_when_later_chunk
 
     assert mock_send.call_count >= 1, "successful chunks were discarded"
     assert result["devices_failed"] == ["1"]
-    # cursor advanced only as far as the last chunk that actually succeeded
-    checkpoint = mock_set_state.call_args_list[0].args[2]["updated_at"]
-    assert checkpoint < present_time_isoformat_upper_bound()
-
-
-def present_time_isoformat_upper_bound():
-    return datetime.now(timezone.utc).isoformat()
+    # The cursor must land exactly on the end of the second (last successful) 7-day
+    # window — i.e. ~16 days ago with a 30-day lookback — NOT at present_time, which
+    # would silently skip the failed window forever.
+    checkpoint = datetime.fromisoformat(mock_set_state.call_args_list[0].args[2]["updated_at"])
+    expected = datetime.now(timezone.utc) - timedelta(days=30) + timedelta(days=14)
+    assert abs((checkpoint - expected).total_seconds()) < 300, (
+        f"cursor at {checkpoint}, expected the last successful window's end ~{expected}"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes [GUNDI-5601](https://allenai.atlassian.net/browse/GUNDI-5601).

## The bug

In `action_pull_observations`, a per-device position-fetch error was re-raised **from inside the `for device in device_list:` loop**, unwinding the entire run. Every device after the failing one was skipped, and because device order is stable between runs, one persistently failing device starved every device behind it indefinitely.

Surfaced during the Lotek v1→v2 production cutover on 2026-08-12: 9 of 28 connections showed it, all of which had run clean on v1. From the customer's side the connection looked enabled and healthy while a subset of collars silently stopped reporting. The underlying trigger is upstream — Lotek's `positions/findByDate` timing out — which this PR cannot fix; what it fixes is the connector turning one slow device into a total, undiagnosable outage.

## What the connector does now

**Per-device isolation, end to end.** Each device's fetch, delivery to Gundi, and cursor checkpoint run inside `_pull_device_observations`, behind a single isolation boundary. A failure in any of those steps is logged against the device and the run continues to the next one. Genuinely integration-wide problems still abort fast: a rejected login (Lotek answers with 400; 401/403 also mapped) raises `LotekUnauthorizedException`, while login 5xx/429 stay per-device so an outage is never reported as "bad credentials".

**Transient errors are retried.** `RETRYABLE_ERRORS` covers transport errors/timeouts (3 attempts with backoff); previously only auth failures were retried, so a single blip killed a device for the whole cycle.

**Partial progress is kept, never double-sent.** With a lookback wider than one 7-day chunk, chunks that fetched successfully before a later chunk failed are still delivered, and the cursor checkpoints to the end of the last successful window — the failed window is retried next run without re-sending what already landed. A device that delivered nothing keeps its cursor untouched.

**Failures are visible.** Every failed device gets an ERROR activity-log entry naming the device, the date window, and the reason (empty httpx timeout messages now render as the exception type instead of a bare `Exception: `). A WARNING summary lists the failed devices (capped at 20 ids). The action result carries `devices_failed` alongside `observations_extracted`, so partial failure is machine-detectable. And if **every** device failed and nothing was delivered, the run raises instead of publishing `action_complete` — a wholly broken integration must not look green in the portal. Batches delivered before a downstream failure still count, so that raise never fires on a run that actually moved data.

## Review history

Three review rounds ran on this branch (two independent reviewers each, plus Copilot); every round's findings and fixes are documented in the PR comments. Notable catches along the way: isolation originally only covered the fetch path; the credentials fail-fast keyed on an exception the login endpoint never raised; a wholly-failed run reported success; partial chunks were discarded forever; and a login 5xx was briefly misclassified as a credential rejection (Copilot). All fixed in-branch with regression tests.

## Known follow-ups (deliberately out of scope)

- **No per-run time budget:** ~5-6 persistently dead devices can exhaust `MAX_ACTION_EXECUTION_TIME` (9 min) via retries and starve devices later in the stable-ordered list. Partial progress survives the cancellation, but a clean deadline check needs a design decision.
- **Refused login is retried 3× per run** (bounded, tested). Splitting expired-token from refused-login exception types would let us retry only the former.
- **`action_auth` labels a login 5xx/429 as "Invalid credentials"** — pre-existing; the status split added here is what a fix would build on.
- The `get_devices` retry still uses the auth-only exception set.

## Testing

`147 passed`, <1s, no sleeps. ~20 new tests, each written failing first, covering: continuation past fetch/send/checkpoint failures (httpx, `LotekException`, and malformed-data paths), retry of transient timeouts, fast abort on rejected login (with login attempts bounded per run, not per device), the all-failed raise and its delivered-data exemption, cursor pinned to the last successful window (verified by flipping the production line and watching tests fail), cursor not advanced for failed devices, error-type rendering, and summary naming. Login status classification is parametrised over 400/401/403 vs 429/500/502/503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[GUNDI-5601]: https://allenai.atlassian.net/browse/GUNDI-5601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ