### PR TITLE
GUNDI-5602: newest-first head pass + internal backfill with bounded staleness

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -88,26 +88,6 @@ def _to_utc(val: datetime) -> datetime:
     return val.astimezone(timezone.utc)
 
 
-def default_updated_at():
-    '''
-    Default for a new configuration is to pretend the last run was 7 days ago
-    '''
-    return datetime.now(tz=timezone.utc) - timedelta(days=7)
-
-
-class IntegrationState(pydantic.BaseModel):
-    updated_at: datetime = pydantic.Field(default_factory=default_updated_at, alias='updated_at')
-    error: str = None
-
-    @pydantic.validator("updated_at")
-    def clean_updated_at(cls, v):
-        if v is None:
-            return default_updated_at()
-        if not v.tzinfo:
-            return v.replace(tzinfo=timezone.utc)
-        return v
-
-
 async def get_token(integration, auth):
     saved_token = await state_manager.get_state(
         str(integration.id),

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -2,7 +2,12 @@ import pydantic
 
 from typing import Optional
 
-from .core import AuthActionConfiguration, PullActionConfiguration, ExecutableActionMixin
+from .core import (
+    AuthActionConfiguration,
+    ExecutableActionMixin,
+    InternalActionConfiguration,
+    PullActionConfiguration,
+)
 from app.services.utils import GlobalUISchemaOptions, UIOptions, FieldWithUIOptions
 
 
@@ -24,10 +29,19 @@ class PullObservationsConfig(PullActionConfiguration, ExecutableActionMixin):
         ge=1,
         le=60,
         title="Default lookback (days)",
+        description="How many days of historic data to import when a device is first seen.",
+    )
+    max_data_age_hours: int = FieldWithUIOptions(
+        12,
+        ge=1,
+        le=12,
+        title="Max data age (hours)",
         description=(
-            "How many days of historic data to fetch for new devices or on the first run. "
-            "Also caps how far back the connector catches up after an outage."
+            "Freshness bound: every run fetches at most this many hours back. "
+            "Positions uploaded longer ago than this that could not be fetched "
+            "are skipped permanently."
         ),
+        ui_options=UIOptions(widget="range"),
     )
     max_pdop: Optional[float] = pydantic.Field(
         None,
@@ -51,7 +65,13 @@ class PullObservationsConfig(PullActionConfiguration, ExecutableActionMixin):
     ui_global_options: GlobalUISchemaOptions = GlobalUISchemaOptions(
         order=[
             "default_lookback_days",
+            "max_data_age_hours",
             "max_pdop",
             "run_on_schedule",
         ],
     )
+
+
+class BackfillObservationsConfig(InternalActionConfiguration):
+    """Internal-only: triggered by pull_observations, never configured in the portal."""
+    pass

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -73,5 +73,19 @@ class PullObservationsConfig(PullActionConfiguration, ExecutableActionMixin):
 
 
 class BackfillObservationsConfig(InternalActionConfiguration):
-    """Internal-only: triggered by pull_observations, never configured in the portal."""
-    pass
+    """Internal-only: triggered by pull_observations, never configured in the portal.
+
+    Needs at least one real field: an InternalActionConfiguration is never
+    portal-registered, so the action-runner has no persisted config to resolve
+    for it (config_manager.get_action_configuration returns None). A fieldless
+    model's .dict() is {}, which trigger_action publishes as an empty
+    config_overrides — indistinguishable from "no override at all", which
+    trips execute_action's "configuration is missing" 404 before the handler
+    ever runs. triggered_by gives the override a non-empty payload and doubles
+    as a diagnostic marker of what triggered this run.
+    """
+    triggered_by: str = pydantic.Field(
+        "pull_observations",
+        title="Triggered By",
+        description="Which action triggered this backfill run.",
+    )

--- a/app/actions/device_state.py
+++ b/app/actions/device_state.py
@@ -20,6 +20,11 @@ class DeviceState(pydantic.BaseModel):
     first run, it only ever shrinks and is never extended. last_backfilled
     orders backfill fairness (least-recently-backfilled first).
     """
+    # Schema version: bump on any breaking field change and add a migration in
+    # _migrate_legacy_cursor — an unparseable blob costs a full-lookback
+    # re-import (review finding), so schema changes must never rely on the
+    # parse-failure fallback.
+    version: int = 1
     high_water: datetime
     gap_start: Optional[datetime] = None
     gap_end: Optional[datetime] = None

--- a/app/actions/device_state.py
+++ b/app/actions/device_state.py
@@ -1,0 +1,47 @@
+import pydantic
+
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def _ensure_utc(v):
+    if v is None:
+        return v
+    if not v.tzinfo:
+        return v.replace(tzinfo=timezone.utc)
+    return v.astimezone(timezone.utc)
+
+
+class DeviceState(pydantic.BaseModel):
+    """Per-device sync state (GUNDI-5602 head-pass design).
+
+    high_water is the newest upload-time already synced. [gap_start, gap_end)
+    is the single unfetched historical range — created once on a device's
+    first run, it only ever shrinks and is never extended. last_backfilled
+    orders backfill fairness (least-recently-backfilled first).
+    """
+    high_water: datetime
+    gap_start: Optional[datetime] = None
+    gap_end: Optional[datetime] = None
+    last_backfilled: Optional[datetime] = None
+
+    @pydantic.root_validator(pre=True)
+    def _migrate_legacy_cursor(cls, values):
+        # Pre-5602 state stored the cursor as updated_at; parse it as
+        # high_water so deployed integrations carry over without a gap.
+        if values.get("high_water") is None and values.get("updated_at") is not None:
+            values = dict(values)
+            values["high_water"] = values["updated_at"]
+        return values
+
+    _tz = pydantic.validator(
+        "high_water", "gap_start", "gap_end", "last_backfilled", allow_reuse=True
+    )(_ensure_utc)
+
+    @property
+    def has_gap(self) -> bool:
+        return (
+            self.gap_start is not None
+            and self.gap_end is not None
+            and self.gap_start < self.gap_end
+        )

--- a/app/actions/device_state.py
+++ b/app/actions/device_state.py
@@ -29,6 +29,12 @@ class DeviceState(pydantic.BaseModel):
     gap_start: Optional[datetime] = None
     gap_end: Optional[datetime] = None
     last_backfilled: Optional[datetime] = None
+    # In-memory marker, never persisted (exclude=True): tells the loader this
+    # state was parsed from a pre-5602 cursor blob, so a cursor lagging beyond
+    # the freshness floor gets its owed range carried over as a gap instead of
+    # being dropped by bounded staleness (review finding: on upgrade day a
+    # stale legacy cursor lost the range the old code would have caught up).
+    migrated_from_legacy: bool = pydantic.Field(False, exclude=True)
 
     @pydantic.root_validator(pre=True)
     def _migrate_legacy_cursor(cls, values):
@@ -37,6 +43,7 @@ class DeviceState(pydantic.BaseModel):
         if values.get("high_water") is None and values.get("updated_at") is not None:
             values = dict(values)
             values["high_water"] = values["updated_at"]
+            values["migrated_from_legacy"] = True
         return values
 
     _tz = pydantic.validator(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -231,6 +231,10 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     failed_devices = []
     deferred_devices = []
     serviced_devices = 0
+    # Only reflects devices actually processed this run — a device deferred by
+    # the deadline/breaker before its gap status is checked doesn't trigger
+    # backfill this cycle. Self-correcting: the next run's head pass reaches it
+    # and triggers then, same as the worst-case import delay the design accepts.
     any_open_gap = False
     for i, device in enumerate(device_list):
         if reason := guards.should_stop():
@@ -598,6 +602,10 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
 
     if not device_failed:
         guards.record(transport_failure=False)
+    # Advances even on zero progress (device_failed on the first window):
+    # deliberate LRS-fairness trade-off so one permanently-broken device
+    # doesn't monopolize the front of the backfill queue. The zero-progress
+    # raise is the actual safety net when it's the only gapped device.
     state.last_backfilled = datetime.now(tz=timezone.utc)
     await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
     return observations_sent, device_failed, not state.has_gap

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -689,7 +689,9 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 serviced_devices += 1
 
         if gapped and serviced_devices == 0 and observations_extracted == 0:
-            # Same systemic-degradation contract as the head pass.
+            # Same systemic-degradation contract as the head pass. The raise
+            # also breaks the self-retrigger cascade below — a wholly-failing
+            # backfill must not re-trigger itself forever.
             raise LotekException(
                 message=(
                     f"No devices could be backfilled for integration {integration_id}: "
@@ -698,7 +700,10 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 )
             )
 
-        return {
+        # _backfill_device mutates the states in place, so this reflects
+        # post-run gap status; deferred devices keep their gaps open.
+        gaps_remaining = any(state.has_gap for _, state in gapped)
+        result = {
             'observations_extracted': observations_extracted,
             'devices_failed': failed_devices,
             'devices_deferred': deferred_devices,
@@ -706,3 +711,16 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         }
     finally:
         await state_manager.delete_state(integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE)
+
+    if gaps_remaining:
+        # Self-retrigger (movebank-connector pattern): keep draining the import
+        # continuously instead of waiting for the next head-pass tick. Runs
+        # AFTER the lease release so the next run doesn't skip on our own lease.
+        try:
+            await trigger_action(integration_id, "backfill_observations")
+        except Exception as e:
+            # The next head pass will re-trigger; losing one cascade step is fine.
+            logger.warning(
+                f"Could not re-trigger backfill for integration {integration_id}: {describe_exception(e)}"
+            )
+    return result

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -58,9 +58,14 @@ def _deadline_exceeded(run_started_at):
     return elapsed > DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME
 
 
-def _retry_attempts(run_started_at):
-    # Past the soft deadline, don't spend the remaining budget on retries.
-    return 1 if _deadline_exceeded(run_started_at) else RETRY_ATTEMPTS
+def _fetch_retry_kwargs(run_started_at):
+    # Past the soft deadline, don't spend the remaining budget re-trying slow
+    # transport failures — but keep the token-expiry retry: it is a cheap
+    # re-auth, and dropping it breaks the "token expiry is retried and
+    # recovers within the run" contract (review finding).
+    if _deadline_exceeded(run_started_at):
+        return {"on": LotekTokenExpiredException, "attempts": RETRY_ATTEMPTS}
+    return {"on": RETRYABLE_ERRORS, "attempts": RETRY_ATTEMPTS}
 
 
 class RunGuards:
@@ -105,6 +110,24 @@ async def _log_deferral(integration, action_id, reason, deferred_ids):
         title=message,
         level=LogLevel.WARNING
     )
+
+
+async def _try_log_activity(integration_id, action_id, title, level):
+    """Best-effort activity-feed publish for per-device paths. A pubsub blip
+    must never escape a per-device handler: an escaping publish discards
+    already-delivered counts and resets the circuit-breaker streak with a
+    failure that says nothing about Lotek (review finding)."""
+    try:
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id=action_id,
+            title=title,
+            level=level
+        )
+    except Exception as e:
+        logger.warning(
+            f"Could not publish activity log for integration {integration_id}: {describe_exception(e)}"
+        )
 
 
 def describe_exception(exc):
@@ -241,6 +264,22 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
     present_time = datetime.now(tz=timezone.utc)
+    # Least-fresh first (mirrors the backfill's LRS ordering): the deadline and
+    # breaker always cut the tail of this list, and Lotek returns devices in a
+    # stable order — without re-ordering, sustained slowness starved the same
+    # tail devices every run until bounded staleness dropped their data
+    # permanently (review finding). Sorting by high_water puts the devices
+    # most behind first, so deferral rotates naturally as serviced devices
+    # move to the back.
+    integration_id = str(integration.id)
+    device_states = []
+    for device in device_list:
+        state, is_new = await _load_device_state(
+            integration_id, device.nDeviceID, present_time, action_config
+        )
+        device_states.append((device, state, is_new))
+    device_states.sort(key=lambda entry: entry[1].high_water)
+
     guards = RunGuards(run_started)
     observations_extracted = 0
     failed_devices = []
@@ -251,14 +290,14 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     # backfill this cycle. Self-correcting: the next run's head pass reaches it
     # and triggers then, same as the worst-case import delay the design accepts.
     any_open_gap = False
-    for i, device in enumerate(device_list):
+    for i, (device, state, is_new) in enumerate(device_states):
         if reason := guards.should_stop():
-            deferred_devices = [d.nDeviceID for d in device_list[i:]]
+            deferred_devices = [d.nDeviceID for d, _, _ in device_states[i:]]
             await _log_deferral(integration, "pull_observations", reason, deferred_devices)
             break
         try:
-            sent, device_failed, transport_failure, state = await _head_pass_device(
-                device, integration, auth, action_config, present_time, guards
+            sent, device_failed, transport_failure = await _head_pass_device(
+                device, state, is_new, integration, auth, action_config, present_time, guards
             )
         except LotekUnauthorizedException:
             raise
@@ -364,15 +403,7 @@ async def _read_device_state(integration_id, device_id, action_id="pull_observat
             f"{integration_id} Error: {describe_exception(e)}"
         )
         logger.warning(message)
-        try:
-            await log_action_activity(
-                integration_id=integration_id,
-                action_id=action_id,
-                title=message,
-                level=LogLevel.WARNING
-            )
-        except Exception:
-            logger.warning(f"Could not publish state-reset warning for device {device_id}")
+        await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
         return None
 
 
@@ -380,12 +411,22 @@ async def _load_device_state(integration_id, device_id, present_time, action_con
     """Returns (state, is_new). is_new means no usable saved state existed and
     the returned state is the first-run initialization (gap birth)."""
     state = await _read_device_state(integration_id, device_id)
+    head_start = present_time - timedelta(hours=action_config.max_data_age_hours)
     if state is not None:
+        if state.migrated_from_legacy and state.high_water < head_start and not state.has_gap:
+            # Upgrade path: a pre-5602 cursor lagging beyond the freshness
+            # floor still owes [cursor, floor] — the old walk would have
+            # caught it up in chunks. Carry it over as the device's gap
+            # (backfill drains it) instead of letting bounded staleness drop
+            # it; is_new=True so the head pass persists the full document.
+            state.gap_start = state.high_water
+            state.gap_end = head_start
+            state.high_water = head_start
+            return state, True
         return state, False
     # First run: the head pass starts at the freshness floor; everything older,
     # back to the configured lookback, becomes the device's one and only gap —
     # the deliberate historical import. It only ever shrinks from here.
-    head_start = present_time - timedelta(hours=action_config.max_data_age_hours)
     gap_start = present_time - timedelta(days=action_config.default_lookback_days)
     if gap_start < head_start:
         return DeviceState(high_water=head_start, gap_start=gap_start, gap_end=head_start), True
@@ -417,7 +458,7 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
     """
     integration_id = str(integration.id)
     try:
-        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+        async for attempt in stamina.retry_context(**_fetch_retry_kwargs(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
                 positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
         logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
@@ -433,13 +474,25 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
         # row mean Lotek-wide degradation, not a bad device.
         message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
         logger.warning(message, exc_info=True)
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id=action_id,
-            title=message,
-            level=LogLevel.WARNING
-        )
+        await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
         return None, True
+    except LotekException as e:
+        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        if e.status_code >= 500 or e.status_code == 429:
+            # A Lotek-side 5xx/429 is outage/throttling, the same class of
+            # Lotek-wide degradation as a timeout: WARNING + breaker-feeding.
+            # Before this branch it fell into the generic handler below, which
+            # actively RESET the breaker streak — an HTTP-error outage could
+            # never trip the breaker (review finding).
+            logger.warning(message, exc_info=True)
+            await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
+            return None, True
+        # Other 4xx (incl. a token-expiry 401 that survived its retry): a
+        # per-device/API-contract problem that won't self-heal — ERROR, and
+        # not breaker-feeding.
+        logger.exception(message)
+        await _try_log_activity(integration_id, action_id, message, LogLevel.ERROR)
+        return None, False
     except Exception as e:
         # Deliberately broad: malformed data from Lotek surfaces as KeyError or
         # pydantic.ValidationError out of the client's parsing, and those must
@@ -451,12 +504,7 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
         # forever (review finding).
         message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
         logger.exception(message)
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id=action_id,
-            title=message,
-            level=LogLevel.ERROR
-        )
+        await _try_log_activity(integration_id, action_id, message, LogLevel.ERROR)
         return None, False
 
 
@@ -491,20 +539,18 @@ async def _deliver(cdip_positions, device, integration, action_id):
             'integration_id': integration_id,
             'action_id': action_id
         })
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id=action_id,
-            title=message,
-            level=LogLevel.ERROR
-        )
+        # Guarded: an escaping publish here would discard observations_sent —
+        # batches that DID land — and could flip a partially-delivered run
+        # into the zero-progress ERROR raise (review finding).
+        await _try_log_activity(integration_id, action_id, message, LogLevel.ERROR)
         return observations_sent, True
     return observations_sent, False
 
 
-async def _head_pass_device(device, integration, auth, action_config, present_time, guards):
+async def _head_pass_device(device, state, is_new, integration, auth, action_config, present_time, guards):
     """Fetch, deliver and checkpoint one device's freshest window.
 
-    Returns (observations_sent, device_failed, transport_failure, state).
+    Returns (observations_sent, device_failed, transport_failure).
     Raises only for integration-wide problems; per-device problems are
     reported through the returned flags so the caller can keep going (and
     record transport_failure for the circuit breaker in one place).
@@ -514,57 +560,34 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
     """
     integration_id = str(integration.id)
     freshness_floor = present_time - timedelta(hours=action_config.max_data_age_hours)
-    state, is_new = await _load_device_state(integration_id, device.nDeviceID, present_time, action_config)
-
-    if state.high_water < freshness_floor:
-        # Bounded staleness (GUNDI-5602, deliberate): anything the cursor still
-        # owed beyond max_data_age_hours is dropped permanently — never added
-        # to the gap — so catch-up cost cannot compound.
-        message = (
-            f"Dropping stale range [{state.high_water.isoformat()}, {freshness_floor.isoformat()}] "
-            f"for device {device.nDeviceID}: older than max_data_age_hours="
-            f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
-        )
-        logger.warning(message)
-        try:
-            await log_action_activity(
-                integration_id=integration_id,
-                action_id="pull_observations",
-                title=message,
-                level=LogLevel.WARNING
-            )
-        except Exception as e:
-            # Informational: a pubsub blip must not keep a stale device from
-            # ever advancing its cursor (review finding).
-            logger.warning(f"Could not publish stale-drop warning for device {device.nDeviceID}: {describe_exception(e)}")
+    # Bounded staleness (GUNDI-5602, deliberate): anything the cursor still
+    # owes beyond max_data_age_hours is dropped permanently — never added to
+    # the gap — so catch-up cost cannot compound. The drop only becomes real
+    # when the cursor actually advances (successful save below), so the
+    # WARNING is deferred until then: announcing it before the fetch
+    # misreported still-recoverable data as dropped on every failed attempt
+    # (review finding).
+    stale_from = state.high_water if state.high_water < freshness_floor else None
 
     lower_date = max(state.high_water - HEAD_LATE_UPLOAD_OVERLAP, freshness_floor)
     cdip_positions, transport_failure = await _fetch_window(
         device, integration, auth, action_config, lower_date, present_time, guards, "pull_observations"
     )
     if cdip_positions is None:
-        return 0, True, transport_failure, state
+        return 0, True, transport_failure
 
     if not cdip_positions:
         # Purely informational; must never affect the device's outcome. A pubsub blip
         # here must not mark a healthy quiet device as failed or stall its cursor.
         message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
         logger.info(message)
-        try:
-            await log_action_activity(
-                integration_id=str(integration.id),
-                action_id="pull_observations",
-                title=message,
-                level=LogLevel.WARNING
-            )
-        except Exception as e:
-            logger.warning(f"Could not publish activity log for device {device.nDeviceID}: {describe_exception(e)}")
+        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.WARNING)
 
     observations_sent, delivery_failed = await _deliver(cdip_positions, device, integration, "pull_observations")
     if delivery_failed:
         # The breaker watches Lotek, not Gundi: a delivery failure is not
         # evidence of Lotek-wide degradation.
-        return observations_sent, True, False, state
+        return observations_sent, True, False
 
     # Advance the cursor to the queried upper bound (upload time), not recorded_at.
     # Queries are by upload date, so wall clock is the correct cursor, and it must
@@ -584,30 +607,38 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
             f"{integration.id} Exception: {describe_exception(e)}"
         )
         logger.exception(message)
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id="pull_observations",
-            title=message,
-            level=LogLevel.ERROR
-        )
-        return observations_sent, True, False, state
+        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.ERROR)
+        return observations_sent, True, False
 
-    return observations_sent, False, False, state
+    if stale_from is not None:
+        # Only now is the drop real: the cursor advanced past the owed range.
+        message = (
+            f"Dropped stale range [{stale_from.isoformat()}, {freshness_floor.isoformat()}] "
+            f"permanently for device {device.nDeviceID}: older than max_data_age_hours="
+            f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
+        )
+        logger.warning(message)
+        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.WARNING)
+
+    return observations_sent, False, False
 
 
 async def _backfill_device(device, state, integration, auth, pull_config, guards):
     """Close up to BACKFILL_MAX_WINDOWS_PER_DEVICE oldest windows of one
     device's gap.
 
-    Returns (observations_sent, device_failed, transport_failure, gap_closed).
-    gap_start advances only past windows that were actually delivered, so a
-    failure re-fetches the same window next trigger (re-sends are tolerated,
-    silent skips are not).
+    Returns (observations_sent, device_failed, transport_failure, gap_closed,
+    windows_advanced). gap_start advances only past windows that were actually
+    delivered, so a failure re-fetches the same window next trigger (re-sends
+    are tolerated, silent skips are not). windows_advanced counts those
+    actually-delivered windows: the caller only keeps the self-retrigger
+    cascade going while some gap is really shrinking.
     """
     integration_id = str(integration.id)
     observations_sent = 0
     device_failed = False
     transport_failure = False
+    windows_advanced = 0
     for _ in range(BACKFILL_MAX_WINDOWS_PER_DEVICE):
         if not state.has_gap:
             break
@@ -638,6 +669,7 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
             integration_id, device.nDeviceID,
             {"gap_start": state.gap_start, "gap_end": state.gap_end}
         )
+        windows_advanced += 1
 
     # Advances even on zero progress (device_failed on the first window):
     # deliberate LRS-fairness trade-off so one permanently-broken device
@@ -647,7 +679,7 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
     await _save_device_state_fields(
         integration_id, device.nDeviceID, {"last_backfilled": state.last_backfilled}
     )
-    return observations_sent, device_failed, transport_failure, not state.has_gap
+    return observations_sent, device_failed, transport_failure, not state.has_gap, windows_advanced
 
 
 @action_title("Backfill Observations")
@@ -662,8 +694,19 @@ async def action_backfill_observations(integration, action_config: BackfillObser
     logger.info(f"Executing backfill_observations action for integration {integration.id}...")
     integration_id = str(integration.id)
     run_started = datetime.now(tz=timezone.utc)
-    auth = get_auth_config(integration)
-    pull_config = get_pull_config(integration)  # max_pdop applies to backfilled data too
+    try:
+        auth = get_auth_config(integration)
+        pull_config = get_pull_config(integration)  # max_pdop applies to backfilled data too
+    except ConfigurationNotFound as e:
+        # Skip quietly, mirroring the runner's skippable_pull behavior: backfill
+        # is machine-triggered, so raising here would route through the generic
+        # _handle_error — an ERROR event embedding the integration's full config
+        # (auth included) on every remaining cascade step (review finding). The
+        # scheduled head pass is where a missing config gets surfaced.
+        logger.warning(
+            f"Skipping backfill for integration {integration_id}: {describe_exception(e)}"
+        )
+        return {"skipped": True, "reason": "configuration_missing"}
 
     if not pull_config.run_on_schedule:
         # The operator's pause toggle must also stop the cascade: internal
@@ -673,13 +716,13 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         logger.info(f"Integration {integration_id} is paused (run_on_schedule=false); skipping backfill.")
         return {"skipped": True, "reason": "integration_paused"}
 
-    got_lease = await state_manager.set_if_absent(
+    lease_token = await state_manager.acquire_lease(
         integration_id,
         "backfill_observations",
         ttl_seconds=app_settings.MAX_ACTION_EXECUTION_TIME,
         source_id=BACKFILL_LEASE_SOURCE,
     )
-    if not got_lease:
+    if not lease_token:
         logger.info(f"Backfill lease already held for integration {integration_id}; skipping run.")
         return {"skipped": True, "reason": "lease_held"}
 
@@ -720,13 +763,14 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         deferred_devices = []
         serviced_devices = 0
         gaps_closed = 0
+        windows_advanced_total = 0
         for i, (device, state) in enumerate(gapped):
             if reason := guards.should_stop():
                 deferred_devices = [d.nDeviceID for d, _ in gapped[i:]]
                 await _log_deferral(integration, "backfill_observations", reason, deferred_devices)
                 break
             try:
-                sent, device_failed, transport_failure, gap_closed = await _backfill_device(
+                sent, device_failed, transport_failure, gap_closed, windows_advanced = await _backfill_device(
                     device, state, integration, auth, pull_config, guards
                 )
             except LotekUnauthorizedException:
@@ -750,6 +794,7 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             guards.record(transport_failure=transport_failure)
             observations_extracted += sent
             gaps_closed += int(gap_closed)
+            windows_advanced_total += windows_advanced
             if device_failed:
                 failed_devices.append(device.nDeviceID)
             else:
@@ -786,8 +831,17 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         # A hot breaker suppresses the self-retrigger: re-entering immediately
         # would defeat the pause the breaker exists to buy (review finding) —
         # the next scheduled head pass re-triggers ~cadence later instead.
+        # Same for a run that advanced no window at all: with a deterministic
+        # per-window failure (e.g. one observation Gundi always rejects),
+        # retriggering on has_gap alone spun an unthrottled tight loop that
+        # re-fetched and re-sent the same window forever (review finding) —
+        # no-progress runs now wait for the next head-pass cadence instead.
         breaker_hot = guards.consecutive_transport_failures >= BREAKER_THRESHOLD
-        gaps_remaining = any(state.has_gap for _, state in gapped) and not breaker_hot
+        gaps_remaining = (
+            any(state.has_gap for _, state in gapped)
+            and not breaker_hot
+            and windows_advanced_total > 0
+        )
         result = {
             'observations_extracted': observations_extracted,
             'devices_failed': failed_devices,
@@ -795,7 +849,21 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             'gaps_closed': gaps_closed,
         }
     finally:
-        await state_manager.delete_state(integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE)
+        # Ownership-checked release: an unconditional DEL could outlive this
+        # run's TTL (e.g. retried through a Redis blip after a cancellation)
+        # and delete a successor's lease, allowing overlapping backfills
+        # (review finding). Compare-and-delete only removes our own token;
+        # if release fails, the TTL expires the lease anyway.
+        try:
+            await state_manager.release_lease(
+                integration_id, "backfill_observations", lease_token,
+                source_id=BACKFILL_LEASE_SOURCE,
+            )
+        except Exception as e:
+            logger.warning(
+                f"Could not release backfill lease for integration {integration_id} "
+                f"(the TTL will expire it): {describe_exception(e)}"
+            )
 
     if gaps_remaining:
         # Self-retrigger (movebank-connector pattern): keep draining the import

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -44,6 +44,13 @@ BREAKER_THRESHOLD = 3
 BACKFILL_MAX_WINDOWS_PER_DEVICE = 2
 BACKFILL_WINDOW = timedelta(days=7)
 BACKFILL_LEASE_SOURCE = "lease"
+# Head fetches re-cover this much of the cursor's trailing edge: rows whose
+# server-assigned UploadTimeStamp falls inside a window we already queried can
+# become queryable only after our request completed (write latency / clock
+# skew), and the gap never re-opens to catch them. Re-sends are tolerated
+# downstream, so the overlap is cheap insurance (carried over from the
+# pre-5602 cursor, which used the same 2h buffer).
+HEAD_LATE_UPLOAD_OVERLAP = timedelta(hours=2)
 
 
 def _deadline_exceeded(run_started_at):
@@ -338,21 +345,64 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     }
 
 
-async def _load_device_state(integration_id, device_id, present_time, action_config):
+async def _read_device_state(integration_id, device_id, action_id="pull_observations"):
+    """Read one device's saved state. Returns a DeviceState, or None when the
+    key is absent or unparseable. Unparseable state is surfaced at WARNING —
+    it means a cursor is about to be discarded and the lookback re-imported
+    (review finding: this was announced only at DEBUG)."""
     saved = await state_manager.get_state(integration_id, "pull_observations", device_id)
-    if saved:
+    if not saved:
+        return None
+    try:
+        return DeviceState.parse_obj(saved)
+    except pydantic.ValidationError as e:
+        message = (
+            f"Discarding unparseable saved state for device {device_id}: the cursor "
+            f"resets and the lookback window will re-import. Integration ID: "
+            f"{integration_id} Error: {describe_exception(e)}"
+        )
+        logger.warning(message)
         try:
-            return DeviceState.parse_obj(saved)
-        except pydantic.ValidationError as e:
-            logger.debug(f"Failed to parse saved state for device {device_id}, starting fresh. Error: {e}")
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id=action_id,
+                title=message,
+                level=LogLevel.WARNING
+            )
+        except Exception:
+            logger.warning(f"Could not publish state-reset warning for device {device_id}")
+        return None
+
+
+async def _load_device_state(integration_id, device_id, present_time, action_config):
+    """Returns (state, is_new). is_new means no usable saved state existed and
+    the returned state is the first-run initialization (gap birth)."""
+    state = await _read_device_state(integration_id, device_id)
+    if state is not None:
+        return state, False
     # First run: the head pass starts at the freshness floor; everything older,
     # back to the configured lookback, becomes the device's one and only gap —
     # the deliberate historical import. It only ever shrinks from here.
     head_start = present_time - timedelta(hours=action_config.max_data_age_hours)
     gap_start = present_time - timedelta(days=action_config.default_lookback_days)
     if gap_start < head_start:
-        return DeviceState(high_water=head_start, gap_start=gap_start, gap_end=head_start)
-    return DeviceState(high_water=head_start)
+        return DeviceState(high_water=head_start, gap_start=gap_start, gap_end=head_start), True
+    return DeviceState(high_water=head_start), True
+
+
+async def _save_device_state_fields(integration_id, device_id, updates):
+    """Merge-save: re-read the current blob and overwrite only the fields this
+    writer owns (head pass: high_water; backfill: gap_*/last_backfilled).
+
+    The two actions can interleave — the Redis lease only serializes backfill
+    against backfill — and whole-blob writes from a stale snapshot were
+    resurrecting closed gaps and rewinding the head cursor (review finding:
+    lost-update race). The re-read shrinks the race window from the whole
+    action duration to milliseconds; re-sends cover whatever remains.
+    """
+    current = await state_manager.get_state(integration_id, "pull_observations", device_id)
+    merged = {**(current or {}), **updates}
+    await state_manager.set_state(integration_id, "pull_observations", merged, device_id)
 
 
 async def _fetch_window(device, integration, auth, config, lower_date, upper_date, guards, action_id):
@@ -462,7 +512,7 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
     """
     integration_id = str(integration.id)
     freshness_floor = present_time - timedelta(hours=action_config.max_data_age_hours)
-    state = await _load_device_state(integration_id, device.nDeviceID, present_time, action_config)
+    state, is_new = await _load_device_state(integration_id, device.nDeviceID, present_time, action_config)
 
     if state.high_water < freshness_floor:
         # Bounded staleness (GUNDI-5602, deliberate): anything the cursor still
@@ -474,14 +524,19 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
             f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
         )
         logger.warning(message)
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id="pull_observations",
-            title=message,
-            level=LogLevel.WARNING
-        )
+        try:
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="pull_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
+        except Exception as e:
+            # Informational: a pubsub blip must not keep a stale device from
+            # ever advancing its cursor (review finding).
+            logger.warning(f"Could not publish stale-drop warning for device {device.nDeviceID}: {describe_exception(e)}")
 
-    lower_date = max(state.high_water, freshness_floor)
+    lower_date = max(state.high_water - HEAD_LATE_UPLOAD_OVERLAP, freshness_floor)
     cdip_positions, transport_failure = await _fetch_window(
         device, integration, auth, action_config, lower_date, present_time, guards, "pull_observations"
     )
@@ -515,13 +570,12 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
     # untouched so the head window is re-fetched next run (re-sends are tolerated,
     # silent skips are not).
     state.high_water = present_time
+    # The head pass owns only high_water; a first run also births the full
+    # document (the gap). Everything else belongs to the backfill (merge-save,
+    # see _save_device_state_fields).
+    updates = state.dict() if is_new else {"high_water": state.high_water}
     try:
-        await state_manager.set_state(
-            integration_id,
-            "pull_observations",
-            state.dict(),
-            device.nDeviceID
-        )
+        await _save_device_state_fields(integration_id, device.nDeviceID, updates)
     except Exception as e:
         message = (
             f"Error saving cursor for device {device.nDeviceID}. Integration ID: "
@@ -572,18 +626,25 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
             break
 
         # Advance the gap only past the delivered window; close it when done.
+        # The backfill owns only the gap fields (merge-save): a concurrent head
+        # pass advancing high_water must survive this write.
         state.gap_start = upper_date
         if not state.has_gap:
             state.gap_start = None
             state.gap_end = None
-        await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
+        await _save_device_state_fields(
+            integration_id, device.nDeviceID,
+            {"gap_start": state.gap_start, "gap_end": state.gap_end}
+        )
 
     # Advances even on zero progress (device_failed on the first window):
     # deliberate LRS-fairness trade-off so one permanently-broken device
     # doesn't monopolize the front of the backfill queue. The zero-progress
     # raise is the actual safety net when it's the only gapped device.
     state.last_backfilled = datetime.now(tz=timezone.utc)
-    await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
+    await _save_device_state_fields(
+        integration_id, device.nDeviceID, {"last_backfilled": state.last_backfilled}
+    )
     return observations_sent, device_failed, transport_failure, not state.has_gap
 
 
@@ -602,6 +663,14 @@ async def action_backfill_observations(integration, action_config: BackfillObser
     auth = get_auth_config(integration)
     pull_config = get_pull_config(integration)  # max_pdop applies to backfilled data too
 
+    if not pull_config.run_on_schedule:
+        # The operator's pause toggle must also stop the cascade: internal
+        # actions bypass the runner's skippable_pull pause check, and backfill
+        # is only ever machine-triggered — a paused integration skips cleanly
+        # (review finding).
+        logger.info(f"Integration {integration_id} is paused (run_on_schedule=false); skipping backfill.")
+        return {"skipped": True, "reason": "integration_paused"}
+
     got_lease = await state_manager.set_if_absent(
         integration_id,
         "backfill_observations",
@@ -610,7 +679,7 @@ async def action_backfill_observations(integration, action_config: BackfillObser
     )
     if not got_lease:
         logger.info(f"Backfill lease already held for integration {integration_id}; skipping run.")
-        return {"skipped": "lease_held"}
+        return {"skipped": True, "reason": "lease_held"}
 
     try:
         try:
@@ -633,14 +702,10 @@ async def action_backfill_observations(integration, action_config: BackfillObser
 
         gapped = []
         for device in device_list:
-            saved = await state_manager.get_state(integration_id, "pull_observations", device.nDeviceID)
-            if not saved:
-                continue
-            try:
-                state = DeviceState.parse_obj(saved)
-            except pydantic.ValidationError:
-                continue  # the head pass will initialize it; nothing to backfill yet
-            if state.has_gap:
+            # Same reader as the head pass — absent or unparseable state means
+            # the head pass (re-)initializes it; nothing to backfill yet.
+            state = await _read_device_state(integration_id, device.nDeviceID, "backfill_observations")
+            if state is not None and state.has_gap:
                 gapped.append((device, state))
         # Least-recently-backfilled first keeps the import fair; devices never
         # backfilled lead the queue.
@@ -716,7 +781,11 @@ async def action_backfill_observations(integration, action_config: BackfillObser
 
         # _backfill_device mutates the states in place, so this reflects
         # post-run gap status; deferred devices keep their gaps open.
-        gaps_remaining = any(state.has_gap for _, state in gapped)
+        # A hot breaker suppresses the self-retrigger: re-entering immediately
+        # would defeat the pause the breaker exists to buy (review finding) —
+        # the next scheduled head pass re-triggers ~cadence later instead.
+        breaker_hot = guards.consecutive_transport_failures >= BREAKER_THRESHOLD
+        gaps_remaining = any(state.has_gap for _, state in gapped) and not breaker_hot
         result = {
             'observations_extracted': observations_extracted,
             'devices_failed': failed_devices,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -306,7 +306,15 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                 str(integration.id), "backfill_observations", BACKFILL_LEASE_SOURCE
             )
             if not lease:
-                await trigger_action(str(integration.id), "backfill_observations")
+                # backfill_observations is an InternalActionConfiguration with no
+                # persisted portal config, so this MUST carry a non-empty config
+                # override — a bare trigger_action(..., "backfill_observations")
+                # publishes an empty config_overrides, which execute_action reads
+                # as "no config at all" and 404s before the handler ever runs.
+                await trigger_action(
+                    str(integration.id), "backfill_observations",
+                    config=BackfillObservationsConfig(triggered_by="pull_observations")
+                )
         except Exception as e:
             # The head pass succeeded; a failed trigger must not fail the run.
             logger.warning(
@@ -717,7 +725,10 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         # continuously instead of waiting for the next head-pass tick. Runs
         # AFTER the lease release so the next run doesn't skip on our own lease.
         try:
-            await trigger_action(integration_id, "backfill_observations")
+            await trigger_action(
+                integration_id, "backfill_observations",
+                config=BackfillObservationsConfig(triggered_by="backfill_observations")
+            )
         except Exception as e:
             # The next head pass will re-trigger; losing one cascade step is fine.
             logger.warning(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -314,7 +314,13 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
             f"Error delivering observations for device {device.nDeviceID}. Integration ID: "
             f"{integration.id} Exception: {describe_exception(e)}"
         )
-        logger.exception(message)
+        # needs_attention drives log-based alerting on delivery failures (template
+        # convention) — kept from the pre-isolation send-loop handler.
+        logger.exception(message, extra={
+            'needs_attention': True,
+            'integration_id': str(integration.id),
+            'action_id': "pull_observations"
+        })
         await log_action_activity(
             integration_id=str(integration.id),
             action_id="pull_observations",

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -433,7 +433,7 @@ async def _load_device_state(integration_id, device_id, present_time, action_con
     return DeviceState(high_water=head_start), True
 
 
-async def _save_device_state_fields(integration_id, device_id, updates):
+async def _save_device_state_fields(integration_id, device_id, updates, init_only=None):
     """Merge-save: atomically overwrite only the fields this writer owns
     (head pass: high_water; backfill: gap_*/last_backfilled).
 
@@ -443,8 +443,15 @@ async def _save_device_state_fields(integration_id, device_id, updates):
     lost-update race). The merge runs server-side in a Lua script, so there
     is no read-to-write window at all (review finding: the previous
     client-side read-merge-write only narrowed the race).
+
+    `init_only` is the create-only channel for gap birth: those fields are
+    written only when the stored document lacks the key entirely, so a stale
+    first-run/migration snapshot cannot overwrite gap progress a backfill
+    already made (a closed gap stores the key as null — still present).
     """
-    await state_manager.merge_state_fields(integration_id, "pull_observations", updates, device_id)
+    await state_manager.merge_state_fields(
+        integration_id, "pull_observations", updates, device_id, init_only=init_only
+    )
 
 
 async def _fetch_window(device, integration, auth, config, lower_date, upper_date, guards, action_id):
@@ -594,12 +601,20 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
     # untouched so the head window is re-fetched next run (re-sends are tolerated,
     # silent skips are not).
     state.high_water = present_time
-    # The head pass owns only high_water; a first run also births the full
-    # document (the gap). Everything else belongs to the backfill (merge-save,
-    # see _save_device_state_fields).
-    updates = state.dict() if is_new else {"high_water": state.high_water}
+    # The head pass owns only high_water; a first run / legacy migration also
+    # births the gap, but create-only — two head runs can overlap, and if the
+    # faster one already birthed the document and a backfill advanced or
+    # closed the gap, this run's stale snapshot must not resurrect it (review
+    # finding). Everything else belongs to the backfill (merge-save, see
+    # _save_device_state_fields); last_backfilled is deliberately never
+    # written here.
+    updates = {"high_water": state.high_water}
+    init_only = None
+    if is_new:
+        updates["version"] = state.version
+        init_only = {"gap_start": state.gap_start, "gap_end": state.gap_end}
     try:
-        await _save_device_state_fields(integration_id, device.nDeviceID, updates)
+        await _save_device_state_fields(integration_id, device.nDeviceID, updates, init_only=init_only)
     except Exception as e:
         message = (
             f"Error saving cursor for device {device.nDeviceID}. Integration ID: "

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -28,7 +28,7 @@ state_manager = IntegrationStateManager()
 # A refused login (LotekUnauthorizedException) is deliberately NOT retryable: it is
 # fatal to the run, and retrying a rejected password risks account lockout.
 RETRYABLE_ERRORS = (LotekTokenExpiredException, httpx.TransportError)  # TransportError covers timeouts
-RETRY_ATTEMPTS = 3
+RETRY_ATTEMPTS = 2
 RETRY_WAIT_INITIAL = 1.0
 RETRY_WAIT_JITTER = 5.0
 RETRY_WAIT_MAX = 32.0

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -12,8 +12,10 @@ from datetime import datetime, timezone, timedelta
 from app.services.errors import ConfigurationNotFound
 from app.actions.client import LotekException, LotekTokenExpiredException, LotekUnauthorizedException
 from app.services.utils import find_config_for_action
-from app.actions.configurations import AuthenticateConfig, PullObservationsConfig
+from app.actions.configurations import AuthenticateConfig, BackfillObservationsConfig, PullObservationsConfig
 from app.actions.core import action_title
+from app.actions.device_state import DeviceState
+from app.services.action_scheduler import trigger_action
 from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.state import IntegrationStateManager
 from gundi_core.schemas.v2.gundi import LogLevel
@@ -34,6 +36,13 @@ RETRY_WAIT_JITTER = 5.0
 RETRY_WAIT_MAX = 32.0
 # A Lotek-wide outage can fail every device; don't put hundreds of ids in a log title.
 MAX_DEVICES_IN_SUMMARY = 20
+# Safety-rail constants (GUNDI-5602): load-protection mechanics, deliberately
+# code constants rather than operator knobs.
+DEADLINE_FRACTION = 0.8
+BREAKER_THRESHOLD = 3
+BACKFILL_MAX_WINDOWS_PER_DEVICE = 2
+BACKFILL_WINDOW = timedelta(days=7)
+BACKFILL_LEASE_SOURCE = "lease"
 
 
 def describe_exception(exc):
@@ -166,14 +175,15 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
     present_time = datetime.now(tz=timezone.utc)
-    lookback = timedelta(days=action_config.default_lookback_days)
-    default_start = present_time - lookback
     observations_extracted = 0
     failed_devices = []
+    deferred_devices = []
+    serviced_devices = 0
+    any_open_gap = False
     for device in device_list:
         try:
-            sent, device_failed = await _pull_device_observations(
-                device, integration, auth, action_config, present_time, default_start
+            sent, device_failed, state = await _head_pass_device(
+                device, integration, auth, action_config, present_time
             )
         except LotekUnauthorizedException:
             raise
@@ -194,8 +204,12 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             failed_devices.append(device.nDeviceID)
             continue
         observations_extracted += sent
+        if state is not None and state.has_gap:
+            any_open_gap = True
         if device_failed:
             failed_devices.append(device.nDeviceID)
+        else:
+            serviced_devices += 1
 
     if failed_devices:
         listed = ', '.join(failed_devices[:MAX_DEVICES_IN_SUMMARY])
@@ -227,61 +241,104 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             )
         )
 
-    return {'observations_extracted': observations_extracted, 'devices_failed': failed_devices}
-
-
-async def _pull_device_observations(device, integration, auth, action_config, present_time, default_start):
-    """Fetch, deliver and checkpoint one device.
-
-    Returns (observations_sent, device_failed). Raises only for integration-wide
-    problems; per-device problems are reported through the returned flag so the
-    caller can keep going.
-    """
-    cdip_positions = []
-    device_failed = False
-    last_successful_upper = None
-    try:
-        saved_state = await state_manager.get_state(str(integration.id), "pull_observations", device.nDeviceID)
-        state = client.IntegrationState.parse_obj({"updated_at": saved_state.get("updated_at") or default_start})
-    except pydantic.ValidationError as e:
-        logger.debug(f"Failed to parse saved state for device {device.nDeviceID}, using default state. Error: {e}")
-        state = client.IntegrationState(updated_at=default_start)
-
-    # Hard limit on query window; 2h overlap buffer to catch late-arriving uploads.
-    lower_date = max(default_start, state.updated_at - timedelta(hours=2))
-    while lower_date < present_time:
-        upper_date = min(present_time, lower_date + timedelta(days=7))
+    if any_open_gap:
         try:
-            async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
-                with attempt:
-                    positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
-            logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
-            # Transform inside the try: a malformed payload is a per-device, fetch-class
-            # failure and must get the same device/date-window log and isolation.
-            cdip_positions.extend(filter_and_transform_positions(positions, integration, action_config))
-        except LotekUnauthorizedException:
-            # Credentials are an integration-wide problem: every remaining device
-            # would fail the same way, so fail fast instead of N identical errors.
-            raise
-        except Exception as e:
-            # Deliberately broad: malformed data from Lotek surfaces as KeyError or
-            # pydantic.ValidationError out of the client's parsing, and those must
-            # not take down the devices behind this one either. CancelledError is a
-            # BaseException, so the action timeout still unwinds normally.
-            message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration.id} Exception: {describe_exception(e)}"
-            logger.exception(message)
-            await log_action_activity(
-                integration_id=str(integration.id),
-                action_id="pull_observations",
-                title=message,
-                level=LogLevel.ERROR
+            lease = await state_manager.get_state(
+                str(integration.id), "backfill_observations", BACKFILL_LEASE_SOURCE
             )
-            device_failed = True
-            break
-        last_successful_upper = upper_date
-        lower_date = upper_date
+            if not lease:
+                await trigger_action(str(integration.id), "backfill_observations")
+        except Exception as e:
+            # The head pass succeeded; a failed trigger must not fail the run.
+            logger.warning(
+                f"Could not trigger backfill for integration {integration.id}: {describe_exception(e)}"
+            )
 
-    if not cdip_positions and not device_failed:
+    return {
+        'observations_extracted': observations_extracted,
+        'devices_failed': failed_devices,
+        'devices_deferred': deferred_devices,
+    }
+
+
+async def _load_device_state(integration_id, device_id, present_time, action_config):
+    saved = await state_manager.get_state(integration_id, "pull_observations", device_id)
+    if saved:
+        try:
+            return DeviceState.parse_obj(saved)
+        except pydantic.ValidationError as e:
+            logger.debug(f"Failed to parse saved state for device {device_id}, starting fresh. Error: {e}")
+    # First run: the head pass starts at the freshness floor; everything older,
+    # back to the configured lookback, becomes the device's one and only gap —
+    # the deliberate historical import. It only ever shrinks from here.
+    head_start = present_time - timedelta(hours=action_config.max_data_age_hours)
+    gap_start = present_time - timedelta(days=action_config.default_lookback_days)
+    if gap_start < head_start:
+        return DeviceState(high_water=head_start, gap_start=gap_start, gap_end=head_start)
+    return DeviceState(high_water=head_start)
+
+
+async def _head_pass_device(device, integration, auth, action_config, present_time):
+    """Fetch, deliver and checkpoint one device's freshest window.
+
+    Returns (observations_sent, device_failed, state). Raises only for
+    integration-wide problems; per-device problems are reported through the
+    returned flag so the caller can keep going. Fetch-phase failures are
+    WARNINGs (transient while Lotek is slow; devices_failed tracks them);
+    delivery/checkpoint failures stay ERRORs.
+    """
+    integration_id = str(integration.id)
+    freshness_floor = present_time - timedelta(hours=action_config.max_data_age_hours)
+    state = await _load_device_state(integration_id, device.nDeviceID, present_time, action_config)
+
+    if state.high_water < freshness_floor:
+        # Bounded staleness (GUNDI-5602, deliberate): anything the cursor still
+        # owed beyond max_data_age_hours is dropped permanently — never added
+        # to the gap — so catch-up cost cannot compound.
+        message = (
+            f"Dropping stale range [{state.high_water.isoformat()}, {freshness_floor.isoformat()}] "
+            f"for device {device.nDeviceID}: older than max_data_age_hours="
+            f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
+        )
+        logger.warning(message)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+
+    lower_date = max(state.high_water, freshness_floor)
+    try:
+        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+            with attempt:
+                positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, present_time, True)
+        logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {present_time}.")
+        # Transform inside the try: a malformed payload is a per-device, fetch-class
+        # failure and must get the same device/date-window log and isolation.
+        cdip_positions = filter_and_transform_positions(positions, integration, action_config)
+    except LotekUnauthorizedException:
+        # Credentials are an integration-wide problem: every remaining device
+        # would fail the same way, so fail fast instead of N identical errors.
+        raise
+    except Exception as e:
+        # Deliberately broad: malformed data from Lotek surfaces as KeyError or
+        # pydantic.ValidationError out of the client's parsing, and those must
+        # not take down the devices behind this one either. CancelledError is a
+        # BaseException, so the action timeout still unwinds normally.
+        # WARNING, not ERROR: these recur daily while Lotek is slow, health
+        # keys on ERROR count alone, and devices_failed already tracks them.
+        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{present_time}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        logger.warning(message, exc_info=True)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+        return 0, True, state
+
+    if not cdip_positions:
         # Purely informational; must never affect the device's outcome. A pubsub blip
         # here must not mark a healthy quiet device as failed or stall its cursor.
         message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
@@ -318,43 +375,42 @@ async def _pull_device_observations(device, integration, auth, action_config, pr
         # convention) — kept from the pre-isolation send-loop handler.
         logger.exception(message, extra={
             'needs_attention': True,
-            'integration_id': str(integration.id),
+            'integration_id': integration_id,
             'action_id': "pull_observations"
         })
         await log_action_activity(
-            integration_id=str(integration.id),
+            integration_id=integration_id,
             action_id="pull_observations",
             title=message,
             level=LogLevel.ERROR
         )
-        return observations_sent, True
+        return observations_sent, True, state
 
-    # Advance state by the queried window (upload time), not recorded_at. Queries are by
-    # upload date, so wall clock is the correct cursor, and it must advance even when a
-    # device returns no positions. When a chunk failed, checkpoint only as far as the
-    # last window that actually succeeded so the failed window is retried without
-    # re-sending what already landed; if nothing succeeded, leave the cursor alone.
-    checkpoint = present_time if not device_failed else last_successful_upper
-    if checkpoint is not None:
-        try:
-            await state_manager.set_state(
-                str(integration.id),
-                "pull_observations",
-                {"updated_at": checkpoint.isoformat()},
-                device.nDeviceID
-            )
-        except Exception as e:
-            message = (
-                f"Error saving cursor for device {device.nDeviceID}. Integration ID: "
-                f"{integration.id} Exception: {describe_exception(e)}"
-            )
-            logger.exception(message)
-            await log_action_activity(
-                integration_id=str(integration.id),
-                action_id="pull_observations",
-                title=message,
-                level=LogLevel.ERROR
-            )
-            return observations_sent, True
+    # Advance the cursor to the queried upper bound (upload time), not recorded_at.
+    # Queries are by upload date, so wall clock is the correct cursor, and it must
+    # advance even when a device returns no positions. On failure the cursor stays
+    # untouched so the head window is re-fetched next run (re-sends are tolerated,
+    # silent skips are not).
+    state.high_water = present_time
+    try:
+        await state_manager.set_state(
+            integration_id,
+            "pull_observations",
+            state.dict(),
+            device.nDeviceID
+        )
+    except Exception as e:
+        message = (
+            f"Error saving cursor for device {device.nDeviceID}. Integration ID: "
+            f"{integration.id} Exception: {describe_exception(e)}"
+        )
+        logger.exception(message)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.ERROR
+        )
+        return observations_sent, True, state
 
-    return observations_sent, device_failed
+    return observations_sent, False, state

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -154,7 +154,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             with attempt:
                 device_list = await client.get_devices(integration, auth)
     except Exception as e:
-        message = f"Error fetching devices from Lotek. Integration ID: {integration.id} Exception: {e}"
+        message = f"Error fetching devices from Lotek. Integration ID: {integration.id} Exception: {describe_exception(e)}"
         logger.exception(message)
         await log_action_activity(
             integration_id=str(integration.id),

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -66,6 +66,8 @@ class RunGuards:
     def should_stop(self):
         if _deadline_exceeded(self.run_started_at):
             return "deadline"
+        if self.consecutive_transport_failures >= BREAKER_THRESHOLD:
+            return "circuit breaker"
         return None
 
     def record(self, transport_failure: bool):
@@ -378,6 +380,19 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
         # Credentials are an integration-wide problem: every remaining device
         # would fail the same way, so fail fast instead of N identical errors.
         raise
+    except httpx.TransportError as e:
+        # Timeouts/transport failures feed the circuit breaker: enough of them
+        # in a row means Lotek-wide degradation, not a bad device.
+        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{present_time}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        logger.warning(message, exc_info=True)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+        guards.record(transport_failure=True)
+        return 0, True, state
     except Exception as e:
         # Deliberately broad: malformed data from Lotek surfaces as KeyError or
         # pydantic.ValidationError out of the client's parsing, and those must
@@ -393,6 +408,7 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
             title=message,
             level=LogLevel.WARNING
         )
+        guards.record(transport_failure=False)
         return 0, True, state
 
     if not cdip_positions:
@@ -441,6 +457,9 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
             title=message,
             level=LogLevel.ERROR
         )
+        # The breaker watches Lotek, not Gundi: a delivery failure is not
+        # evidence of Lotek-wide degradation.
+        guards.record(transport_failure=False)
         return observations_sent, True, state
 
     # Advance the cursor to the queried upper bound (upload time), not recorded_at.
@@ -468,6 +487,8 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
             title=message,
             level=LogLevel.ERROR
         )
+        guards.record(transport_failure=False)
         return observations_sent, True, state
 
+    guards.record(transport_failure=False)
     return observations_sent, False, state

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -77,13 +77,19 @@ class RunGuards:
             self.consecutive_transport_failures = 0
 
 
+def _summarize_ids(ids):
+    # A Lotek-wide outage can involve every device; don't put hundreds of ids
+    # in a log title.
+    listed = ', '.join(ids[:MAX_DEVICES_IN_SUMMARY])
+    if len(ids) > MAX_DEVICES_IN_SUMMARY:
+        listed += f" and {len(ids) - MAX_DEVICES_IN_SUMMARY} more"
+    return listed
+
+
 async def _log_deferral(integration, action_id, reason, deferred_ids):
-    listed = ', '.join(deferred_ids[:MAX_DEVICES_IN_SUMMARY])
-    if len(deferred_ids) > MAX_DEVICES_IN_SUMMARY:
-        listed += f" and {len(deferred_ids) - MAX_DEVICES_IN_SUMMARY} more"
     message = (
         f"Stopping early ({reason}) for integration {integration.id}: deferring "
-        f"{len(deferred_ids)} device(s) to the next run: {listed}."
+        f"{len(deferred_ids)} device(s) to the next run: {_summarize_ids(deferred_ids)}."
     )
     logger.warning(message)
     await log_action_activity(
@@ -242,7 +248,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             await _log_deferral(integration, "pull_observations", reason, deferred_devices)
             break
         try:
-            sent, device_failed, state = await _head_pass_device(
+            sent, device_failed, transport_failure, state = await _head_pass_device(
                 device, integration, auth, action_config, present_time, guards
             )
         except LotekUnauthorizedException:
@@ -264,8 +270,11 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             failed_devices.append(device.nDeviceID)
             guards.record(transport_failure=False)
             continue
+        # Single recording site: transport failures arm the breaker, anything
+        # else (success included) breaks the consecutive streak.
+        guards.record(transport_failure=transport_failure)
         observations_extracted += sent
-        if state is not None and state.has_gap:
+        if state.has_gap:
             any_open_gap = True
         if device_failed:
             failed_devices.append(device.nDeviceID)
@@ -273,13 +282,10 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             serviced_devices += 1
 
     if failed_devices:
-        listed = ', '.join(failed_devices[:MAX_DEVICES_IN_SUMMARY])
-        if len(failed_devices) > MAX_DEVICES_IN_SUMMARY:
-            listed += f" and {len(failed_devices) - MAX_DEVICES_IN_SUMMARY} more"
         message = (
             f"Pulled observations with {len(failed_devices)} of {len(device_list)} device(s) "
-            f"failing for integration {integration.id}: {listed}. They will be retried on the "
-            f"next run."
+            f"failing for integration {integration.id}: {_summarize_ids(failed_devices)}. "
+            f"They will be retried on the next run."
         )
         logger.warning(message)
         await log_action_activity(
@@ -349,14 +355,110 @@ async def _load_device_state(integration_id, device_id, present_time, action_con
     return DeviceState(high_water=head_start)
 
 
+async def _fetch_window(device, integration, auth, config, lower_date, upper_date, guards, action_id):
+    """Fetch + transform one window for one device.
+
+    Returns (cdip_positions | None, transport_failure). None means the fetch
+    failed — already logged and classified; the caller marks the device failed
+    and records transport_failure for the circuit breaker. Raises only
+    LotekUnauthorizedException (integration-wide).
+    """
+    integration_id = str(integration.id)
+    try:
+        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+            with attempt:
+                positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
+        logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
+        # Transform inside the try: a malformed payload is a per-device, fetch-class
+        # failure and must get the same device/date-window log and isolation.
+        return filter_and_transform_positions(positions, integration, config), False
+    except LotekUnauthorizedException:
+        # Credentials are an integration-wide problem: every remaining device
+        # would fail the same way, so fail fast instead of N identical errors.
+        raise
+    except httpx.TransportError as e:
+        # WARNING + breaker-feeding: enough timeouts/transport failures in a
+        # row mean Lotek-wide degradation, not a bad device.
+        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        logger.warning(message, exc_info=True)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id=action_id,
+            title=message,
+            level=LogLevel.WARNING
+        )
+        return None, True
+    except Exception as e:
+        # Deliberately broad: malformed data from Lotek surfaces as KeyError or
+        # pydantic.ValidationError out of the client's parsing, and those must
+        # not take down the devices behind this one either. CancelledError is a
+        # BaseException, so the action timeout still unwinds normally.
+        # ERROR, not WARNING: unlike a transient timeout (httpx.TransportError,
+        # above), a data-shape break is permanent and won't self-heal on retry —
+        # it must stay visible to health/alerting or it can persist unnoticed
+        # forever (review finding).
+        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        logger.exception(message)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id=action_id,
+            title=message,
+            level=LogLevel.ERROR
+        )
+        return None, False
+
+
+async def _deliver(cdip_positions, device, integration, action_id):
+    """Send one device's transformed positions to Gundi in batches.
+
+    Returns (observations_sent, delivery_failed). Handled here rather than in
+    the caller so batches already delivered keep counting toward the run's
+    total — otherwise a send failure after a successful delivery reports
+    "nothing delivered". The cursor stays untouched on failure, so the
+    un-delivered remainder is re-fetched next run (re-sends are tolerated,
+    silent skips are not).
+    """
+    integration_id = str(integration.id)
+    observations_sent = 0
+    try:
+        if cdip_positions:
+            logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
+            for i, batch in enumerate(generate_batches(cdip_positions)):
+                logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
+                await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
+                observations_sent += len(batch)
+    except Exception as e:
+        message = (
+            f"Error delivering observations for device {device.nDeviceID}. Integration ID: "
+            f"{integration.id} Exception: {describe_exception(e)}"
+        )
+        # needs_attention drives log-based alerting on delivery failures (template
+        # convention) — kept from the pre-isolation send-loop handler.
+        logger.exception(message, extra={
+            'needs_attention': True,
+            'integration_id': integration_id,
+            'action_id': action_id
+        })
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id=action_id,
+            title=message,
+            level=LogLevel.ERROR
+        )
+        return observations_sent, True
+    return observations_sent, False
+
+
 async def _head_pass_device(device, integration, auth, action_config, present_time, guards):
     """Fetch, deliver and checkpoint one device's freshest window.
 
-    Returns (observations_sent, device_failed, state). Raises only for
-    integration-wide problems; per-device problems are reported through the
-    returned flag so the caller can keep going. Fetch-phase failures are
-    WARNINGs (transient while Lotek is slow; devices_failed tracks them);
-    delivery/checkpoint failures stay ERRORs.
+    Returns (observations_sent, device_failed, transport_failure, state).
+    Raises only for integration-wide problems; per-device problems are
+    reported through the returned flags so the caller can keep going (and
+    record transport_failure for the circuit breaker in one place).
+    Fetch-phase transport failures are WARNINGs (transient while Lotek is
+    slow; devices_failed tracks them); data-shape, delivery and checkpoint
+    failures stay ERRORs.
     """
     integration_id = str(integration.id)
     freshness_floor = present_time - timedelta(hours=action_config.max_data_age_hours)
@@ -380,50 +482,11 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
         )
 
     lower_date = max(state.high_water, freshness_floor)
-    try:
-        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
-            with attempt:
-                positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, present_time, True)
-        logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {present_time}.")
-        # Transform inside the try: a malformed payload is a per-device, fetch-class
-        # failure and must get the same device/date-window log and isolation.
-        cdip_positions = filter_and_transform_positions(positions, integration, action_config)
-    except LotekUnauthorizedException:
-        # Credentials are an integration-wide problem: every remaining device
-        # would fail the same way, so fail fast instead of N identical errors.
-        raise
-    except httpx.TransportError as e:
-        # Timeouts/transport failures feed the circuit breaker: enough of them
-        # in a row means Lotek-wide degradation, not a bad device.
-        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{present_time}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
-        logger.warning(message, exc_info=True)
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id="pull_observations",
-            title=message,
-            level=LogLevel.WARNING
-        )
-        guards.record(transport_failure=True)
-        return 0, True, state
-    except Exception as e:
-        # Deliberately broad: malformed data from Lotek surfaces as KeyError or
-        # pydantic.ValidationError out of the client's parsing, and those must
-        # not take down the devices behind this one either. CancelledError is a
-        # BaseException, so the action timeout still unwinds normally.
-        # ERROR, not WARNING: unlike a transient timeout (httpx.TransportError,
-        # above), a data-shape break is permanent and won't self-heal on retry —
-        # it must stay visible to health/alerting or it can persist unnoticed
-        # forever (review finding).
-        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{present_time}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
-        logger.exception(message)
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id="pull_observations",
-            title=message,
-            level=LogLevel.ERROR
-        )
-        guards.record(transport_failure=False)
-        return 0, True, state
+    cdip_positions, transport_failure = await _fetch_window(
+        device, integration, auth, action_config, lower_date, present_time, guards, "pull_observations"
+    )
+    if cdip_positions is None:
+        return 0, True, transport_failure, state
 
     if not cdip_positions:
         # Purely informational; must never affect the device's outcome. A pubsub blip
@@ -440,41 +503,11 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
         except Exception as e:
             logger.warning(f"Could not publish activity log for device {device.nDeviceID}: {describe_exception(e)}")
 
-    observations_sent = 0
-    try:
-        if cdip_positions:
-            logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
-            for i, batch in enumerate(generate_batches(cdip_positions)):
-                logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
-                await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
-                observations_sent += len(batch)
-    except Exception as e:
-        # Handled here rather than in the caller so batches already delivered keep
-        # counting toward the run's total — otherwise a send/checkpoint failure after a
-        # successful delivery reports "nothing delivered". Cursor stays untouched below,
-        # so the un-delivered remainder is re-fetched next run (re-sends are tolerated,
-        # silent skips are not).
-        message = (
-            f"Error delivering observations for device {device.nDeviceID}. Integration ID: "
-            f"{integration.id} Exception: {describe_exception(e)}"
-        )
-        # needs_attention drives log-based alerting on delivery failures (template
-        # convention) — kept from the pre-isolation send-loop handler.
-        logger.exception(message, extra={
-            'needs_attention': True,
-            'integration_id': integration_id,
-            'action_id': "pull_observations"
-        })
-        await log_action_activity(
-            integration_id=integration_id,
-            action_id="pull_observations",
-            title=message,
-            level=LogLevel.ERROR
-        )
+    observations_sent, delivery_failed = await _deliver(cdip_positions, device, integration, "pull_observations")
+    if delivery_failed:
         # The breaker watches Lotek, not Gundi: a delivery failure is not
         # evidence of Lotek-wide degradation.
-        guards.record(transport_failure=False)
-        return observations_sent, True, state
+        return observations_sent, True, False, state
 
     # Advance the cursor to the queried upper bound (upload time), not recorded_at.
     # Queries are by upload date, so wall clock is the correct cursor, and it must
@@ -501,95 +534,40 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
             title=message,
             level=LogLevel.ERROR
         )
-        guards.record(transport_failure=False)
-        return observations_sent, True, state
+        return observations_sent, True, False, state
 
-    guards.record(transport_failure=False)
-    return observations_sent, False, state
+    return observations_sent, False, False, state
 
 
 async def _backfill_device(device, state, integration, auth, pull_config, guards):
     """Close up to BACKFILL_MAX_WINDOWS_PER_DEVICE oldest windows of one
     device's gap.
 
-    Returns (observations_sent, device_failed, gap_closed). gap_start advances
-    only past windows that were actually delivered, so a failure re-fetches the
-    same window next trigger (re-sends are tolerated, silent skips are not).
+    Returns (observations_sent, device_failed, transport_failure, gap_closed).
+    gap_start advances only past windows that were actually delivered, so a
+    failure re-fetches the same window next trigger (re-sends are tolerated,
+    silent skips are not).
     """
     integration_id = str(integration.id)
     observations_sent = 0
     device_failed = False
+    transport_failure = False
     for _ in range(BACKFILL_MAX_WINDOWS_PER_DEVICE):
         if not state.has_gap:
             break
         window_start = state.gap_start
         upper_date = min(state.gap_end, state.gap_start + BACKFILL_WINDOW)
-        try:
-            async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
-                with attempt:
-                    positions = await client.get_positions(device.nDeviceID, auth, integration, window_start, upper_date, True)
-            cdip_positions = filter_and_transform_positions(positions, integration, pull_config)
-        except LotekUnauthorizedException:
-            raise
-        except httpx.TransportError as e:
-            message = (
-                f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
-                f"Dates: [{window_start},{upper_date}]. Integration ID: {integration_id} "
-                f"Exception: {describe_exception(e)}"
-            )
-            logger.warning(message, exc_info=True)
-            await log_action_activity(
-                integration_id=integration_id,
-                action_id="backfill_observations",
-                title=message,
-                level=LogLevel.WARNING
-            )
-            guards.record(transport_failure=True)
-            device_failed = True
-            break
-        except Exception as e:
-            # ERROR, not WARNING: a data-shape break is permanent, unlike the
-            # transient timeout above — it must stay visible to alerting.
-            message = (
-                f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
-                f"Dates: [{window_start},{upper_date}]. Integration ID: {integration_id} "
-                f"Exception: {describe_exception(e)}"
-            )
-            logger.exception(message)
-            await log_action_activity(
-                integration_id=integration_id,
-                action_id="backfill_observations",
-                title=message,
-                level=LogLevel.ERROR
-            )
-            guards.record(transport_failure=False)
+
+        cdip_positions, transport_failure = await _fetch_window(
+            device, integration, auth, pull_config, window_start, upper_date, guards, "backfill_observations"
+        )
+        if cdip_positions is None:
             device_failed = True
             break
 
-        try:
-            for i, batch in enumerate(generate_batches(cdip_positions)):
-                logger.info(f'Sending backfill batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
-                await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
-                observations_sent += len(batch)
-        except Exception as e:
-            message = (
-                f"Error delivering backfill observations for device {device.nDeviceID}. "
-                f"Integration ID: {integration_id} Exception: {describe_exception(e)}"
-            )
-            # needs_attention drives log-based alerting on delivery failures
-            # (template convention), same as the head pass.
-            logger.exception(message, extra={
-                'needs_attention': True,
-                'integration_id': integration_id,
-                'action_id': "backfill_observations"
-            })
-            await log_action_activity(
-                integration_id=integration_id,
-                action_id="backfill_observations",
-                title=message,
-                level=LogLevel.ERROR
-            )
-            guards.record(transport_failure=False)
+        sent, delivery_failed = await _deliver(cdip_positions, device, integration, "backfill_observations")
+        observations_sent += sent
+        if delivery_failed:
             device_failed = True
             break
 
@@ -600,15 +578,13 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
             state.gap_end = None
         await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
 
-    if not device_failed:
-        guards.record(transport_failure=False)
     # Advances even on zero progress (device_failed on the first window):
     # deliberate LRS-fairness trade-off so one permanently-broken device
     # doesn't monopolize the front of the backfill queue. The zero-progress
     # raise is the actual safety net when it's the only gapped device.
     state.last_backfilled = datetime.now(tz=timezone.utc)
     await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
-    return observations_sent, device_failed, not state.has_gap
+    return observations_sent, device_failed, transport_failure, not state.has_gap
 
 
 @action_title("Backfill Observations")
@@ -683,7 +659,7 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 await _log_deferral(integration, "backfill_observations", reason, deferred_devices)
                 break
             try:
-                sent, device_failed, gap_closed = await _backfill_device(
+                sent, device_failed, transport_failure, gap_closed = await _backfill_device(
                     device, state, integration, auth, pull_config, guards
                 )
             except LotekUnauthorizedException:
@@ -703,12 +679,28 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 failed_devices.append(device.nDeviceID)
                 guards.record(transport_failure=False)
                 continue
+            # Single recording site, mirroring the head-pass loop.
+            guards.record(transport_failure=transport_failure)
             observations_extracted += sent
             gaps_closed += int(gap_closed)
             if device_failed:
                 failed_devices.append(device.nDeviceID)
             else:
                 serviced_devices += 1
+
+        if failed_devices:
+            message = (
+                f"Backfilled with {len(failed_devices)} of {len(gapped)} gapped device(s) "
+                f"failing for integration {integration_id}: {_summarize_ids(failed_devices)}. "
+                f"Their gaps are retried on the next trigger."
+            )
+            logger.warning(message)
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="backfill_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
 
         if gapped and serviced_devices == 0 and observations_extracted == 0:
             # Same systemic-degradation contract as the head pass. The raise

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -5,6 +5,7 @@ import pydantic
 
 import app.services.gundi as gundi_tools
 import app.actions.client as client
+import app.settings as app_settings
 import app.settings.integration as settings
 
 from datetime import datetime, timezone, timedelta
@@ -43,6 +44,52 @@ BREAKER_THRESHOLD = 3
 BACKFILL_MAX_WINDOWS_PER_DEVICE = 2
 BACKFILL_WINDOW = timedelta(days=7)
 BACKFILL_LEASE_SOURCE = "lease"
+
+
+def _deadline_exceeded(run_started_at):
+    elapsed = (datetime.now(tz=timezone.utc) - run_started_at).total_seconds()
+    return elapsed > DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME
+
+
+def _retry_attempts(run_started_at):
+    # Past the soft deadline, don't spend the remaining budget on retries.
+    return 1 if _deadline_exceeded(run_started_at) else RETRY_ATTEMPTS
+
+
+class RunGuards:
+    """Per-run deadline + circuit-breaker state for a device loop."""
+
+    def __init__(self, run_started_at):
+        self.run_started_at = run_started_at
+        self.consecutive_transport_failures = 0
+
+    def should_stop(self):
+        if _deadline_exceeded(self.run_started_at):
+            return "deadline"
+        return None
+
+    def record(self, transport_failure: bool):
+        if transport_failure:
+            self.consecutive_transport_failures += 1
+        else:
+            self.consecutive_transport_failures = 0
+
+
+async def _log_deferral(integration, action_id, reason, deferred_ids):
+    listed = ', '.join(deferred_ids[:MAX_DEVICES_IN_SUMMARY])
+    if len(deferred_ids) > MAX_DEVICES_IN_SUMMARY:
+        listed += f" and {len(deferred_ids) - MAX_DEVICES_IN_SUMMARY} more"
+    message = (
+        f"Stopping early ({reason}) for integration {integration.id}: deferring "
+        f"{len(deferred_ids)} device(s) to the next run: {listed}."
+    )
+    logger.warning(message)
+    await log_action_activity(
+        integration_id=str(integration.id),
+        action_id=action_id,
+        title=message,
+        level=LogLevel.WARNING
+    )
 
 
 def describe_exception(exc):
@@ -157,6 +204,8 @@ def ensure_timezone_aware(val: datetime, default_tz: timezone = timezone.utc) ->
 async def action_pull_observations(integration, action_config: PullObservationsConfig):
     logger.info(f"Executing pull_observations action with integration {integration} and action_config {action_config}...")
 
+    # The clock starts before get_devices: it spends the same action budget.
+    run_started = datetime.now(tz=timezone.utc)
     auth = get_auth_config(integration)
     try:
         async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
@@ -175,15 +224,20 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
     present_time = datetime.now(tz=timezone.utc)
+    guards = RunGuards(run_started)
     observations_extracted = 0
     failed_devices = []
     deferred_devices = []
     serviced_devices = 0
     any_open_gap = False
-    for device in device_list:
+    for i, device in enumerate(device_list):
+        if reason := guards.should_stop():
+            deferred_devices = [d.nDeviceID for d in device_list[i:]]
+            await _log_deferral(integration, "pull_observations", reason, deferred_devices)
+            break
         try:
             sent, device_failed, state = await _head_pass_device(
-                device, integration, auth, action_config, present_time
+                device, integration, auth, action_config, present_time, guards
             )
         except LotekUnauthorizedException:
             raise
@@ -202,6 +256,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                 level=LogLevel.ERROR
             )
             failed_devices.append(device.nDeviceID)
+            guards.record(transport_failure=False)
             continue
         observations_extracted += sent
         if state is not None and state.has_gap:
@@ -280,7 +335,7 @@ async def _load_device_state(integration_id, device_id, present_time, action_con
     return DeviceState(high_water=head_start)
 
 
-async def _head_pass_device(device, integration, auth, action_config, present_time):
+async def _head_pass_device(device, integration, auth, action_config, present_time, guards):
     """Fetch, deliver and checkpoint one device's freshest window.
 
     Returns (observations_sent, device_failed, state). Raises only for
@@ -312,7 +367,7 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
 
     lower_date = max(state.high_water, freshness_floor)
     try:
-        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+        async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
                 positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, present_time, True)
         logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {present_time}.")

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -217,7 +217,9 @@ def ensure_timezone_aware(val: datetime, default_tz: timezone = timezone.utc) ->
 @action_title("Integration Settings")
 @activity_logger()
 async def action_pull_observations(integration, action_config: PullObservationsConfig):
-    logger.info(f"Executing pull_observations action with integration {integration} and action_config {action_config}...")
+    # Log only the id: the full Integration object embeds auth config data in
+    # plaintext (same leak family as the action-runner _handle_error ticket).
+    logger.info(f"Executing pull_observations action for integration {integration.id}...")
 
     # The clock starts before get_devices: it spends the same action budget.
     run_started = datetime.now(tz=timezone.utc)
@@ -235,7 +237,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             title=message,
             level=LogLevel.ERROR
         )
-        raise e
+        raise  # bare: preserve the original traceback
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
     present_time = datetime.now(tz=timezone.utc)
@@ -698,7 +700,7 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 title=message,
                 level=LogLevel.ERROR
             )
-            raise e
+            raise  # bare: preserve the original traceback
 
         gapped = []
         for device in device_list:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -434,18 +434,17 @@ async def _load_device_state(integration_id, device_id, present_time, action_con
 
 
 async def _save_device_state_fields(integration_id, device_id, updates):
-    """Merge-save: re-read the current blob and overwrite only the fields this
-    writer owns (head pass: high_water; backfill: gap_*/last_backfilled).
+    """Merge-save: atomically overwrite only the fields this writer owns
+    (head pass: high_water; backfill: gap_*/last_backfilled).
 
     The two actions can interleave — the Redis lease only serializes backfill
     against backfill — and whole-blob writes from a stale snapshot were
     resurrecting closed gaps and rewinding the head cursor (review finding:
-    lost-update race). The re-read shrinks the race window from the whole
-    action duration to milliseconds; re-sends cover whatever remains.
+    lost-update race). The merge runs server-side in a Lua script, so there
+    is no read-to-write window at all (review finding: the previous
+    client-side read-merge-write only narrowed the race).
     """
-    current = await state_manager.get_state(integration_id, "pull_observations", device_id)
-    merged = {**(current or {}), **updates}
-    await state_manager.set_state(integration_id, "pull_observations", merged, device_id)
+    await state_manager.merge_state_fields(integration_id, "pull_observations", updates, device_id)
 
 
 async def _fetch_window(device, integration, auth, config, lower_date, upper_date, guards, action_id):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -492,3 +492,217 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
 
     guards.record(transport_failure=False)
     return observations_sent, False, state
+
+
+async def _backfill_device(device, state, integration, auth, pull_config, guards):
+    """Close up to BACKFILL_MAX_WINDOWS_PER_DEVICE oldest windows of one
+    device's gap.
+
+    Returns (observations_sent, device_failed, gap_closed). gap_start advances
+    only past windows that were actually delivered, so a failure re-fetches the
+    same window next trigger (re-sends are tolerated, silent skips are not).
+    """
+    integration_id = str(integration.id)
+    observations_sent = 0
+    device_failed = False
+    for _ in range(BACKFILL_MAX_WINDOWS_PER_DEVICE):
+        if not state.has_gap:
+            break
+        window_start = state.gap_start
+        upper_date = min(state.gap_end, state.gap_start + BACKFILL_WINDOW)
+        try:
+            async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+                with attempt:
+                    positions = await client.get_positions(device.nDeviceID, auth, integration, window_start, upper_date, True)
+            cdip_positions = filter_and_transform_positions(positions, integration, pull_config)
+        except LotekUnauthorizedException:
+            raise
+        except httpx.TransportError as e:
+            message = (
+                f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
+                f"Dates: [{window_start},{upper_date}]. Integration ID: {integration_id} "
+                f"Exception: {describe_exception(e)}"
+            )
+            logger.warning(message, exc_info=True)
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="backfill_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
+            guards.record(transport_failure=True)
+            device_failed = True
+            break
+        except Exception as e:
+            message = (
+                f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
+                f"Dates: [{window_start},{upper_date}]. Integration ID: {integration_id} "
+                f"Exception: {describe_exception(e)}"
+            )
+            logger.warning(message, exc_info=True)
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="backfill_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
+            guards.record(transport_failure=False)
+            device_failed = True
+            break
+
+        try:
+            for i, batch in enumerate(generate_batches(cdip_positions)):
+                logger.info(f'Sending backfill batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
+                await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
+                observations_sent += len(batch)
+        except Exception as e:
+            message = (
+                f"Error delivering backfill observations for device {device.nDeviceID}. "
+                f"Integration ID: {integration_id} Exception: {describe_exception(e)}"
+            )
+            # needs_attention drives log-based alerting on delivery failures
+            # (template convention), same as the head pass.
+            logger.exception(message, extra={
+                'needs_attention': True,
+                'integration_id': integration_id,
+                'action_id': "backfill_observations"
+            })
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="backfill_observations",
+                title=message,
+                level=LogLevel.ERROR
+            )
+            guards.record(transport_failure=False)
+            device_failed = True
+            break
+
+        # Advance the gap only past the delivered window; close it when done.
+        state.gap_start = upper_date
+        if not state.has_gap:
+            state.gap_start = None
+            state.gap_end = None
+        await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
+
+    if not device_failed:
+        guards.record(transport_failure=False)
+    state.last_backfilled = datetime.now(tz=timezone.utc)
+    await state_manager.set_state(integration_id, "pull_observations", state.dict(), device.nDeviceID)
+    return observations_sent, device_failed, not state.has_gap
+
+
+@action_title("Backfill Observations")
+@activity_logger()
+async def action_backfill_observations(integration, action_config: BackfillObservationsConfig):
+    """Internal action: closes per-device historical gaps opened by the head
+    pass, oldest-first, least-recently-backfilled device first. Triggered by
+    pull_observations; the Redis lease keeps overlapping triggers from
+    double-running when a backfill grinds past the next head-pass trigger."""
+    logger.info(f"Executing backfill_observations action with integration {integration}...")
+    integration_id = str(integration.id)
+    run_started = datetime.now(tz=timezone.utc)
+    auth = get_auth_config(integration)
+    pull_config = get_pull_config(integration)  # max_pdop applies to backfilled data too
+
+    got_lease = await state_manager.set_if_absent(
+        integration_id,
+        "backfill_observations",
+        ttl_seconds=app_settings.MAX_ACTION_EXECUTION_TIME,
+        source_id=BACKFILL_LEASE_SOURCE,
+    )
+    if not got_lease:
+        logger.info(f"Backfill lease already held for integration {integration_id}; skipping run.")
+        return {"skipped": "lease_held"}
+
+    try:
+        try:
+            async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
+                with attempt:
+                    device_list = await client.get_devices(integration, auth)
+        except Exception as e:
+            message = (
+                f"Error fetching devices from Lotek for backfill. Integration ID: "
+                f"{integration_id} Exception: {describe_exception(e)}"
+            )
+            logger.exception(message)
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="backfill_observations",
+                title=message,
+                level=LogLevel.ERROR
+            )
+            raise e
+
+        gapped = []
+        for device in device_list:
+            saved = await state_manager.get_state(integration_id, "pull_observations", device.nDeviceID)
+            if not saved:
+                continue
+            try:
+                state = DeviceState.parse_obj(saved)
+            except pydantic.ValidationError:
+                continue  # the head pass will initialize it; nothing to backfill yet
+            if state.has_gap:
+                gapped.append((device, state))
+        # Least-recently-backfilled first keeps the import fair; devices never
+        # backfilled lead the queue.
+        epoch = datetime.min.replace(tzinfo=timezone.utc)
+        gapped.sort(key=lambda pair: pair[1].last_backfilled or epoch)
+
+        guards = RunGuards(run_started)
+        observations_extracted = 0
+        failed_devices = []
+        deferred_devices = []
+        serviced_devices = 0
+        gaps_closed = 0
+        for i, (device, state) in enumerate(gapped):
+            if reason := guards.should_stop():
+                deferred_devices = [d.nDeviceID for d, _ in gapped[i:]]
+                await _log_deferral(integration, "backfill_observations", reason, deferred_devices)
+                break
+            try:
+                sent, device_failed, gap_closed = await _backfill_device(
+                    device, state, integration, auth, pull_config, guards
+                )
+            except LotekUnauthorizedException:
+                raise
+            except Exception as e:
+                message = (
+                    f"Failed to backfill device {device.nDeviceID} for integration "
+                    f"{integration_id}: {describe_exception(e)}"
+                )
+                logger.exception(message)
+                await log_action_activity(
+                    integration_id=integration_id,
+                    action_id="backfill_observations",
+                    title=message,
+                    level=LogLevel.ERROR
+                )
+                failed_devices.append(device.nDeviceID)
+                guards.record(transport_failure=False)
+                continue
+            observations_extracted += sent
+            gaps_closed += int(gap_closed)
+            if device_failed:
+                failed_devices.append(device.nDeviceID)
+            else:
+                serviced_devices += 1
+
+        if gapped and serviced_devices == 0 and observations_extracted == 0:
+            # Same systemic-degradation contract as the head pass.
+            raise LotekException(
+                message=(
+                    f"No devices could be backfilled for integration {integration_id}: "
+                    f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+                    f"{len(gapped)}. See the per-device errors in this action's activity log."
+                )
+            )
+
+        return {
+            'observations_extracted': observations_extracted,
+            'devices_failed': failed_devices,
+            'devices_deferred': deferred_devices,
+            'gaps_closed': gaps_closed,
+        }
+    finally:
+        await state_manager.delete_state(integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -228,16 +228,18 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             level=LogLevel.WARNING
         )
 
-    if device_list and len(failed_devices) == len(device_list) and observations_extracted == 0:
-        # Every device failed and nothing was delivered: report the run as failed rather
-        # than returning normally, otherwise a wholly broken integration keeps publishing
-        # action_complete and looks healthy in the portal. A device that delivered part
-        # of its window before failing still counts as progress, so it stays a warning.
-        # This comes after the summary so the worst case keeps its device-naming log.
+    if device_list and serviced_devices == 0 and observations_extracted == 0:
+        # Zero progress: nothing serviced and nothing delivered — whether every
+        # device failed or the rails deferred them all, this is systemic
+        # degradation and must alert rather than publish action_complete. A
+        # device that delivered part of its window before failing still counts
+        # as progress, so partial runs stay warnings. This comes after the
+        # summary so the worst case keeps its device-naming log.
         raise LotekException(
             message=(
-                f"All {len(device_list)} device(s) failed for integration {integration.id}. "
-                f"See the per-device errors in this action's activity log."
+                f"No devices could be serviced for integration {integration.id}: "
+                f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+                f"{len(device_list)}. See the per-device errors in this action's activity log."
             )
         )
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -618,7 +618,9 @@ async def action_backfill_observations(integration, action_config: BackfillObser
     pass, oldest-first, least-recently-backfilled device first. Triggered by
     pull_observations; the Redis lease keeps overlapping triggers from
     double-running when a backfill grinds past the next head-pass trigger."""
-    logger.info(f"Executing backfill_observations action with integration {integration}...")
+    # Log only the id: the full Integration object embeds auth config data in
+    # plaintext (same leak family as the action-runner _handle_error ticket).
+    logger.info(f"Executing backfill_observations action for integration {integration.id}...")
     integration_id = str(integration.id)
     run_started = datetime.now(tz=timezone.utc)
     auth = get_auth_config(integration)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -406,15 +406,17 @@ async def _head_pass_device(device, integration, auth, action_config, present_ti
         # pydantic.ValidationError out of the client's parsing, and those must
         # not take down the devices behind this one either. CancelledError is a
         # BaseException, so the action timeout still unwinds normally.
-        # WARNING, not ERROR: these recur daily while Lotek is slow, health
-        # keys on ERROR count alone, and devices_failed already tracks them.
+        # ERROR, not WARNING: unlike a transient timeout (httpx.TransportError,
+        # above), a data-shape break is permanent and won't self-heal on retry —
+        # it must stay visible to health/alerting or it can persist unnoticed
+        # forever (review finding).
         message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{present_time}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
-        logger.warning(message, exc_info=True)
+        logger.exception(message)
         await log_action_activity(
             integration_id=integration_id,
             action_id="pull_observations",
             title=message,
-            level=LogLevel.WARNING
+            level=LogLevel.ERROR
         )
         guards.record(transport_failure=False)
         return 0, True, state
@@ -542,17 +544,19 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
             device_failed = True
             break
         except Exception as e:
+            # ERROR, not WARNING: a data-shape break is permanent, unlike the
+            # transient timeout above — it must stay visible to alerting.
             message = (
                 f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
                 f"Dates: [{window_start},{upper_date}]. Integration ID: {integration_id} "
                 f"Exception: {describe_exception(e)}"
             )
-            logger.warning(message, exc_info=True)
+            logger.exception(message)
             await log_action_activity(
                 integration_id=integration_id,
                 action_id="backfill_observations",
                 title=message,
-                level=LogLevel.WARNING
+                level=LogLevel.ERROR
             )
             guards.record(transport_failure=False)
             device_failed = True

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _zero_retry_waits(monkeypatch):
+    # Retry-path tests otherwise sleep through real stamina backoff (minutes
+    # over the suite, enough to blow a CI step timeout — review finding).
+    # Zeroing the module constants keeps the retry logic itself exercised.
+    monkeypatch.setattr("app.actions.handlers.RETRY_WAIT_INITIAL", 0.0)
+    monkeypatch.setattr("app.actions.handlers.RETRY_WAIT_JITTER", 0.0)
+    monkeypatch.setattr("app.actions.handlers.RETRY_WAIT_MAX", 0.0)

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -1,5 +1,28 @@
 import pytest
 
+from app.services.state import IntegrationStateManager
+
+
+@pytest.fixture(autouse=True)
+def _emulate_atomic_state_merge(monkeypatch):
+    # merge_state_fields is a server-side Lua script in production; tests mock
+    # the class-level get_state/set_state, so emulate the script's
+    # read-merge-write through them. Resolved at call time, so each test's own
+    # get_state/set_state patches (including side_effect sequences that model
+    # concurrent writers) are what the merge sees — and assertions keep
+    # inspecting set_state's merged documents.
+    from app.actions.handlers import state_manager
+
+    async def fake_merge(integration_id, action_id, updates, source_id="no-source"):
+        # go through the instance so both mock styles work (class-attr
+        # AsyncMocks and plain functions taking self)
+        current = await state_manager.get_state(integration_id, action_id, source_id)
+        await state_manager.set_state(
+            integration_id, action_id, {**(current or {}), **updates}, source_id
+        )
+
+    monkeypatch.setattr(IntegrationStateManager, "merge_state_fields", staticmethod(fake_merge))
+
 
 @pytest.fixture(autouse=True)
 def _zero_retry_waits(monkeypatch):

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -13,13 +13,18 @@ def _emulate_atomic_state_merge(monkeypatch):
     # inspecting set_state's merged documents.
     from app.actions.handlers import state_manager
 
-    async def fake_merge(integration_id, action_id, updates, source_id="no-source"):
+    async def fake_merge(integration_id, action_id, updates, source_id="no-source", init_only=None):
         # go through the instance so both mock styles work (class-attr
         # AsyncMocks and plain functions taking self)
         current = await state_manager.get_state(integration_id, action_id, source_id)
-        await state_manager.set_state(
-            integration_id, action_id, {**(current or {}), **updates}, source_id
-        )
+        merged = {**(current or {}), **updates}
+        # init_only mirrors the Lua script's key-presence check: a key stored
+        # as JSON null decodes to cjson.null (not Lua nil), so it counts as
+        # PRESENT and is not overwritten — only a missing key accepts the value.
+        for key, value in (init_only or {}).items():
+            if key not in merged:
+                merged[key] = value
+        await state_manager.set_state(integration_id, action_id, merged, source_id)
 
     monkeypatch.setattr(IntegrationStateManager, "merge_state_fields", staticmethod(fake_merge))
 

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -197,6 +197,61 @@ async def test_backfill_skips_devices_without_gaps(
 
 
 @pytest.mark.asyncio
+async def test_backfill_retriggers_itself_when_gaps_remain(
+    mocker, lotek_integration, mock_redis
+):
+    # Movebank-pattern cascade: a run that leaves gaps open (window cap or
+    # deferral) re-triggers itself so the import drains continuously instead of
+    # waiting for the next head-pass tick. The re-trigger must fire AFTER the
+    # lease release, or the next run would see its own lease and skip.
+    calls = []
+    get_positions, _, _, release, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=21)}
+    )
+    release.side_effect = lambda *a, **k: calls.append("release")
+    trigger = mocker.patch(
+        "app.actions.handlers.trigger_action",
+        new=AsyncMock(side_effect=lambda *a, **k: calls.append("trigger")),
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    trigger.assert_awaited_once_with(str(lotek_integration.id), "backfill_observations")
+    assert calls == ["release", "trigger"], "re-trigger must come after the lease release"
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_retrigger_when_all_gaps_closed(
+    mocker, lotek_integration, mock_redis
+):
+    _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=5)}
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["gaps_closed"] == 1
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_retrigger_on_zero_progress(
+    mocker, lotek_integration, mock_redis
+):
+    # Zero progress raises — the raise is the cascade's natural chain-breaker,
+    # otherwise a wholly-failing backfill would re-trigger itself forever.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    get_positions.side_effect = httpx.ReadTimeout("")
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    with pytest.raises(LotekException):
+        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_backfill_zero_progress_raises(
     mocker, lotek_integration, mock_redis
 ):

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -222,17 +222,10 @@ async def test_backfill_orders_devices_least_recently_backfilled_first(
         mocker, mock_redis, _devices("recent", "never", "old"), states
     )
     await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    # Each device's 6-day gap fits a single 7-day window, so exactly one fetch
+    # per device, least-recently-backfilled first (never-backfilled leads).
     order = [c.args[0] for c in get_positions.await_args_list]
-    assert order == ["never", "never", "old", "old", "recent", "recent"] or order == [
-        "never", "old", "recent"
-    ]
-    # each device has a 6-day gap → a single window; exact per-device counts
-    # are covered elsewhere, ordering is what matters here
-    deduped = []
-    for d in order:
-        if not deduped or deduped[-1] != d:
-            deduped.append(d)
-    assert deduped == ["never", "old", "recent"]
+    assert order == ["never", "old", "recent"]
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -158,6 +158,22 @@ async def test_backfill_orders_devices_least_recently_backfilled_first(
 
 
 @pytest.mark.asyncio
+async def test_backfill_malformed_data_failure_logs_error_not_warning(
+    mocker, lotek_integration, mock_redis
+):
+    # Review finding: a data-shape break is permanent, unlike a transient
+    # timeout, and must stay ERROR so it can alert.
+    get_positions, _, _, _, log = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    get_positions.return_value = None  # blows up in filter_and_transform_positions
+    with pytest.raises(LotekException):  # single device, zero progress
+        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    device_logs = [c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")]
+    assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
+
+
+@pytest.mark.asyncio
 async def test_backfill_does_not_advance_gap_when_send_fails(
     mocker, lotek_integration, lotek_position, mock_redis
 ):

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -214,7 +214,11 @@ async def test_backfill_retriggers_itself_when_gaps_remain(
         new=AsyncMock(side_effect=lambda *a, **k: calls.append("trigger")),
     )
     await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
-    trigger.assert_awaited_once_with(str(lotek_integration.id), "backfill_observations")
+    trigger.assert_awaited_once()
+    args, kwargs = trigger.await_args
+    assert args[:2] == (str(lotek_integration.id), "backfill_observations")
+    config = kwargs.get("config") or args[2]
+    assert config.dict() != {}, "an empty override 404s in execute_action before the handler runs"
     assert calls == ["release", "trigger"], "re-trigger must come after the lease release"
 
 

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -1,0 +1,211 @@
+import pytest
+import httpx
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+from gundi_core.schemas.v2 import LogLevel
+from app.actions.handlers import (
+    BACKFILL_MAX_WINDOWS_PER_DEVICE,
+    RETRY_ATTEMPTS,
+    action_backfill_observations,
+)
+from app.actions.client import LotekDevice, LotekException
+from app.actions.configurations import BackfillObservationsConfig, PullObservationsConfig
+
+
+def _devices(*device_ids):
+    return [
+        LotekDevice(nDeviceID=d, strSpecialID="s", dtCreated=datetime.now(), strSatellite="sat")
+        for d in device_ids
+    ]
+
+
+def _gap_state(days_back_start=7, days_back_end=1, last_backfilled=None):
+    now = datetime.now(timezone.utc)
+    state = {
+        "high_water": now.isoformat(),
+        "gap_start": (now - timedelta(days=days_back_start)).isoformat(),
+        "gap_end": (now - timedelta(days=days_back_end)).isoformat(),
+    }
+    if last_backfilled:
+        state["last_backfilled"] = last_backfilled.isoformat()
+    return state
+
+
+def _setup_backfill_mocks(mocker, mock_redis, devices, states_by_device):
+    # The lotek_integration fixture only carries an auth config; backfill also
+    # reads the pull config for max_pdop — patch the config getter instead.
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=devices))
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=PullObservationsConfig())
+    get_positions = mocker.patch(
+        "app.actions.client.get_positions", new=AsyncMock(return_value=[])
+    )
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(side_effect=lambda i, a, d: states_by_device.get(d, {})),
+    )
+    set_state = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_state", new=AsyncMock()
+    )
+    lease = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_if_absent",
+        new=AsyncMock(return_value=True),
+    )
+    release = mocker.patch(
+        "app.services.state.IntegrationStateManager.delete_state", new=AsyncMock()
+    )
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    return get_positions, set_state, lease, release, log
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_whole_run_when_lease_is_held(
+    mocker, lotek_integration, mock_redis
+):
+    get_positions, _, lease, release, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    lease.return_value = False
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result == {"skipped": "lease_held"}
+    get_positions.assert_not_awaited()
+    release.assert_not_awaited()  # a lease we didn't take is not ours to release
+
+
+@pytest.mark.asyncio
+async def test_backfill_releases_lease_even_when_the_run_raises(
+    mocker, lotek_integration, mock_redis
+):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    _, _, _, release, _ = _setup_backfill_mocks(mocker, mock_redis, [], {})
+    mocker.patch(
+        "app.actions.client.get_devices", new=AsyncMock(side_effect=httpx.ReadTimeout(""))
+    )
+    with pytest.raises(httpx.ReadTimeout):
+        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_backfill_caps_windows_per_device_and_advances_gap_start(
+    mocker, lotek_integration, mock_redis
+):
+    # A 20-day gap needs 3 seven-day windows; only 2 (the cap) may run,
+    # oldest-first, and gap_start must advance to the end of the last
+    # delivered window.
+    get_positions, set_state, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=21)}
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    assert get_positions.await_count == BACKFILL_MAX_WINDOWS_PER_DEVICE
+    first_start = get_positions.await_args_list[0].args[3]
+    second_start = get_positions.await_args_list[1].args[3]
+    assert second_start - first_start == timedelta(days=7)
+    final_state = set_state.await_args_list[-1].args[2]
+    assert final_state["gap_start"] - first_start == timedelta(days=14)
+    assert final_state["gap_end"] is not None  # 20d gap: still open after 2 windows
+
+
+@pytest.mark.asyncio
+async def test_backfill_closes_gap_to_null_when_fully_covered(
+    mocker, lotek_integration, mock_redis
+):
+    get_positions, set_state, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=5)}
+    )
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert get_positions.await_count == 1  # 4-day gap fits one 7-day window
+    final_state = set_state.await_args_list[-1].args[2]
+    assert final_state["gap_start"] is None and final_state["gap_end"] is None
+    assert final_state["last_backfilled"] is not None
+    assert result["gaps_closed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_orders_devices_least_recently_backfilled_first(
+    mocker, lotek_integration, mock_redis
+):
+    now = datetime.now(timezone.utc)
+    states = {
+        "recent": _gap_state(last_backfilled=now - timedelta(minutes=5)),
+        "never": _gap_state(),  # no last_backfilled → leads
+        "old": _gap_state(last_backfilled=now - timedelta(days=2)),
+    }
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("recent", "never", "old"), states
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    order = [c.args[0] for c in get_positions.await_args_list]
+    assert order == ["never", "never", "old", "old", "recent", "recent"] or order == [
+        "never", "old", "recent"
+    ]
+    # each device has a 6-day gap → a single window; exact per-device counts
+    # are covered elsewhere, ordering is what matters here
+    deduped = []
+    for d in order:
+        if not deduped or deduped[-1] != d:
+            deduped.append(d)
+    assert deduped == ["never", "old", "recent"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_advance_gap_when_send_fails(
+    mocker, lotek_integration, lotek_position, mock_redis
+):
+    get_positions, set_state, _, _, log = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1", "2"), {"1": _gap_state(), "2": _gap_state()}
+    )
+    get_positions.return_value = [lotek_position]
+    mocker.patch(
+        "app.actions.handlers.gundi_tools.send_observations_to_gundi",
+        new=AsyncMock(side_effect=[Exception("boom"), None]),
+    )
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["devices_failed"] == ["1"]
+    # device 1's gap must remain open (only its last_backfilled save may run)
+    device_1_gap_saves = [
+        c for c in set_state.await_args_list
+        if c.args[3] == "1" and c.args[2].get("gap_start") is None
+    ]
+    assert not device_1_gap_saves, "a failed window must not close or advance the gap"
+    error_logs = [c for c in log.await_args_list if c.kwargs["level"] == LogLevel.ERROR]
+    assert error_logs, "delivery failures must stay ERROR in backfill too"
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_devices_without_gaps(
+    mocker, lotek_integration, mock_redis
+):
+    now = datetime.now(timezone.utc)
+    states = {"1": {"high_water": now.isoformat()}, "2": _gap_state()}
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1", "2"), states
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    assert set(c.args[0] for c in get_positions.await_args_list) == {"2"}
+
+
+@pytest.mark.asyncio
+async def test_backfill_zero_progress_raises(
+    mocker, lotek_integration, mock_redis
+):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    get_positions, _, _, release, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    get_positions.side_effect = httpx.ReadTimeout("")
+    with pytest.raises(LotekException, match="No devices could be backfilled"):
+        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    release.assert_awaited_once()

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -52,11 +52,11 @@ def _setup_backfill_mocks(mocker, mock_redis, devices, states_by_device):
         "app.services.state.IntegrationStateManager.set_state", new=AsyncMock()
     )
     lease = mocker.patch(
-        "app.services.state.IntegrationStateManager.set_if_absent",
-        new=AsyncMock(return_value=True),
+        "app.services.state.IntegrationStateManager.acquire_lease",
+        new=AsyncMock(return_value="lease-token"),
     )
     release = mocker.patch(
-        "app.services.state.IntegrationStateManager.delete_state", new=AsyncMock()
+        "app.services.state.IntegrationStateManager.release_lease", new=AsyncMock(return_value=True)
     )
     log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
     return get_positions, set_state, lease, release, log
@@ -69,7 +69,7 @@ async def test_backfill_skips_whole_run_when_lease_is_held(
     get_positions, _, lease, release, _ = _setup_backfill_mocks(
         mocker, mock_redis, _devices("1"), {"1": _gap_state()}
     )
-    lease.return_value = False
+    lease.return_value = None  # acquire_lease: None = already held
     result = await action_backfill_observations(
         lotek_integration, BackfillObservationsConfig()
     )
@@ -355,3 +355,73 @@ async def test_backfill_zero_progress_raises(
     with pytest.raises(LotekException, match="No devices could be backfilled"):
         await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
     release.assert_awaited_once()
+
+
+# --- chrisdoehring review fix round ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_retrigger_when_no_window_advanced(
+    mocker, lotek_integration, lotek_position, mock_redis
+):
+    # Review finding: with a deterministic partial-delivery failure (batch 1
+    # lands, a later batch is always rejected), the run counts extracted
+    # observations — dodging the zero-progress raise — but never advances the
+    # gap, so retriggering on has_gap alone spun an unthrottled tight loop.
+    # No window advanced → no cascade; the next head pass retries ~cadence later.
+    from app.settings.integration import OBSERVATIONS_BATCH_SIZE
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    get_positions.return_value = [lotek_position] * (OBSERVATIONS_BATCH_SIZE + 1)
+    mocker.patch(
+        "app.actions.handlers.gundi_tools.send_observations_to_gundi",
+        new=AsyncMock(side_effect=[None, Exception("422 rejected")]),
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["observations_extracted"] == OBSERVATIONS_BATCH_SIZE  # batch 1 landed
+    assert result["devices_failed"] == ["1"]
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_still_retriggers_while_windows_are_advancing(
+    mocker, lotek_integration, mock_redis
+):
+    # Companion to the no-progress gate: a run that IS draining (window cap
+    # hit, gap still open) keeps the cascade going.
+    _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=30)}
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    trigger.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_quietly_when_config_is_missing(
+    mocker, lotek_integration, mock_redis
+):
+    # Review finding: an operator unconfiguring pull/auth mid-cascade made the
+    # backfill raise into the runner's generic _handle_error — an ERROR event
+    # embedding the full config (auth included) on every remaining cascade
+    # step. Missing config now skips; the head pass surfaces it.
+    from app.services.errors import ConfigurationNotFound
+    get_positions, _, lease, _, log = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    mocker.patch(
+        "app.actions.handlers.get_pull_config",
+        side_effect=ConfigurationNotFound("pull config missing"),
+    )
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result == {"skipped": True, "reason": "configuration_missing"}
+    lease.assert_not_awaited()
+    get_positions.assert_not_awaited()
+    error_logs = [c for c in log.await_args_list if c.kwargs.get("level") == LogLevel.ERROR]
+    assert not error_logs

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -73,9 +73,84 @@ async def test_backfill_skips_whole_run_when_lease_is_held(
     result = await action_backfill_observations(
         lotek_integration, BackfillObservationsConfig()
     )
-    assert result == {"skipped": "lease_held"}
+    assert result == {"skipped": True, "reason": "lease_held"}
     get_positions.assert_not_awaited()
     release.assert_not_awaited()  # a lease we didn't take is not ours to release
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_when_integration_is_paused(
+    mocker, lotek_integration, mock_redis
+):
+    # Review finding: run_on_schedule=False (the operator's pause toggle) must
+    # also stop the cascade — internal actions bypass the runner's pause check,
+    # so the backfill has to honor it itself.
+    from app.actions.configurations import PullObservationsConfig
+    get_positions, _, lease, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    mocker.patch(
+        "app.actions.handlers.get_pull_config",
+        return_value=PullObservationsConfig(run_on_schedule=False),
+    )
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result == {"skipped": True, "reason": "integration_paused"}
+    lease.assert_not_awaited()
+    get_positions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_retrigger_while_breaker_is_hot(
+    mocker, lotek_integration, mock_redis
+):
+    # Review finding: an immediate self-retrigger after a breaker trip defeats
+    # the pause the breaker exists to buy — the next scheduled head pass is the
+    # one that should re-trigger, ~cadence later.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    states = {d: _gap_state(days_back_start=5) for d in ("1", "2", "3", "4", "5")}
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5"), states
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    # device 1 succeeds (its 4-day gap closes in one window); 2, 3, 4 exhaust
+    # retries on timeouts and trip the breaker; 5 is deferred with its gap open
+    fail = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS
+    get_positions.side_effect = [[]] + fail * 3
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["devices_deferred"] == ["5"]
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_save_does_not_clobber_concurrently_advanced_high_water(
+    mocker, lotek_integration, mock_redis
+):
+    # Review finding (lost-update race): the backfill must persist only the
+    # fields it owns (gap_*, last_backfilled). A head pass advancing high_water
+    # mid-backfill must survive the backfill's writes.
+    now = datetime.now(timezone.utc)
+    old_hw = (now - timedelta(hours=6)).isoformat()
+    new_hw = (now - timedelta(minutes=1)).isoformat()
+    snapshot = {**_gap_state(days_back_start=5), "high_water": old_hw}
+    advanced = {**_gap_state(days_back_start=5), "high_water": new_hw}
+    get_positions, set_state, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {}
+    )
+    reads = mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        # scanner read (old hw), then merge re-reads (head pass advanced hw)
+        new=AsyncMock(side_effect=[snapshot, advanced, advanced]),
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    for c in set_state.await_args_list:
+        assert str(c.args[2].get("high_water")) == new_hw, (
+            "the backfill rewound a high_water a concurrent head pass had advanced"
+        )
 
 
 @pytest.mark.asyncio
@@ -108,9 +183,11 @@ async def test_backfill_caps_windows_per_device_and_advances_gap_start(
     first_start = get_positions.await_args_list[0].args[3]
     second_start = get_positions.await_args_list[1].args[3]
     assert second_start - first_start == timedelta(days=7)
-    final_state = set_state.await_args_list[-1].args[2]
-    assert final_state["gap_start"] - first_start == timedelta(days=14)
-    assert final_state["gap_end"] is not None  # 20d gap: still open after 2 windows
+    # [-1] is the last_backfilled merge-save; [-2] is the last window's gap save
+    window_save = set_state.await_args_list[-2].args[2]
+    assert window_save["gap_start"] - first_start == timedelta(days=14)
+    assert window_save["gap_end"] is not None  # 20d gap: still open after 2 windows
+    assert set_state.await_args_list[-1].args[2]["last_backfilled"] is not None
 
 
 @pytest.mark.asyncio
@@ -124,9 +201,10 @@ async def test_backfill_closes_gap_to_null_when_fully_covered(
         lotek_integration, BackfillObservationsConfig()
     )
     assert get_positions.await_count == 1  # 4-day gap fits one 7-day window
-    final_state = set_state.await_args_list[-1].args[2]
-    assert final_state["gap_start"] is None and final_state["gap_end"] is None
-    assert final_state["last_backfilled"] is not None
+    # [-1] is the last_backfilled merge-save; [-2] is the gap-close save
+    window_save = set_state.await_args_list[-2].args[2]
+    assert window_save["gap_start"] is None and window_save["gap_end"] is None
+    assert set_state.await_args_list[-1].args[2]["last_backfilled"] is not None
     assert result["gaps_closed"] == 1
 
 

--- a/app/actions/tests/test_backfill_trigger_e2e.py
+++ b/app/actions/tests/test_backfill_trigger_e2e.py
@@ -1,0 +1,68 @@
+import pytest
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+from gundi_core.schemas.v2 import IntegrationActionConfiguration
+from app.actions.client import LotekDevice
+from app.actions.handlers import action_pull_observations
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_trigger_actually_runs_backfill_end_to_end(mocker, lotek_integration, pull_config):
+    """Regression test (GUNDI-5602 review finding): backfill_observations is an
+    InternalActionConfiguration, so no IntegrationActionConfiguration row for it
+    is ever persisted (self_registration.py skips internal actions at
+    registration; nothing else creates one). trigger_action() with no `config`
+    argument publishes config_overrides=None, and execute_action's
+    `not action_config and not config_overrides` check 404s BEFORE
+    action_backfill_observations ever runs. This exercises the REAL chain —
+    action_pull_observations -> trigger_action (sync) -> execute_action ->
+    action_backfill_observations — which every other backfill test bypasses by
+    calling action_backfill_observations directly, and which is why this was
+    invisible until reviewed.
+    """
+    # Real Lotek integrations always carry a pull_observations config; add one
+    # so get_pull_config() inside action_backfill_observations resolves it,
+    # matching production (lotek_integration only ships an auth config).
+    lotek_integration.configurations.append(
+        IntegrationActionConfiguration.parse_obj({
+            "id": "30f8878c-4a98-4c95-88eb-79f73c40fb2e",
+            "integration": str(lotek_integration.id),
+            "action": {
+                "id": "75b3040f-ab1f-42e7-b39f-8965c088b154",
+                "type": "pull",
+                "name": "Pull Observations",
+                "value": "pull_observations",
+            },
+            "data": {},
+        })
+    )
+    mocker.patch("app.services.action_scheduler.settings.TRIGGER_ACTIONS_ALWAYS_SYNC", True)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.services.action_runner.publish_event", new=AsyncMock())
+    mock_config_manager = mocker.patch("app.services.action_runner.config_manager")
+    mock_config_manager.get_integration_details = AsyncMock(return_value=lotek_integration)
+    # No stored config for the internal action — this is the actual production
+    # state, since it is never registered or persisted anywhere.
+    mock_config_manager.get_action_configuration = AsyncMock(return_value=None)
+
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch(
+        "app.actions.client.get_devices",
+        new=AsyncMock(return_value=[LotekDevice(nDeviceID="1", strSpecialID="s", dtCreated=datetime.now(), strSatellite="sat")]),
+    )
+    mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[]))
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.state.IntegrationStateManager.delete_state", new=AsyncMock(return_value=None))
+    lease = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_if_absent", new=AsyncMock(return_value=True)
+    )
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert lease.await_count == 1, (
+        f"backfill_observations never ran — the trigger's config resolution "
+        f"short-circuited it. pull_observations result: {result}"
+    )

--- a/app/actions/tests/test_backfill_trigger_e2e.py
+++ b/app/actions/tests/test_backfill_trigger_e2e.py
@@ -55,9 +55,9 @@ async def test_pull_observations_trigger_actually_runs_backfill_end_to_end(mocke
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[]))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
-    mocker.patch("app.services.state.IntegrationStateManager.delete_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.services.state.IntegrationStateManager.release_lease", new=AsyncMock(return_value=True))
     lease = mocker.patch(
-        "app.services.state.IntegrationStateManager.set_if_absent", new=AsyncMock(return_value=True)
+        "app.services.state.IntegrationStateManager.acquire_lease", new=AsyncMock(return_value="lease-token")
     )
 
     result = await action_pull_observations(lotek_integration, pull_config)

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -24,8 +24,17 @@ def test_ui_order_lists_every_property_including_hidden_run_on_schedule():
     assert set(ui["ui:order"]) == set(PullObservationsConfig.schema()["properties"].keys())
 
 
-def test_backfill_config_is_internal_and_fieldless():
+def test_backfill_config_is_internal():
     # InternalActionConfiguration subclasses are skipped at registration —
     # backfill must never appear in the portal.
     assert issubclass(BackfillObservationsConfig, InternalActionConfiguration)
-    assert BackfillObservationsConfig.schema().get("properties", {}) == {}
+
+
+def test_backfill_config_has_a_default_so_trigger_overrides_are_never_empty():
+    # trigger_action() publishes config.dict() as the command's config_overrides.
+    # BackfillObservationsConfig has no persisted portal config (it's internal),
+    # so an empty dict here is indistinguishable from "no override at all" and
+    # trips execute_action's "configuration is missing" 404 before the handler
+    # ever runs (GUNDI-5602 review finding). A real default field keeps the
+    # override non-empty.
+    assert BackfillObservationsConfig().dict() != {}

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -1,0 +1,31 @@
+import pydantic
+import pytest
+
+from app.actions.configurations import BackfillObservationsConfig, PullObservationsConfig
+from app.actions.core import InternalActionConfiguration
+
+
+def test_max_data_age_hours_defaults_to_12_and_is_bounded_1_to_12():
+    assert PullObservationsConfig().max_data_age_hours == 12
+    with pytest.raises(pydantic.ValidationError):
+        PullObservationsConfig(max_data_age_hours=0)
+    with pytest.raises(pydantic.ValidationError):
+        PullObservationsConfig(max_data_age_hours=13)
+
+
+def test_max_data_age_hours_renders_as_range_slider():
+    ui = PullObservationsConfig.ui_schema()
+    assert ui["max_data_age_hours"]["ui:widget"] == "range"
+
+
+def test_ui_order_lists_every_property_including_hidden_run_on_schedule():
+    # rjsf + ajv strict mode fails silently when ui:order misses a property.
+    ui = PullObservationsConfig.ui_schema()
+    assert set(ui["ui:order"]) == set(PullObservationsConfig.schema()["properties"].keys())
+
+
+def test_backfill_config_is_internal_and_fieldless():
+    # InternalActionConfiguration subclasses are skipped at registration —
+    # backfill must never appear in the portal.
+    assert issubclass(BackfillObservationsConfig, InternalActionConfiguration)
+    assert BackfillObservationsConfig.schema().get("properties", {}) == {}

--- a/app/actions/tests/test_device_state.py
+++ b/app/actions/tests/test_device_state.py
@@ -1,0 +1,56 @@
+import json
+
+import pydantic
+import pytest
+
+from datetime import datetime, timezone
+
+from app.actions.device_state import DeviceState
+
+
+def test_legacy_updated_at_cursor_parses_as_high_water_with_no_gap():
+    # Pre-5602 state stored {"updated_at": ...}; deployed integrations must
+    # carry their cursor over without opening a gap.
+    state = DeviceState.parse_obj({"updated_at": "2026-08-10T00:00:00+00:00"})
+    assert state.high_water == datetime(2026, 8, 10, tzinfo=timezone.utc)
+    assert state.gap_start is None and state.gap_end is None
+    assert not state.has_gap
+
+
+def test_naive_datetimes_are_assumed_utc():
+    state = DeviceState.parse_obj({"high_water": "2026-08-10T00:00:00"})
+    assert state.high_water.tzinfo is not None
+    assert state.high_water == datetime(2026, 8, 10, tzinfo=timezone.utc)
+
+
+def test_has_gap_true_only_for_a_nonempty_range():
+    base = {"high_water": "2026-08-13T00:00:00+00:00"}
+    open_gap = DeviceState.parse_obj(
+        {**base, "gap_start": "2026-08-01T00:00:00+00:00", "gap_end": "2026-08-05T00:00:00+00:00"}
+    )
+    assert open_gap.has_gap
+    empty_gap = DeviceState.parse_obj(
+        {**base, "gap_start": "2026-08-05T00:00:00+00:00", "gap_end": "2026-08-05T00:00:00+00:00"}
+    )
+    assert not empty_gap.has_gap
+
+
+def test_missing_cursor_is_a_validation_error():
+    # No high_water and no legacy updated_at → caller must treat as first run.
+    with pytest.raises(pydantic.ValidationError):
+        DeviceState.parse_obj({"error": "whatever"})
+
+
+def test_round_trips_through_state_manager_json():
+    # state_manager serializes with json.dumps(default=str); the model must
+    # re-parse its own dict() output after that trip.
+    state = DeviceState.parse_obj(
+        {
+            "high_water": "2026-08-13T00:00:00+00:00",
+            "gap_start": "2026-08-01T00:00:00+00:00",
+            "gap_end": "2026-08-06T00:00:00+00:00",
+            "last_backfilled": "2026-08-12T00:00:00+00:00",
+        }
+    )
+    reparsed = DeviceState.parse_obj(json.loads(json.dumps(state.dict(), default=str)))
+    assert reparsed == state

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -664,6 +664,27 @@ async def test_action_pull_observations_isolates_transform_failure_to_the_device
 
 
 @pytest.mark.asyncio
+async def test_malformed_data_failure_logs_error_not_warning(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: malformed/unparseable data is a permanent, code/data-shape
+    # problem — not Lotek being slow — and must stay ERROR so it can alert,
+    # unlike a transient timeout (WARNING, see
+    # test_transient_fetch_failure_logs_warning_not_error). The demotion to
+    # WARNING was only ever meant for transient fetch timeouts.
+    get_positions, _, _, log = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+
+    async def get_positions_side_effect(device_id, *args, **kwargs):
+        return None if device_id == "1" else []  # device 1: malformed; device 2: fine
+
+    get_positions.side_effect = get_positions_side_effect
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["1"]
+    device_logs = [c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")]
+    assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
+
+
+@pytest.mark.asyncio
 async def test_action_pull_observations_emits_summary_before_all_failed_raise(
     mocker, lotek_integration, pull_config, mock_redis
 ):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -898,7 +898,7 @@ async def test_steady_state_advances_high_water_and_keeps_gap_closed(
 async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # Bounded staleness (Victor's call): a cursor further back than max_age
+    # Bounded staleness (agreed design decision): a cursor further back than max_age
     # means that span is dropped permanently — WARNING with the range, gap unchanged.
     stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
     get_positions, _, set_state, log = _setup_pull_mocks(

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -900,6 +900,9 @@ async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
 ):
     # Bounded staleness (agreed design decision): a cursor further back than max_age
     # means that span is dropped permanently — WARNING with the range, gap unchanged.
+    # The WARNING is published only after the cursor actually advances (review
+    # finding: announcing it before the fetch misreported still-recoverable
+    # data as dropped).
     stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
     get_positions, _, set_state, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
@@ -913,7 +916,7 @@ async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
     assert saved.get("gap_start") is None  # NOT added to the gap
     drop_warnings = [
         c for c in log.await_args_list
-        if c.kwargs["level"] == LogLevel.WARNING and "Dropping stale range" in c.kwargs["title"]
+        if c.kwargs["level"] == LogLevel.WARNING and "Dropped stale range" in c.kwargs["title"]
     ]
     assert len(drop_warnings) == 1
     assert "device 1" in drop_warnings[0].kwargs["title"]
@@ -1029,7 +1032,7 @@ async def test_deadline_defers_remaining_devices_with_warning(
 ):
     # Past ~80% of the action budget we stop STARTING device work and exit in
     # control — never via the asyncio.wait_for guillotine. Call order per
-    # device: should_stop() then _retry_attempts(), hence the side_effect
+    # device: should_stop() then _fetch_retry_kwargs(), hence the side_effect
     # sequence [False(stop d1), False(retry d1), True(stop d2)].
     _, _, _, log = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2", "3"))
     mocker.patch(
@@ -1045,12 +1048,21 @@ async def test_deadline_defers_remaining_devices_with_warning(
     assert len(deferral_logs) == 1
 
 
-def test_retry_attempts_drop_to_one_past_deadline(mocker):
-    from app.actions.handlers import _retry_attempts
+def test_retry_narrows_to_token_expiry_past_deadline(mocker):
+    # Past the soft deadline transport retries stop (no budget for slow
+    # backoff), but token expiry keeps its retry: the retry is a cheap
+    # re-auth, and dropping it broke the "token expiry recovers within the
+    # run" contract (review finding).
+    from app.actions.handlers import _fetch_retry_kwargs, RETRYABLE_ERRORS
+    from app.actions.client import LotekTokenExpiredException
     mocker.patch("app.actions.handlers._deadline_exceeded", return_value=False)
-    assert _retry_attempts(datetime.now(timezone.utc)) == RETRY_ATTEMPTS
+    assert _fetch_retry_kwargs(datetime.now(timezone.utc)) == {
+        "on": RETRYABLE_ERRORS, "attempts": RETRY_ATTEMPTS
+    }
     mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
-    assert _retry_attempts(datetime.now(timezone.utc)) == 1
+    assert _fetch_retry_kwargs(datetime.now(timezone.utc)) == {
+        "on": LotekTokenExpiredException, "attempts": RETRY_ATTEMPTS
+    }
 
 
 def test_deadline_fraction_of_budget():
@@ -1178,7 +1190,7 @@ async def test_stale_drop_publish_failure_does_not_stall_the_device(
     )
 
     async def flaky_publish(**kwargs):
-        if "Dropping stale range" in kwargs.get("title", ""):
+        if "Dropped stale range" in kwargs.get("title", ""):
             raise Exception("pubsub down")
 
     log.side_effect = flaky_publish
@@ -1237,3 +1249,143 @@ async def test_head_pass_save_does_not_clobber_concurrently_closed_gap(
         "the head pass resurrected a gap a concurrent backfill had closed"
     )
     assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1)
+
+
+# --- chrisdoehring review fix round ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lotek_5xx_failures_feed_the_circuit_breaker(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: LotekException (e.g. a 503 during a Lotek-wide outage)
+    # fell into the generic handler, which RESET the breaker streak — an
+    # HTTP-error outage could never trip the breaker and the run ground
+    # through every device. 5xx/429 must arm the breaker like timeouts.
+    from app.actions.handlers import BREAKER_THRESHOLD
+    get_positions, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+    )
+    get_positions.side_effect = LotekException(message="down", status_code=503)
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)
+    # breaker trips after 3 consecutive 503s; devices 4 and 5 are deferred
+    deferral_logs = [
+        c for c in log.await_args_list
+        if "circuit breaker" in c.kwargs.get("title", "").lower()
+    ]
+    assert len(deferral_logs) == 1
+    assert get_positions.await_count == BREAKER_THRESHOLD
+    # outage failures are WARNINGs (transient), not ERRORs
+    device_logs = [c for c in log.await_args_list if "Device:" in c.kwargs.get("title", "")]
+    assert device_logs and all(c.kwargs["level"] == LogLevel.WARNING for c in device_logs)
+
+
+@pytest.mark.asyncio
+async def test_lotek_4xx_failure_stays_error_and_does_not_feed_breaker(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # The 4xx side of the same finding: a per-device API-contract problem is
+    # permanent — ERROR, and it must break (not feed) the breaker streak.
+    get_positions, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4")
+    )
+    get_positions.side_effect = LotekException(message="bad request", status_code=404)
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)
+    assert get_positions.await_count == 4, "4xx failures must not trip the breaker"
+    device_logs = [c for c in log.await_args_list if "Device:" in c.kwargs.get("title", "")]
+    assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
+
+
+@pytest.mark.asyncio
+async def test_head_pass_services_least_fresh_devices_first(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: deferral always cut the same stable-ordered tail, so
+    # under sustained slowness the tail devices starved until bounded
+    # staleness dropped their data permanently. The head pass now orders
+    # least-fresh first (mirroring the backfill's LRS fairness).
+    now = datetime.now(timezone.utc)
+    states = {
+        "fresh": {"high_water": (now - timedelta(minutes=10)).isoformat()},
+        "stale": {"high_water": (now - timedelta(hours=10)).isoformat()},
+        "middle": {"high_water": (now - timedelta(hours=5)).isoformat()},
+    }
+    get_positions, get_state, _, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("fresh", "stale", "middle")
+    )
+    get_state.side_effect = lambda i, a, d: states.get(d, {})
+    await action_pull_observations(lotek_integration, pull_config)
+    order = [c.args[0] for c in get_positions.await_args_list]
+    assert order == ["stale", "middle", "fresh"]
+
+
+@pytest.mark.asyncio
+async def test_stale_legacy_cursor_migrates_into_gap_not_permanent_drop(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: on upgrade day a legacy cursor more than
+    # max_data_age_hours behind got no gap — the owed range was dropped
+    # permanently, though the pre-5602 walk would have recovered it. A stale
+    # legacy cursor now carries its owed range over as the device's gap.
+    behind = datetime.now(timezone.utc) - timedelta(days=3)
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"updated_at": behind.isoformat()}
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    saved = set_state.call_args.args[2]
+    assert abs(saved["gap_start"] - behind) < timedelta(seconds=1), (
+        "the owed range's start must be the legacy cursor"
+    )
+    floor = datetime.now(timezone.utc) - timedelta(hours=pull_config.max_data_age_hours)
+    assert abs(saved["gap_end"] - floor) < timedelta(minutes=1)
+    assert abs(saved["high_water"] - datetime.now(timezone.utc)) < timedelta(minutes=1)
+    # nothing was dropped, so no drop warning
+    assert not any(
+        "stale range" in c.kwargs.get("title", "").lower() for c in log.await_args_list
+    )
+    assert result["observations_extracted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_stale_drop_warning_when_the_fetch_fails(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: the drop WARNING was published before the fetch, so a
+    # failing device produced contradictory "permanently dropped" reports for
+    # data that was still recoverable. No cursor advance → no drop warning.
+    stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
+    )
+    get_positions.side_effect = httpx.ReadTimeout("")
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)
+    set_state.assert_not_awaited()
+    assert not any(
+        "stale range" in c.kwargs.get("title", "").lower() for c in log.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_error_publish_failure_stays_contained_to_the_device(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: the activity publish inside _fetch_window's error
+    # handlers was unguarded — a pubsub blip escaped the per-device isolation
+    # and reset the breaker streak with a failure that says nothing about
+    # Lotek. It must be best-effort like the other per-device publishes.
+    get_positions, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2")
+    )
+    get_positions.side_effect = [httpx.ReadTimeout(""), httpx.ReadTimeout(""), []]
+
+    async def flaky_publish(**kwargs):
+        if "Error fetching positions" in kwargs.get("title", ""):
+            raise Exception("pubsub down")
+
+    log.side_effect = flaky_publish
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["1"]
+    assert get_positions.await_count == 3, "device 2 was never serviced"

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -99,7 +99,7 @@ async def test_invalid_position_filtered_and_logs_warning_when_no_valid_observat
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
     result = await action_pull_observations(lotek_integration, pull_config)
-    assert result == {'observations_extracted': 0, 'devices_failed': []}
+    assert result == {'observations_extracted': 0, 'devices_failed': [], 'devices_deferred': []}
     mock_log_action_activity.assert_any_call(
         integration_id=str(lotek_integration.id),
         action_id="pull_observations",
@@ -108,22 +108,23 @@ async def test_invalid_position_filtered_and_logs_warning_when_no_valid_observat
     )
 
 @pytest.mark.asyncio
-async def test_lookback_days_config_sets_first_run_window(mocker, lotek_integration, pull_config, mock_redis):
+async def test_lookback_days_config_sets_first_run_gap_depth(mocker, lotek_integration, pull_config, mock_redis):
+    # default_lookback_days now controls only the first-run import depth: the
+    # head pass makes ONE fresh call and the rest becomes the device's gap.
     mocker.patch("app.services.state.redis", mock_redis)
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
     mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
     mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=[LotekDevice(nDeviceID="1", strSpecialID="special", dtCreated=datetime.now(), strSatellite="satellite")]))
     mock_get_positions = mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[]))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
-    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
     pull_config.default_lookback_days = 30
     await action_pull_observations(lotek_integration, pull_config)
-    # first chunk starts ~30 days back
-    first_call_start = mock_get_positions.call_args_list[0].args[3]
-    age_days = (datetime.now(timezone.utc) - first_call_start).days
-    assert age_days == 30
-    # window walked in 7-day chunks up to now
-    assert len(mock_get_positions.call_args_list) == 5
+    assert len(mock_get_positions.call_args_list) == 1
+    saved = mock_set_state.call_args.args[2]
+    gap_age_days = (datetime.now(timezone.utc) - saved["gap_start"]).days
+    assert gap_age_days == 30
 
 @pytest.mark.asyncio
 async def test_action_pull_observations_success(mocker, lotek_integration, pull_config, mock_redis):
@@ -135,7 +136,7 @@ async def test_action_pull_observations_success(mocker, lotek_integration, pull_
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     result = await action_pull_observations(lotek_integration, pull_config)
-    assert result == {'observations_extracted': 0, 'devices_failed': []}
+    assert result == {'observations_extracted': 0, 'devices_failed': [], 'devices_deferred': []}
 
 def _devices(*device_ids):
     return [
@@ -175,7 +176,7 @@ async def test_action_pull_observations_continues_after_one_device_fails(
     assert queried[0] == "1"
     assert queried[-1] == "3"
     assert queried.count("2") == RETRY_ATTEMPTS
-    assert result == {"observations_extracted": 2, "devices_failed": ["2"]}
+    assert result == {"observations_extracted": 2, "devices_failed": ["2"], "devices_deferred": []}
     assert mock_send.call_count == 2
 
 
@@ -205,7 +206,7 @@ async def test_action_pull_observations_continues_after_lotek_error_status(
     result = await action_pull_observations(lotek_integration, pull_config)
 
     assert queried == ["1", "2", "3"]
-    assert result == {"observations_extracted": 2, "devices_failed": ["2"]}
+    assert result == {"observations_extracted": 2, "devices_failed": ["2"], "devices_deferred": []}
 
 
 @pytest.mark.asyncio
@@ -237,7 +238,7 @@ async def test_action_pull_observations_continues_after_malformed_device_data(
     result = await action_pull_observations(lotek_integration, pull_config)
 
     assert queried[-1] == "3"
-    assert result == {"observations_extracted": 2, "devices_failed": ["2"]}
+    assert result == {"observations_extracted": 2, "devices_failed": ["2"], "devices_deferred": []}
 
 
 @pytest.mark.asyncio
@@ -330,7 +331,7 @@ async def test_action_pull_observations_counts_data_delivered_before_downstream_
 
     result = await action_pull_observations(lotek_integration, pull_config)
 
-    assert result == {"observations_extracted": 1, "devices_failed": ["1"]}
+    assert result == {"observations_extracted": 1, "devices_failed": ["1"], "devices_deferred": []}
 
 
 @pytest.mark.asyncio
@@ -411,49 +412,6 @@ async def test_action_pull_observations_fails_when_every_device_fails(
 
     with pytest.raises(LotekException):
         await action_pull_observations(lotek_integration, pull_config)
-
-
-@pytest.mark.asyncio
-async def test_action_pull_observations_keeps_successful_chunks_when_later_chunk_fails(
-    mocker, lotek_integration, pull_config, mock_redis, lotek_position
-):
-    # With a lookback wider than one chunk, data already fetched should be delivered and
-    # checkpointed up to the last good window instead of being thrown away every run.
-    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
-    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
-    mocker.patch("app.services.state.redis", mock_redis)
-    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
-    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
-    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
-    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
-    mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
-    mock_send = mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
-    pull_config.default_lookback_days = 30
-
-    windows = []
-
-    async def get_positions(device_id, auth, integration, lower, upper, geo_only):
-        if lower not in windows:
-            windows.append(lower)
-        # the third window fails every time, so retries are exhausted on it
-        if windows.index(lower) == 2:
-            raise httpx.ReadTimeout("")
-        return [lotek_position]
-
-    mocker.patch("app.actions.client.get_positions", new=get_positions)
-
-    result = await action_pull_observations(lotek_integration, pull_config)
-
-    assert mock_send.call_count >= 1, "successful chunks were discarded"
-    assert result["devices_failed"] == ["1"]
-    # The cursor must land exactly on the end of the second (last successful) 7-day
-    # window — i.e. ~16 days ago with a 30-day lookback — NOT at present_time, which
-    # would silently skip the failed window forever.
-    checkpoint = datetime.fromisoformat(mock_set_state.call_args_list[0].args[2]["updated_at"])
-    expected = datetime.now(timezone.utc) - timedelta(days=30) + timedelta(days=14)
-    assert abs((checkpoint - expected).total_seconds()) < 300, (
-        f"cursor at {checkpoint}, expected the last successful window's end ~{expected}"
-    )
 
 
 @pytest.mark.asyncio
@@ -539,7 +497,7 @@ async def test_action_pull_observations_retries_transient_timeout(
     result = await action_pull_observations(lotek_integration, pull_config)
 
     assert len(attempts) == 2, "the transient timeout should have been retried"
-    assert result == {"observations_extracted": 1, "devices_failed": []}
+    assert result == {"observations_extracted": 1, "devices_failed": [], "devices_deferred": []}
 
 
 @pytest.mark.asyncio
@@ -677,28 +635,23 @@ async def test_action_pull_observations_quiet_device_unaffected_by_logging_failu
 
 
 @pytest.mark.asyncio
-async def test_action_pull_observations_delivers_partial_chunks_when_transform_fails(
+async def test_action_pull_observations_isolates_transform_failure_to_the_device(
     mocker, lotek_integration, pull_config, mock_redis, lotek_position
 ):
-    # A transform failure on a later chunk is a per-device failure like any other:
-    # chunks already fetched must still be delivered and checkpointed.
+    # A malformed payload (transform blows up) is a per-device, fetch-class
+    # failure: the device is marked failed and the devices behind it still run.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     mocker.patch("app.services.state.redis", mock_redis)
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
     mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
-    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1")))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2")))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mock_send = mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
-    pull_config.default_lookback_days = 30
-
-    windows = []
 
     async def get_positions(device_id, auth, integration, lower, upper, geo_only):
-        if lower not in windows:
-            windows.append(lower)
-        if windows.index(lower) == 2:
+        if device_id == "1":
             return None  # malformed response: filter_and_transform will blow up iterating
         return [lotek_position]
 
@@ -707,7 +660,7 @@ async def test_action_pull_observations_delivers_partial_chunks_when_transform_f
     result = await action_pull_observations(lotek_integration, pull_config)
 
     assert result["devices_failed"] == ["1"]
-    assert mock_send.call_count >= 1, "chunks fetched before the transform failure were discarded"
+    assert mock_send.call_count == 1, "the device behind the malformed one was not delivered"
 
 
 @pytest.mark.asyncio
@@ -789,7 +742,7 @@ async def test_action_pull_observations_retries_token_expiry_and_recovers(
     result = await action_pull_observations(lotek_integration, pull_config)
 
     assert len(attempts) == 2, "token expiry was not retried"
-    assert result == {"observations_extracted": 1, "devices_failed": []}
+    assert result == {"observations_extracted": 1, "devices_failed": [], "devices_deferred": []}
 
 
 @pytest.mark.asyncio
@@ -817,3 +770,199 @@ def test_retry_attempts_is_two():
     # 3 attempts × 9 windows amplified Lotek's slowness into our own 9-min
     # timeouts (GUNDI-5602). One retry still recovers token expiry.
     assert RETRY_ATTEMPTS == 2
+
+
+# --- GUNDI-5602 head-pass tests -------------------------------------------
+
+
+def _setup_pull_mocks(mocker, mock_redis, devices, positions=None, saved_state=None):
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=devices))
+    get_positions = mocker.patch(
+        "app.actions.client.get_positions", new=AsyncMock(return_value=positions or [])
+    )
+    get_state = mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(return_value=saved_state or {}),
+    )
+    set_state = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None)
+    )
+    mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    return get_positions, get_state, set_state, log
+
+
+@pytest.mark.asyncio
+async def test_head_pass_fetches_single_max_age_window_on_first_run(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # First run: ONE request per device covering [now - max_data_age_hours, now]
+    # — not a chunked walk over the whole lookback.
+    get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    await action_pull_observations(lotek_integration, pull_config)
+    assert get_positions.await_count == 1
+    start, end = get_positions.call_args.args[3], get_positions.call_args.args[4]
+    assert abs((end - start) - timedelta(hours=pull_config.max_data_age_hours)) < timedelta(minutes=1)
+
+
+@pytest.mark.asyncio
+async def test_first_run_opens_gap_from_lookback_to_freshness_floor(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _, _, set_state, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    await action_pull_observations(lotek_integration, pull_config)
+    saved = set_state.call_args.args[2]
+    gap_span = saved["gap_end"] - saved["gap_start"]
+    expected = timedelta(days=pull_config.default_lookback_days) - timedelta(
+        hours=pull_config.max_data_age_hours
+    )
+    assert abs(gap_span - expected) < timedelta(minutes=1)
+
+
+@pytest.mark.asyncio
+async def test_no_gap_opened_when_lookback_fits_inside_max_age(mocker):
+    # Portal bounds (lookback >= 1 day > max_age <= 12h) make this unreachable
+    # via valid config, but the guard in _load_device_state must hold anyway —
+    # pin it at the unit level with construct() to bypass validation.
+    from app.actions.handlers import _load_device_state
+    from app.actions.configurations import PullObservationsConfig
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(return_value={}),
+    )
+    config = PullObservationsConfig.construct(
+        default_lookback_days=1, max_data_age_hours=48, max_pdop=None
+    )
+    state = await _load_device_state(
+        "some-integration-id", "1", datetime.now(timezone.utc), config
+    )
+    assert not state.has_gap
+    assert state.gap_start is None and state.gap_end is None
+
+
+@pytest.mark.asyncio
+async def test_steady_state_advances_high_water_and_keeps_gap_closed(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A device whose cursor is fresh (within max_age) head-fetches from its
+    # cursor and neither opens a gap nor drops anything.
+    recent = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    start = get_positions.call_args.args[3]
+    assert abs((datetime.now(timezone.utc) - start) - timedelta(hours=2)) < timedelta(minutes=1)
+    saved = set_state.call_args.args[2]
+    assert saved.get("gap_start") is None
+    assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1), (
+        "high_water was not advanced to the queried upper bound"
+    )
+    assert result["devices_deferred"] == []
+    warning_titles = [
+        c.kwargs["title"] for c in log.await_args_list if c.kwargs["level"] == LogLevel.WARNING
+    ]
+    assert not any("stale" in t.lower() for t in warning_titles)
+
+
+@pytest.mark.asyncio
+async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Bounded staleness (Victor's call): a cursor further back than max_age
+    # means that span is dropped permanently — WARNING with the range, gap unchanged.
+    stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    start = get_positions.call_args.args[3]
+    assert abs(
+        (datetime.now(timezone.utc) - start) - timedelta(hours=pull_config.max_data_age_hours)
+    ) < timedelta(minutes=1)
+    saved = set_state.call_args.args[2]
+    assert saved.get("gap_start") is None  # NOT added to the gap
+    drop_warnings = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "Dropping stale range" in c.kwargs["title"]
+    ]
+    assert len(drop_warnings) == 1
+    assert "device 1" in drop_warnings[0].kwargs["title"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_updated_at_state_migrates_to_high_water(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    recent = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+    get_positions, _, set_state, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"updated_at": recent}
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    start = get_positions.call_args.args[3]
+    assert abs((datetime.now(timezone.utc) - start) - timedelta(hours=3)) < timedelta(minutes=1)
+    saved = set_state.call_args.args[2]
+    assert "high_water" in saved and saved.get("gap_start") is None
+
+
+@pytest.mark.asyncio
+async def test_transient_fetch_failure_logs_warning_not_error(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Health/alerting keys on ERROR count; recurring per-device timeouts must
+    # not mark the connection unhealthy. devices_failed already tracks them.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2")
+    )
+    get_positions.side_effect = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS + [[]]
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["1"]
+    device_1_logs = [
+        c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")
+    ]
+    assert device_1_logs and all(c.kwargs["level"] == LogLevel.WARNING for c in device_1_logs)
+
+
+@pytest.mark.asyncio
+async def test_failed_head_fetch_does_not_advance_high_water(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    recent = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    get_positions, _, set_state, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
+    )
+    get_positions.side_effect = httpx.ReadTimeout("")
+    with pytest.raises(LotekException):
+        # single device, nothing serviced → the run-level failure raise
+        await action_pull_observations(lotek_integration, pull_config)
+    set_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_stays_error_and_does_not_advance_high_water(
+    mocker, lotek_integration, lotek_position, pull_config, mock_redis
+):
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2"), positions=[lotek_position]
+    )
+    mocker.patch(
+        "app.actions.handlers.gundi_tools.send_observations_to_gundi",
+        new=AsyncMock(side_effect=[Exception("boom"), None]),
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["1"]
+    error_logs = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.ERROR and "delivering" in c.kwargs["title"].lower()
+    ]
+    assert len(error_logs) == 1
+    # only device 2's checkpoint was written
+    saved_devices = [c.args[3] for c in set_state.await_args_list]
+    assert saved_devices == ["2"]

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1078,7 +1078,13 @@ async def test_head_pass_triggers_backfill_when_gap_open_and_lease_free(
     _setup_pull_mocks(mocker, mock_redis, _devices("1"))
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
     await action_pull_observations(lotek_integration, pull_config)
-    trigger.assert_awaited_once_with(str(lotek_integration.id), "backfill_observations")
+    trigger.assert_awaited_once()
+    args, kwargs = trigger.await_args
+    assert args[:2] == (str(lotek_integration.id), "backfill_observations")
+    # A fieldless config would serialize to an empty dict — indistinguishable
+    # from "no override" and 404s in execute_action before the handler runs.
+    config = kwargs.get("config") or args[2]
+    assert config.dict() != {}
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1251,6 +1251,63 @@ async def test_head_pass_save_does_not_clobber_concurrently_closed_gap(
     assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1)
 
 
+@pytest.mark.asyncio
+async def test_stale_first_run_save_does_not_resurrect_a_gap_closed_meanwhile(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: two overlapping head runs both load is_new=True; the
+    # faster one births the document and its triggered backfill closes the
+    # gap (gap keys stored as null — present). The slower run's save must not
+    # resurrect the gap from its stale snapshot: gap birth is create-only,
+    # and a key present as null counts as present.
+    now = datetime.now(timezone.utc)
+    gap_closed_doc = {
+        "version": 1,
+        "high_water": (now - timedelta(minutes=5)).isoformat(),
+        "gap_start": None,
+        "gap_end": None,
+        "last_backfilled": now.isoformat(),
+    }
+    _, get_state, set_state, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    # 1st read = this run loading state (absent → is_new, gap birthed in memory);
+    # 2nd read = the merge-save re-read (the faster run + backfill already ran).
+    get_state.side_effect = [{}, gap_closed_doc]
+    await action_pull_observations(lotek_integration, pull_config)
+    saved = set_state.call_args.args[2]
+    assert saved.get("gap_start") is None and saved.get("gap_end") is None, (
+        "a stale is_new save resurrected a gap a backfill had already closed"
+    )
+    assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1), (
+        "high_water must still be overwritten by the head save"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_first_run_save_does_not_rewind_an_advanced_gap(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Same race, gap still open: the faster run's backfill advanced gap_start
+    # past some drained windows. The slower run's create-only gap birth must
+    # leave the advanced value alone instead of rewinding to the full lookback.
+    now = datetime.now(timezone.utc)
+    advanced_start = (now - timedelta(days=3)).isoformat()
+    gap_end = (now - timedelta(hours=12)).isoformat()
+    gap_advanced_doc = {
+        "version": 1,
+        "high_water": (now - timedelta(minutes=5)).isoformat(),
+        "gap_start": advanced_start,
+        "gap_end": gap_end,
+    }
+    _, get_state, set_state, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    get_state.side_effect = [{}, gap_advanced_doc]
+    await action_pull_observations(lotek_integration, pull_config)
+    saved = set_state.call_args.args[2]
+    assert saved["gap_start"] == advanced_start, (
+        "a stale is_new save rewound gap_start to its full-lookback snapshot"
+    )
+    assert saved["gap_end"] == gap_end
+
+
 # --- chrisdoehring review fix round ------------------------------------------
 
 

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1068,3 +1068,60 @@ async def test_breaker_counter_resets_on_success(
     result = await action_pull_observations(lotek_integration, pull_config)
     assert result["devices_deferred"] == []
     assert result["devices_failed"] == ["1", "3", "5"]
+
+
+@pytest.mark.asyncio
+async def test_head_pass_triggers_backfill_when_gap_open_and_lease_free(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # First run on default config opens a gap → backfill must be triggered.
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    await action_pull_observations(lotek_integration, pull_config)
+    trigger.assert_awaited_once_with(str(lotek_integration.id), "backfill_observations")
+
+
+@pytest.mark.asyncio
+async def test_head_pass_does_not_trigger_backfill_when_lease_held(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    # per-device state reads return {}, but the lease key reads as held
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(side_effect=lambda i, a, s="no-source": "1" if s == "lease" else {}),
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_head_pass_does_not_trigger_backfill_without_gaps(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"), saved_state={"high_water": recent})
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    await action_pull_observations(lotek_integration, pull_config)
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_trigger_failure_does_not_fail_the_head_pass(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    mocker.patch(
+        "app.actions.handlers.trigger_action", new=AsyncMock(side_effect=Exception("pubsub down"))
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == []
+
+
+def test_backfill_action_is_discovered_but_internal():
+    from app.actions.core import discover_actions, InternalActionConfiguration
+    handlers = discover_actions(module_name="app.actions.handlers", prefix="action_")
+    assert "backfill_observations" in handlers
+    _, config_model, _ = handlers["backfill_observations"]
+    assert issubclass(config_model, InternalActionConfiguration)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -966,3 +966,17 @@ async def test_delivery_failure_stays_error_and_does_not_advance_high_water(
     # only device 2's checkpoint was written
     saved_devices = [c.args[3] for c in set_state.await_args_list]
     assert saved_devices == ["2"]
+
+
+@pytest.mark.asyncio
+async def test_all_failed_run_raises_zero_progress(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A run that services nothing and delivers nothing is systemic degradation —
+    # it must alert (raise/ERROR), not publish action_complete.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+    get_positions.side_effect = httpx.ReadTimeout("")
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1028,3 +1028,43 @@ def test_deadline_fraction_of_budget():
     # 540s budget → soft deadline ~432s. Pin the fraction.
     from app.actions.handlers import DEADLINE_FRACTION
     assert DEADLINE_FRACTION == 0.8
+
+
+@pytest.mark.asyncio
+async def test_breaker_trips_after_three_consecutive_transport_failures(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # 3 consecutive timeouts = Lotek-wide degradation: stop early, defer the
+    # rest (WARNING), instead of grinding every device into the same wall.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    get_positions, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+    )
+    # device 1 succeeds; 2,3,4 exhaust retries on timeouts; 5 must be deferred
+    get_positions.side_effect = [[]] + [httpx.ReadTimeout("")] * (3 * RETRY_ATTEMPTS)
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["2", "3", "4"]
+    assert result["devices_deferred"] == ["5"]
+    breaker_logs = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "circuit breaker" in c.kwargs["title"].lower()
+    ]
+    assert len(breaker_logs) == 1
+
+
+@pytest.mark.asyncio
+async def test_breaker_counter_resets_on_success(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Failures interleaved with successes are per-device noise, not an outage.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    get_positions, _, _, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+    )
+    fail = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS
+    get_positions.side_effect = fail + [[]] + fail + [[]] + fail  # F S F S F
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_deferred"] == []
+    assert result["devices_failed"] == ["1", "3", "5"]

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -857,9 +857,10 @@ async def test_no_gap_opened_when_lookback_fits_inside_max_age(mocker):
     config = PullObservationsConfig.construct(
         default_lookback_days=1, max_data_age_hours=48, max_pdop=None
     )
-    state = await _load_device_state(
+    state, is_new = await _load_device_state(
         "some-integration-id", "1", datetime.now(timezone.utc), config
     )
+    assert is_new
     assert not state.has_gap
     assert state.gap_start is None and state.gap_end is None
 
@@ -869,14 +870,18 @@ async def test_steady_state_advances_high_water_and_keeps_gap_closed(
     mocker, lotek_integration, pull_config, mock_redis
 ):
     # A device whose cursor is fresh (within max_age) head-fetches from its
-    # cursor and neither opens a gap nor drops anything.
+    # cursor (minus the late-upload overlap) and neither opens a gap nor
+    # drops anything.
     recent = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
     get_positions, _, set_state, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
     )
     result = await action_pull_observations(lotek_integration, pull_config)
     start = get_positions.call_args.args[3]
-    assert abs((datetime.now(timezone.utc) - start) - timedelta(hours=2)) < timedelta(minutes=1)
+    from app.actions.handlers import HEAD_LATE_UPLOAD_OVERLAP
+    assert abs(
+        (datetime.now(timezone.utc) - start) - (timedelta(hours=2) + HEAD_LATE_UPLOAD_OVERLAP)
+    ) < timedelta(minutes=1)
     saved = set_state.call_args.args[2]
     assert saved.get("gap_start") is None
     assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1), (
@@ -924,7 +929,10 @@ async def test_legacy_updated_at_state_migrates_to_high_water(
     )
     await action_pull_observations(lotek_integration, pull_config)
     start = get_positions.call_args.args[3]
-    assert abs((datetime.now(timezone.utc) - start) - timedelta(hours=3)) < timedelta(minutes=1)
+    from app.actions.handlers import HEAD_LATE_UPLOAD_OVERLAP
+    assert abs(
+        (datetime.now(timezone.utc) - start) - (timedelta(hours=3) + HEAD_LATE_UPLOAD_OVERLAP)
+    ) < timedelta(minutes=1)
     saved = set_state.call_args.args[2]
     assert "high_water" in saved and saved.get("gap_start") is None
 
@@ -1152,3 +1160,80 @@ def test_backfill_action_is_discovered_but_internal():
     assert "backfill_observations" in handlers
     _, config_model, _ = handlers["backfill_observations"]
     assert issubclass(config_model, InternalActionConfiguration)
+
+
+# --- Fable-5 review fix round -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stale_drop_publish_failure_does_not_stall_the_device(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: the stale-drop WARNING publish was the only activity
+    # publish on the fetch path without a guard — a degraded pubsub must not
+    # keep a stale device from ever advancing its cursor.
+    stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
+    )
+
+    async def flaky_publish(**kwargs):
+        if "Dropping stale range" in kwargs.get("title", ""):
+            raise Exception("pubsub down")
+
+    log.side_effect = flaky_publish
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == []
+    saved = set_state.call_args.args[2]
+    assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1)
+
+
+@pytest.mark.asyncio
+async def test_unparseable_state_reset_is_surfaced_at_warning(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding: discarding a cursor and re-importing the whole lookback
+    # was announced only at DEBUG. It must be visible in the activity log.
+    get_positions, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": "not-a-date"}
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    reset_warnings = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "unparseable" in c.kwargs["title"].lower()
+    ]
+    assert len(reset_warnings) == 1
+    assert "device 1" in reset_warnings[0].kwargs["title"]
+
+
+@pytest.mark.asyncio
+async def test_head_pass_save_does_not_clobber_concurrently_closed_gap(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Review finding (lost-update race): the head pass must persist only the
+    # fields it owns (high_water). If a concurrent backfill closed the gap
+    # between our load and our save, the closed gap must survive our write.
+    now = datetime.now(timezone.utc)
+    open_gap_state = {
+        "high_water": (now - timedelta(hours=2)).isoformat(),
+        "gap_start": (now - timedelta(days=7)).isoformat(),
+        "gap_end": (now - timedelta(hours=12)).isoformat(),
+    }
+    gap_closed_state = {
+        "high_water": (now - timedelta(hours=2)).isoformat(),
+        "gap_start": None,
+        "gap_end": None,
+        "last_backfilled": now.isoformat(),
+    }
+    get_positions, get_state, set_state, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1")
+    )
+    # 1st read = the head pass loading its snapshot (gap open);
+    # 2nd read = the merge-save re-read (backfill closed the gap meanwhile).
+    get_state.side_effect = [open_gap_state, gap_closed_state]
+    await action_pull_observations(lotek_integration, pull_config)
+    saved = set_state.call_args.args[2]
+    assert saved.get("gap_start") is None and saved.get("gap_end") is None, (
+        "the head pass resurrected a gap a concurrent backfill had closed"
+    )
+    assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -811,3 +811,9 @@ async def test_get_devices_failure_logs_exception_type_when_message_is_empty(
         await action_pull_observations(lotek_integration, pull_config)
     title = mock_log.call_args.kwargs["title"]
     assert "ReadTimeout" in title
+
+
+def test_retry_attempts_is_two():
+    # 3 attempts × 9 windows amplified Lotek's slowness into our own 9-min
+    # timeouts (GUNDI-5602). One retry still recovers token expiry.
+    assert RETRY_ATTEMPTS == 2

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -790,3 +790,24 @@ async def test_action_pull_observations_retries_token_expiry_and_recovers(
 
     assert len(attempts) == 2, "token expiry was not retried"
     assert result == {"observations_extracted": 1, "devices_failed": []}
+
+
+@pytest.mark.asyncio
+async def test_get_devices_failure_logs_exception_type_when_message_is_empty(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # httpx timeouts stringify to "" — the activity log must name the type,
+    # not render a bare "Exception: ".
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch(
+        "app.actions.client.get_devices",
+        new=AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+    mock_log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    with pytest.raises(httpx.ReadTimeout):
+        await action_pull_observations(lotek_integration, pull_config)
+    title = mock_log.call_args.kwargs["title"]
+    assert "ReadTimeout" in title

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -980,3 +980,51 @@ async def test_all_failed_run_raises_zero_progress(
     get_positions.side_effect = httpx.ReadTimeout("")
     with pytest.raises(LotekException, match="No devices could be serviced"):
         await action_pull_observations(lotek_integration, pull_config)
+
+
+@pytest.mark.asyncio
+async def test_zero_progress_run_raises_even_when_devices_were_only_deferred(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A run that services nothing is systemic degradation — it must alert
+    # (ERROR/raise), not warn forever. Deferring every device counts.
+    _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)
+
+
+@pytest.mark.asyncio
+async def test_deadline_defers_remaining_devices_with_warning(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Past ~80% of the action budget we stop STARTING device work and exit in
+    # control — never via the asyncio.wait_for guillotine. Call order per
+    # device: should_stop() then _retry_attempts(), hence the side_effect
+    # sequence [False(stop d1), False(retry d1), True(stop d2)].
+    _, _, _, log = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2", "3"))
+    mocker.patch(
+        "app.actions.handlers._deadline_exceeded", side_effect=[False, False, True]
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_deferred"] == ["2", "3"]
+    assert result["devices_failed"] == []
+    deferral_logs = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "deadline" in c.kwargs["title"].lower()
+    ]
+    assert len(deferral_logs) == 1
+
+
+def test_retry_attempts_drop_to_one_past_deadline(mocker):
+    from app.actions.handlers import _retry_attempts
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=False)
+    assert _retry_attempts(datetime.now(timezone.utc)) == RETRY_ATTEMPTS
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+    assert _retry_attempts(datetime.now(timezone.utc)) == 1
+
+
+def test_deadline_fraction_of_budget():
+    # 540s budget → soft deadline ~432s. Pin the fraction.
+    from app.actions.handlers import DEADLINE_FRACTION
+    assert DEADLINE_FRACTION == 0.8

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -21,11 +21,19 @@ _RELEASE_LEASE_SCRIPT = (
 # runs scripts atomically, so two writers updating disjoint fields can never
 # lose each other's update — unlike a client-side read-merge-write, which
 # always leaves a window between the read and the SET.
+# ARGV[2] fields are create-only: applied only when the key is absent from
+# the stored document. Presence is key-presence, not truthiness — a stored
+# JSON null decodes to cjson.null (not Lua nil), so a field another writer
+# set to null (e.g. a closed gap) still counts as PRESENT and is NOT
+# overwritten, while a document missing the key entirely accepts the value.
 _MERGE_STATE_SCRIPT = """
 local doc = {}
 local current = redis.call('GET', KEYS[1])
 if current then doc = cjson.decode(current) end
 for k, v in pairs(cjson.decode(ARGV[1])) do doc[k] = v end
+for k, v in pairs(cjson.decode(ARGV[2])) do
+  if doc[k] == nil then doc[k] = v end
+end
 redis.call('SET', KEYS[1], cjson.encode(doc))
 return 1
 """
@@ -75,19 +83,26 @@ class IntegrationStateManager:
         return bool(was_set)
 
     async def merge_state_fields(
-        self, integration_id: str, action_id: str, updates: dict, source_id: str = "no-source"
+        self, integration_id: str, action_id: str, updates: dict, source_id: str = "no-source",
+        init_only: Optional[dict] = None,
     ):
         """Atomically merge `updates` into the JSON state blob at the key,
         overwriting only those fields (server-side Lua, so concurrent writers
         owning disjoint fields cannot lose each other's update). Creates the
-        document when the key is absent. The stored format stays a plain JSON
-        blob, fully compatible with get_state/set_state.
+        document when the key is absent. `init_only` fields are create-only:
+        written only when the stored document lacks the key entirely — a key
+        present with a null value counts as present and is left alone, so a
+        stale writer cannot resurrect a field another writer already nulled.
+        The stored format stays a plain JSON blob, fully compatible with
+        get_state/set_state.
         """
         key = f"integration_state.{integration_id}.{action_id}.{source_id}"
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.eval(
-                    _MERGE_STATE_SCRIPT, 1, key, json.dumps(updates, default=str)
+                    _MERGE_STATE_SCRIPT, 1, key,
+                    json.dumps(updates, default=str),
+                    json.dumps(init_only or {}, default=str),
                 )
 
     async def acquire_lease(

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -1,8 +1,20 @@
 import json
+import uuid
+from typing import Optional
+
 import stamina
 import httpx
 import redis.asyncio as redis
 from app import settings
+
+
+# Compare-and-delete: only deletes the key if it still holds the caller's
+# token, so a stale releaser (e.g. a cancelled run whose DEL was retried
+# through a Redis blip past its own TTL) cannot delete a successor's lease.
+_RELEASE_LEASE_SCRIPT = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then "
+    "return redis.call('del', KEYS[1]) else return 0 end"
+)
 
 
 class IntegrationStateManager:
@@ -47,6 +59,36 @@ class IntegrationStateManager:
                     nx=True,
                 )
         return bool(was_set)
+
+    async def acquire_lease(
+        self, integration_id: str, action_id: str, *, ttl_seconds: int, source_id: str = "no-source"
+    ) -> Optional[str]:
+        """Atomically acquire an ownership lease: SET NX of a unique token with
+        a TTL. Returns the token when acquired (pass it to release_lease), or
+        None when another holder already has the lease. Unlike set_if_absent,
+        the token lets the holder release without racing a successor that
+        acquired after the TTL expired.
+        """
+        token = str(uuid.uuid4())
+        key = f"integration_state.{integration_id}.{action_id}.{source_id}"
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                was_set = await self.db_client.set(key, json.dumps(token), ex=ttl_seconds, nx=True)
+        return token if was_set else None
+
+    async def release_lease(
+        self, integration_id: str, action_id: str, token: str, source_id: str = "no-source"
+    ) -> bool:
+        """Release a lease acquired with acquire_lease, only if this caller
+        still owns it (compare-and-delete on the token). Returns True when the
+        lease was deleted, False when it was already expired or re-acquired by
+        someone else. Safe to retry: it can never delete another holder's lease.
+        """
+        key = f"integration_state.{integration_id}.{action_id}.{source_id}"
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                deleted = await self.db_client.eval(_RELEASE_LEASE_SCRIPT, 1, key, json.dumps(token))
+        return bool(deleted)
 
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -16,6 +16,20 @@ _RELEASE_LEASE_SCRIPT = (
     "return redis.call('del', KEYS[1]) else return 0 end"
 )
 
+# Atomic field merge into a JSON-blob state key: decode the current document
+# (or start empty), overwrite only the fields in ARGV[1], re-encode. Redis
+# runs scripts atomically, so two writers updating disjoint fields can never
+# lose each other's update — unlike a client-side read-merge-write, which
+# always leaves a window between the read and the SET.
+_MERGE_STATE_SCRIPT = """
+local doc = {}
+local current = redis.call('GET', KEYS[1])
+if current then doc = cjson.decode(current) end
+for k, v in pairs(cjson.decode(ARGV[1])) do doc[k] = v end
+redis.call('SET', KEYS[1], cjson.encode(doc))
+return 1
+"""
+
 
 class IntegrationStateManager:
 
@@ -59,6 +73,22 @@ class IntegrationStateManager:
                     nx=True,
                 )
         return bool(was_set)
+
+    async def merge_state_fields(
+        self, integration_id: str, action_id: str, updates: dict, source_id: str = "no-source"
+    ):
+        """Atomically merge `updates` into the JSON state blob at the key,
+        overwriting only those fields (server-side Lua, so concurrent writers
+        owning disjoint fields cannot lose each other's update). Creates the
+        document when the key is absent. The stored format stays a plain JSON
+        blob, fully compatible with get_state/set_state.
+        """
+        key = f"integration_state.{integration_id}.{action_id}.{source_id}"
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                await self.db_client.eval(
+                    _MERGE_STATE_SCRIPT, 1, key, json.dumps(updates, default=str)
+                )
 
     async def acquire_lease(
         self, integration_id: str, action_id: str, *, ttl_seconds: int, source_id: str = "no-source"

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 from app.conftest import async_return
-from app.services.state import IntegrationStateManager
+from app.services.state import IntegrationStateManager, _MERGE_STATE_SCRIPT
 
 
 @pytest.mark.asyncio
@@ -113,6 +113,29 @@ async def test_set_if_absent(mocker, mock_redis, integration_v2):
         ttl_seconds=3600,
     )
     assert was_set is False
+
+
+@pytest.mark.asyncio
+async def test_merge_state_fields_executes_atomic_lua(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    mock_redis.Redis.return_value.eval.return_value = async_return(1)
+    state_manager = IntegrationStateManager()
+    integration_id = str(integration_v2.id)
+    updates = {"high_water": "2026-08-14T01:02:03+00:00", "gap_start": None}
+
+    await state_manager.merge_state_fields(
+        integration_id=integration_id,
+        action_id="pull_observations",
+        source_id="device-123",
+        updates=updates,
+    )
+
+    mock_redis.Redis.return_value.eval.assert_called_once_with(
+        _MERGE_STATE_SCRIPT,
+        1,
+        f"integration_state.{integration_id}.pull_observations.device-123",
+        json.dumps(updates, default=str),
+    )
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -135,6 +135,33 @@ async def test_merge_state_fields_executes_atomic_lua(mocker, mock_redis, integr
         1,
         f"integration_state.{integration_id}.pull_observations.device-123",
         json.dumps(updates, default=str),
+        json.dumps({}, default=str),
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_state_fields_passes_init_only_fields(mocker, mock_redis, integration_v2):
+    mocker.patch("app.services.state.redis", mock_redis)
+    mock_redis.Redis.return_value.eval.return_value = async_return(1)
+    state_manager = IntegrationStateManager()
+    integration_id = str(integration_v2.id)
+    updates = {"high_water": "2026-08-14T01:02:03+00:00"}
+    init_only = {"gap_start": "2026-08-01T00:00:00+00:00", "gap_end": "2026-08-10T00:00:00+00:00"}
+
+    await state_manager.merge_state_fields(
+        integration_id=integration_id,
+        action_id="pull_observations",
+        source_id="device-123",
+        updates=updates,
+        init_only=init_only,
+    )
+
+    mock_redis.Redis.return_value.eval.assert_called_once_with(
+        _MERGE_STATE_SCRIPT,
+        1,
+        f"integration_state.{integration_id}.pull_observations.device-123",
+        json.dumps(updates, default=str),
+        json.dumps(init_only, default=str),
     )
 
 

--- a/docs/superpowers/plans/2026-08-13-lotek-head-pass.md
+++ b/docs/superpowers/plans/2026-08-13-lotek-head-pass.md
@@ -553,7 +553,7 @@ async def test_steady_state_advances_high_water_and_keeps_gap_closed(
 async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # Bounded staleness (Victor's call): a cursor further back than max_age
+    # Bounded staleness (agreed design decision): a cursor further back than max_age
     # means that span is dropped permanently — WARNING with the range, gap unchanged.
     stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
     get_positions, _, set_state, log = _setup_pull_mocks(
@@ -1798,7 +1798,7 @@ gh pr create --repo PADAS/gundi-integration-lotek \
 PR body must include (draft in the scratchpad, then pass via `--body-file`):
 - Link to GUNDI-5602 and the spec file in-repo.
 - The architecture summary (head pass / internal backfill / single shrinking gap / lease).
-- **The bounded-staleness trade-off stated explicitly**: data older than `max_data_age_hours` that could not be fetched is dropped permanently (WARNING with device + range). This supersedes the earlier "no data loss, only delay" framing — deliberate call, approved by Victor: gaps can't grow, catch-up can't compound, rangers always get fresh positions. Default 12 h with a 10-min cadence ≈ 72 missed runs of slack.
+- **The bounded-staleness trade-off stated explicitly**: data older than `max_data_age_hours` that could not be fetched is dropped permanently (WARNING with device + range). This supersedes the earlier "no data loss, only delay" framing — an agreed design decision: gaps can't grow, catch-up can't compound, rangers always get fresh positions. Default 12 h with a 10-min cadence ≈ 72 missed runs of slack.
 - Safety rails: soft deadline (80% of 540 s), circuit breaker (K=3 consecutive transport failures), zero-progress raise, backfill lease (NX + TTL).
 - Error-semantics table (what stays ERROR vs demoted to WARNING) and why (health = ERROR count in 60 min).
 - Load math: steady state 1 request/device/run vs up to ~27 today.

--- a/docs/superpowers/plans/2026-08-13-lotek-head-pass.md
+++ b/docs/superpowers/plans/2026-08-13-lotek-head-pass.md
@@ -1,0 +1,1832 @@
+# Lotek Head Pass + Internal Backfill (GUNDI-5602) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flip the Lotek connector to newest-first fetching: a head pass in `pull_observations` that always delivers the freshest window per device, plus an internal `backfill_observations` action that closes the bounded historical gap — with deadline / circuit-breaker / zero-progress / lease safety rails.
+
+**Architecture:** Per the approved spec `docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md` (source of truth). Per-device state moves from a single `updated_at` cursor to `{high_water, gap_start, gap_end, last_backfilled}` in a new `DeviceState` model. `pull_observations` head-fetches `[max(high_water, now − max_data_age_hours), now]` for every device every run, then triggers `backfill_observations` (an `InternalActionConfiguration` action, never shown in the portal) when gaps exist and the Redis lease is free. Anything older than `max_data_age_hours` that was never fetched is **dropped permanently** with a WARNING — bounded staleness is the deliberate, approved trade-off.
+
+**Tech Stack:** Python 3.11, pydantic v1, httpx, stamina, redis.asyncio, pytest + pytest-asyncio + pytest-mock. Suite runs with `./venv/bin/python -m pytest app -q`.
+
+## Global Constraints
+
+- TDD strictly: failing test first, then minimal implementation. Flip-verify assertions that pin critical lines (change the production line, watch the test fail, restore byte-identical).
+- Test suite must stay **< 2 s**: patch `RETRY_WAIT_INITIAL` / `RETRY_WAIT_JITTER` / `RETRY_WAIT_MAX` to 0 in any test that exercises retries. Never `sleep`.
+- Health/alerting keys on ERROR-count only (cdip `calculate_integration_status`, ≥3 ERROR logs / 60 min → UNHEALTHY). ERROR = "someone can and should act": login refused, `get_devices` failure, delivery failure, zero-progress. WARNING = per-device transient fetch failures, deferrals (deadline/breaker), dropped stale ranges.
+- Code constants, NOT config fields: `RETRY_ATTEMPTS = 2`, `DEADLINE_FRACTION = 0.8`, `BREAKER_THRESHOLD = 3`, `BACKFILL_MAX_WINDOWS_PER_DEVICE = 2`, `BACKFILL_WINDOW = timedelta(days=7)`.
+- New config field: `max_data_age_hours`, default 12, ge=1, le=12, `ui:widget: range`. `ui:order` must list every property including hidden `run_on_schedule`.
+- State keys: device state stays under `(integration_id, "pull_observations", device_id)` — shared by both actions. Backfill lease under `(integration_id, "backfill_observations", "lease")` via the existing atomic `IntegrationStateManager.set_if_absent` (NX + TTL = `settings.MAX_ACTION_EXECUTION_TIME`).
+- `Optional[str]`, not `str | None` (pydantic v1 codebase style). All datetimes tz-aware UTC.
+- Commit after every green task. Branch: `feat/GUNDI-5602-head-pass-backfill` off `origin/main`.
+
+---
+
+### Task 1: Branch + fold pending working-tree edits
+
+The working tree already carries two reviewed edits (restored from stash): the `needs_attention` extra on the delivery-error `logger.exception` in `app/actions/handlers.py`, and `pytest.ini` `testpaths = app`. The spec doc is untracked. Commit all three on the new branch.
+
+**Files:**
+- Modify: (already modified) `app/actions/handlers.py`, `pytest.ini`
+- Create: (already on disk, untracked) `docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md`, this plan file
+
+**Interfaces:**
+- Produces: branch `feat/GUNDI-5602-head-pass-backfill` that every later task commits to.
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+git fetch origin && git checkout -b feat/GUNDI-5602-head-pass-backfill origin/main
+```
+
+(The dirty edits carry over — they don't conflict with `origin/main`.)
+
+- [ ] **Step 2: Run the full suite to establish a green baseline**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: all pass, < 2 s. If `testpaths = app` surfaces previously-uncollected failing tests, STOP and report — do not fix unrelated failures silently.
+
+- [ ] **Step 3: Commit in two commits**
+
+```bash
+git add pytest.ini && git commit -m "fix: collect all tests under app/, not just app/actions/test"
+git add app/actions/handlers.py docs/ && git commit -m "fix: restore needs_attention extra on delivery errors; add GUNDI-5602 spec + plan"
+```
+
+---
+
+### Task 2: `get_devices` error message uses `describe_exception`
+
+`action_pull_observations` line ~157 interpolates `{e}` directly; httpx timeout exceptions stringify empty, rendering `Exception: ` in the activity log.
+
+**Files:**
+- Modify: `app/actions/handlers.py:157`
+- Test: `app/actions/tests/test_handlers.py`
+
+**Interfaces:**
+- Consumes: existing `describe_exception(exc)` in handlers.py.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_get_devices_failure_logs_exception_type_when_message_is_empty(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # httpx timeouts stringify to "" — the activity log must name the type,
+    # not render a bare "Exception: ".
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    mocker.patch(
+        "app.actions.client.get_devices",
+        new=AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+    mock_log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    with pytest.raises(httpx.ReadTimeout):
+        await action_pull_observations(lotek_integration, pull_config)
+    title = mock_log.call_args.kwargs["title"]
+    assert "ReadTimeout" in title
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_handlers.py::test_get_devices_failure_logs_exception_type_when_message_is_empty -q`
+Expected: FAIL — title ends with `Exception: ` (empty).
+
+- [ ] **Step 3: Fix the message**
+
+In `action_pull_observations`, change:
+
+```python
+        message = f"Error fetching devices from Lotek. Integration ID: {integration.id} Exception: {e}"
+```
+
+to:
+
+```python
+        message = f"Error fetching devices from Lotek. Integration ID: {integration.id} Exception: {describe_exception(e)}"
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "fix: name the exception type in get_devices failure logs"
+```
+
+---
+
+### Task 3: `RETRY_ATTEMPTS` 3 → 2
+
+Retry×budget amplification is a root cause of the 9-minute timeouts. One retry (2 attempts) still recovers token expiry and single timeouts.
+
+**Files:**
+- Modify: `app/actions/handlers.py:31`
+- Test: `app/actions/tests/test_handlers.py`
+
+**Interfaces:**
+- Produces: `RETRY_ATTEMPTS == 2` — later tasks' retry tests assume 2 attempts.
+
+- [ ] **Step 1: Write the failing pin test**
+
+```python
+def test_retry_attempts_is_two():
+    # 3 attempts × 9 windows amplified Lotek's slowness into our own 9-min
+    # timeouts (GUNDI-5602). One retry still recovers token expiry.
+    assert RETRY_ATTEMPTS == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_handlers.py::test_retry_attempts_is_two -q`
+Expected: FAIL — currently 3.
+
+- [ ] **Step 3: Change the constant**
+
+```python
+RETRY_ATTEMPTS = 2
+```
+
+- [ ] **Step 4: Run the full suite; fix retry-count assertions**
+
+Run: `./venv/bin/python -m pytest app -q`
+`test_action_pull_observations_retries_transient_timeout` and `test_action_pull_observations_isolates_persistent_401_on_one_device` import `RETRY_ATTEMPTS`, so counts should self-adjust — verify they still assert something meaningful (a side_effect list sized `RETRY_ATTEMPTS` with success last must still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "fix: reduce position-fetch retries to 2 attempts (GUNDI-5602 load relief)"
+```
+
+---
+
+### Task 4: `DeviceState` model with legacy-cursor migration
+
+New module holding the per-device state schema. Replaces `client.IntegrationState` for handler use.
+
+**Files:**
+- Create: `app/actions/device_state.py`
+- Test: `app/actions/tests/test_device_state.py`
+
+**Interfaces:**
+- Produces: `DeviceState(high_water: datetime, gap_start: Optional[datetime], gap_end: Optional[datetime], last_backfilled: Optional[datetime])`, property `has_gap -> bool`. `DeviceState.parse_obj({"updated_at": ...})` migrates the legacy cursor to `high_water` with no gap. All later tasks import `from app.actions.device_state import DeviceState`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import pytest
+import pydantic
+from datetime import datetime, timezone
+
+from app.actions.device_state import DeviceState
+
+
+def test_legacy_updated_at_cursor_parses_as_high_water_with_no_gap():
+    # Pre-5602 state stored {"updated_at": ...}; deployed integrations must
+    # carry their cursor over without opening a gap.
+    state = DeviceState.parse_obj({"updated_at": "2026-08-10T00:00:00+00:00"})
+    assert state.high_water == datetime(2026, 8, 10, tzinfo=timezone.utc)
+    assert state.gap_start is None and state.gap_end is None
+    assert not state.has_gap
+
+
+def test_naive_datetimes_are_assumed_utc():
+    state = DeviceState.parse_obj({"high_water": "2026-08-10T00:00:00"})
+    assert state.high_water.tzinfo is not None
+    assert state.high_water == datetime(2026, 8, 10, tzinfo=timezone.utc)
+
+
+def test_has_gap_true_only_for_a_nonempty_range():
+    base = {"high_water": "2026-08-13T00:00:00+00:00"}
+    open_gap = DeviceState.parse_obj(
+        {**base, "gap_start": "2026-08-01T00:00:00+00:00", "gap_end": "2026-08-05T00:00:00+00:00"}
+    )
+    assert open_gap.has_gap
+    empty_gap = DeviceState.parse_obj(
+        {**base, "gap_start": "2026-08-05T00:00:00+00:00", "gap_end": "2026-08-05T00:00:00+00:00"}
+    )
+    assert not empty_gap.has_gap
+
+
+def test_missing_cursor_is_a_validation_error():
+    # No high_water and no legacy updated_at → caller must treat as first run.
+    with pytest.raises(pydantic.ValidationError):
+        DeviceState.parse_obj({"error": "whatever"})
+
+
+def test_round_trips_through_state_manager_json():
+    # state_manager serializes with json.dumps(default=str); the model must
+    # re-parse its own dict() output after that trip.
+    import json
+    state = DeviceState.parse_obj(
+        {
+            "high_water": "2026-08-13T00:00:00+00:00",
+            "gap_start": "2026-08-01T00:00:00+00:00",
+            "gap_end": "2026-08-06T00:00:00+00:00",
+            "last_backfilled": "2026-08-12T00:00:00+00:00",
+        }
+    )
+    reparsed = DeviceState.parse_obj(json.loads(json.dumps(state.dict(), default=str)))
+    assert reparsed == state
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_device_state.py -q`
+Expected: FAIL — `ModuleNotFoundError: app.actions.device_state`.
+
+- [ ] **Step 3: Implement the model**
+
+Create `app/actions/device_state.py`:
+
+```python
+import pydantic
+
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def _ensure_utc(v):
+    if v is None:
+        return v
+    if not v.tzinfo:
+        return v.replace(tzinfo=timezone.utc)
+    return v.astimezone(timezone.utc)
+
+
+class DeviceState(pydantic.BaseModel):
+    """Per-device sync state (GUNDI-5602 head-pass design).
+
+    high_water is the newest upload-time already synced. [gap_start, gap_end)
+    is the single unfetched historical range — created once on a device's
+    first run, it only ever shrinks and is never extended. last_backfilled
+    orders backfill fairness (least-recently-backfilled first).
+    """
+    high_water: datetime
+    gap_start: Optional[datetime] = None
+    gap_end: Optional[datetime] = None
+    last_backfilled: Optional[datetime] = None
+
+    @pydantic.root_validator(pre=True)
+    def _migrate_legacy_cursor(cls, values):
+        # Pre-5602 state stored the cursor as updated_at; parse it as
+        # high_water so deployed integrations carry over without a gap.
+        if values.get("high_water") is None and values.get("updated_at") is not None:
+            values = dict(values)
+            values["high_water"] = values["updated_at"]
+        return values
+
+    _tz = pydantic.validator(
+        "high_water", "gap_start", "gap_end", "last_backfilled", allow_reuse=True
+    )(_ensure_utc)
+
+    @property
+    def has_gap(self) -> bool:
+        return (
+            self.gap_start is not None
+            and self.gap_end is not None
+            and self.gap_start < self.gap_end
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_device_state.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Flip-verify the migration line**
+
+Temporarily change `values["high_water"] = values["updated_at"]` to `values["high_water"] = None` → `test_legacy_updated_at_cursor_parses_as_high_water_with_no_gap` must FAIL. Restore byte-identical, re-run, PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/actions/device_state.py app/actions/tests/test_device_state.py
+git commit -m "feat: DeviceState model with high_water/gap fields and legacy cursor migration"
+```
+
+---
+
+### Task 5: Config — `max_data_age_hours` slider + `BackfillObservationsConfig`
+
+**Files:**
+- Modify: `app/actions/configurations.py`
+- Test: `app/actions/tests/test_handlers.py` (config tests live alongside; a new `test_configurations.py` is fine too — use `app/actions/tests/test_configurations.py`)
+
+**Interfaces:**
+- Produces: `PullObservationsConfig.max_data_age_hours: int` (default 12, ge=1, le=12); `BackfillObservationsConfig(InternalActionConfiguration)` with no fields. Handlers import `BackfillObservationsConfig` from `app.actions.configurations`.
+
+- [ ] **Step 1: Write the failing tests** (`app/actions/tests/test_configurations.py`)
+
+```python
+import pydantic
+import pytest
+
+from app.actions.configurations import BackfillObservationsConfig, PullObservationsConfig
+from app.actions.core import InternalActionConfiguration
+
+
+def test_max_data_age_hours_defaults_to_12_and_is_bounded_1_to_12():
+    assert PullObservationsConfig().max_data_age_hours == 12
+    with pytest.raises(pydantic.ValidationError):
+        PullObservationsConfig(max_data_age_hours=0)
+    with pytest.raises(pydantic.ValidationError):
+        PullObservationsConfig(max_data_age_hours=13)
+
+
+def test_max_data_age_hours_renders_as_range_slider():
+    ui = PullObservationsConfig.ui_schema()
+    assert ui["max_data_age_hours"]["ui:widget"] == "range"
+
+
+def test_ui_order_lists_every_property_including_hidden_run_on_schedule():
+    # rjsf + ajv strict mode fails silently when ui:order misses a property.
+    ui = PullObservationsConfig.ui_schema()
+    assert set(ui["ui:order"]) == set(PullObservationsConfig.schema()["properties"].keys())
+
+
+def test_backfill_config_is_internal_and_fieldless():
+    # InternalActionConfiguration subclasses are skipped at registration —
+    # backfill must never appear in the portal.
+    assert issubclass(BackfillObservationsConfig, InternalActionConfiguration)
+    assert BackfillObservationsConfig.schema().get("properties", {}) == {}
+```
+
+Note: verify the exact `ui_schema()` output shape against `UISchemaModelMixin` in `app/services/utils.py` when the first test run fails — the assertion keys above assume rjsf conventions (`"ui:order"`, per-field `"ui:widget"`); adjust the *test's key access* (not its intent) if the mixin nests differently. The existing `run_on_schedule` hidden widget is a working reference.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_configurations.py -q`
+Expected: FAIL — `ImportError: BackfillObservationsConfig` / missing field.
+
+- [ ] **Step 3: Implement**
+
+In `app/actions/configurations.py`, extend the import from `.core`:
+
+```python
+from .core import (
+    AuthActionConfiguration,
+    ExecutableActionMixin,
+    InternalActionConfiguration,
+    PullActionConfiguration,
+)
+```
+
+Add to `PullObservationsConfig` after `default_lookback_days` (and narrow that field's description per the spec):
+
+```python
+    default_lookback_days: int = pydantic.Field(
+        7,
+        ge=1,
+        le=60,
+        title="Default lookback (days)",
+        description="How many days of historic data to import when a device is first seen.",
+    )
+    max_data_age_hours: int = FieldWithUIOptions(
+        12,
+        ge=1,
+        le=12,
+        title="Max data age (hours)",
+        description=(
+            "Freshness bound: every run fetches at most this many hours back. "
+            "Positions uploaded longer ago than this that could not be fetched "
+            "are skipped permanently."
+        ),
+        ui_options=UIOptions(widget="range"),
+    )
+```
+
+Update `ui_global_options`:
+
+```python
+    ui_global_options: GlobalUISchemaOptions = GlobalUISchemaOptions(
+        order=[
+            "default_lookback_days",
+            "max_data_age_hours",
+            "max_pdop",
+            "run_on_schedule",
+        ],
+    )
+```
+
+Add at the bottom:
+
+```python
+class BackfillObservationsConfig(InternalActionConfiguration):
+    """Internal-only: triggered by pull_observations, never configured in the portal."""
+    pass
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/configurations.py app/actions/tests/test_configurations.py
+git commit -m "feat: max_data_age_hours slider config + internal backfill config (GUNDI-5602)"
+```
+
+---
+
+### Task 6: Head-pass rewrite of `pull_observations`
+
+The big one. Replaces the oldest-first chunk walk in `_pull_device_observations` with a single head fetch per device, first-run gap creation, permanent stale-drop, and the WARNING demotion for per-device transient fetch failures. Delivery/checkpoint failures stay ERROR. Result gains `devices_deferred: []` (populated by Tasks 8–9).
+
+**Files:**
+- Modify: `app/actions/handlers.py` (replace `_pull_device_observations` with `_load_device_state` + `_head_pass_device`; rewrite the loop body of `action_pull_observations`)
+- Test: `app/actions/tests/test_handlers.py`
+
+**Interfaces:**
+- Consumes: `DeviceState` (Task 4), `max_data_age_hours` (Task 5).
+- Produces:
+  - `async def _load_device_state(integration_id: str, device_id: str, present_time: datetime, action_config) -> DeviceState`
+  - `async def _head_pass_device(device, integration, auth, action_config, present_time) -> tuple[int, bool, Optional[DeviceState]]` — `(observations_sent, device_failed, state)`; raises only `LotekUnauthorizedException` (integration-wide); records nothing about breakers yet (Task 8 adds the `guards` parameter, Task 9 uses it for the breaker).
+  - `action_pull_observations` returns `{'observations_extracted': int, 'devices_failed': list, 'devices_deferred': list}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test_handlers.py` (shared setup mirrors existing tests; `freshness floor` = `now − max_data_age_hours`):
+
+```python
+def _setup_pull_mocks(mocker, mock_redis, devices, positions=None, saved_state=None):
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=devices))
+    get_positions = mocker.patch(
+        "app.actions.client.get_positions", new=AsyncMock(return_value=positions or [])
+    )
+    get_state = mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(return_value=saved_state or {}),
+    )
+    set_state = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None)
+    )
+    mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    return get_positions, get_state, set_state, log
+
+
+@pytest.mark.asyncio
+async def test_head_pass_fetches_single_max_age_window_on_first_run(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # First run: ONE request per device covering [now - max_data_age_hours, now]
+    # — not a chunked walk over the whole lookback.
+    get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    await action_pull_observations(lotek_integration, pull_config)
+    assert get_positions.await_count == 1
+    start, end = get_positions.call_args.args[3], get_positions.call_args.args[4]
+    assert abs((end - start) - timedelta(hours=pull_config.max_data_age_hours)) < timedelta(minutes=1)
+
+
+@pytest.mark.asyncio
+async def test_first_run_opens_gap_from_lookback_to_freshness_floor(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _, _, set_state, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    await action_pull_observations(lotek_integration, pull_config)
+    saved = set_state.call_args.args[2]
+    gap_span = saved["gap_end"] - saved["gap_start"]
+    expected = timedelta(days=pull_config.default_lookback_days) - timedelta(
+        hours=pull_config.max_data_age_hours
+    )
+    assert abs(gap_span - expected) < timedelta(minutes=1)
+
+
+@pytest.mark.asyncio
+async def test_no_gap_opened_when_lookback_fits_inside_max_age(mocker):
+    # Portal bounds (lookback >= 1 day > max_age <= 12h) make this unreachable
+    # via valid config, but the guard in _load_device_state must hold anyway —
+    # pin it at the unit level with construct() to bypass validation.
+    from app.actions.handlers import _load_device_state
+    from app.actions.configurations import PullObservationsConfig
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(return_value={}),
+    )
+    config = PullObservationsConfig.construct(
+        default_lookback_days=1, max_data_age_hours=48, max_pdop=None
+    )
+    state = await _load_device_state(
+        "some-integration-id", "1", datetime.now(timezone.utc), config
+    )
+    assert not state.has_gap
+    assert state.gap_start is None and state.gap_end is None
+
+
+@pytest.mark.asyncio
+async def test_steady_state_advances_high_water_and_keeps_gap_closed(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A device whose cursor is fresh (within max_age) head-fetches from its
+    # cursor and neither opens a gap nor drops anything.
+    recent = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    start = get_positions.call_args.args[3]
+    assert abs((datetime.now(timezone.utc) - start) - timedelta(hours=2)) < timedelta(minutes=1)
+    saved = set_state.call_args.args[2]
+    assert saved.get("gap_start") is None
+    assert result["devices_deferred"] == []
+    warning_titles = [
+        c.kwargs["title"] for c in log.await_args_list if c.kwargs["level"] == LogLevel.WARNING
+    ]
+    assert not any("stale" in t.lower() for t in warning_titles)
+
+
+@pytest.mark.asyncio
+async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Bounded staleness (Victor's call): a cursor further back than max_age
+    # means that span is dropped permanently — WARNING with the range, gap unchanged.
+    stale = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    start = get_positions.call_args.args[3]
+    assert abs(
+        (datetime.now(timezone.utc) - start) - timedelta(hours=pull_config.max_data_age_hours)
+    ) < timedelta(minutes=1)
+    saved = set_state.call_args.args[2]
+    assert saved.get("gap_start") is None  # NOT added to the gap
+    drop_warnings = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "Dropping stale range" in c.kwargs["title"]
+    ]
+    assert len(drop_warnings) == 1
+    assert "device 1" in drop_warnings[0].kwargs["title"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_updated_at_state_migrates_to_high_water(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    recent = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+    get_positions, _, set_state, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"updated_at": recent}
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    start = get_positions.call_args.args[3]
+    assert abs((datetime.now(timezone.utc) - start) - timedelta(hours=3)) < timedelta(minutes=1)
+    saved = set_state.call_args.args[2]
+    assert "high_water" in saved and saved.get("gap_start") is None
+
+
+@pytest.mark.asyncio
+async def test_transient_fetch_failure_logs_warning_not_error(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Health/alerting keys on ERROR count; recurring per-device timeouts must
+    # not mark the connection unhealthy. devices_failed already tracks them.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2")
+    )
+    get_positions.side_effect = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS + [[]]
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["1"]
+    device_1_logs = [
+        c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")
+    ]
+    assert device_1_logs and all(c.kwargs["level"] == LogLevel.WARNING for c in device_1_logs)
+
+
+@pytest.mark.asyncio
+async def test_failed_head_fetch_does_not_advance_high_water(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    recent = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    get_positions, _, set_state, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
+    )
+    get_positions.side_effect = httpx.ReadTimeout("")
+    with pytest.raises(LotekException):
+        # single device, nothing serviced → zero-progress raise (Task 7 keeps this
+        # as the all-failed raise until then: adapt to whichever exists when writing)
+        await action_pull_observations(lotek_integration, pull_config)
+    set_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_stays_error_and_does_not_advance_high_water(
+    mocker, lotek_integration, lotek_position, pull_config, mock_redis
+):
+    get_positions, _, set_state, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2"), positions=[lotek_position]
+    )
+    send = mocker.patch(
+        "app.actions.handlers.gundi_tools.send_observations_to_gundi",
+        new=AsyncMock(side_effect=[Exception("boom"), None]),
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["1"]
+    error_logs = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.ERROR and "delivering" in c.kwargs["title"].lower()
+    ]
+    assert len(error_logs) == 1
+    # only device 2's checkpoint was written
+    saved_devices = [c.args[3] for c in set_state.await_args_list]
+    assert saved_devices == ["2"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_handlers.py -q -k "head_pass or first_run or steady_state or stale_span or legacy_updated or transient_fetch or delivery_failure_stays"`
+Expected: FAIL (chunked walk, missing keys, ERROR levels).
+
+- [ ] **Step 3: Implement the rewrite**
+
+In `app/actions/handlers.py`:
+
+Imports and constants (top of file):
+
+```python
+from app.actions.device_state import DeviceState
+from app.services.action_scheduler import trigger_action
+```
+
+```python
+RETRY_ATTEMPTS = 2
+...
+MAX_DEVICES_IN_SUMMARY = 20
+# Safety-rail constants (GUNDI-5602): load-protection mechanics, deliberately
+# code constants rather than operator knobs.
+DEADLINE_FRACTION = 0.8
+BREAKER_THRESHOLD = 3
+BACKFILL_MAX_WINDOWS_PER_DEVICE = 2
+BACKFILL_WINDOW = timedelta(days=7)
+BACKFILL_LEASE_SOURCE = "lease"
+```
+
+New state loader (replaces the `client.IntegrationState` block):
+
+```python
+async def _load_device_state(integration_id, device_id, present_time, action_config):
+    saved = await state_manager.get_state(integration_id, "pull_observations", device_id)
+    if saved:
+        try:
+            return DeviceState.parse_obj(saved)
+        except pydantic.ValidationError as e:
+            logger.debug(f"Failed to parse saved state for device {device_id}, starting fresh. Error: {e}")
+    # First run: the head pass starts at the freshness floor; everything older,
+    # back to the configured lookback, becomes the device's one and only gap —
+    # the deliberate historical import. It only ever shrinks from here.
+    head_start = present_time - timedelta(hours=action_config.max_data_age_hours)
+    gap_start = present_time - timedelta(days=action_config.default_lookback_days)
+    if gap_start < head_start:
+        return DeviceState(high_water=head_start, gap_start=gap_start, gap_end=head_start)
+    return DeviceState(high_water=head_start)
+```
+
+Head-pass worker (replaces `_pull_device_observations`; keep the no-positions info WARNING, the `needs_attention` delivery-error block, and the checkpoint-error block from the old function — they move over nearly verbatim):
+
+```python
+async def _head_pass_device(device, integration, auth, action_config, present_time):
+    """Fetch, deliver and checkpoint one device's freshest window.
+
+    Returns (observations_sent, device_failed, state). Raises only for
+    integration-wide problems; per-device problems are reported through the
+    returned flag so the caller can keep going. Fetch-phase failures are
+    WARNINGs (transient while Lotek is slow; devices_failed tracks them);
+    delivery/checkpoint failures stay ERRORs.
+    """
+    integration_id = str(integration.id)
+    freshness_floor = present_time - timedelta(hours=action_config.max_data_age_hours)
+    state = await _load_device_state(integration_id, device.nDeviceID, present_time, action_config)
+
+    if state.high_water < freshness_floor:
+        # Bounded staleness (GUNDI-5602, deliberate): anything the cursor still
+        # owed beyond max_data_age_hours is dropped permanently — never added
+        # to the gap — so catch-up cost cannot compound.
+        message = (
+            f"Dropping stale range [{state.high_water.isoformat()}, {freshness_floor.isoformat()}] "
+            f"for device {device.nDeviceID}: older than max_data_age_hours="
+            f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
+        )
+        logger.warning(message)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING,
+        )
+
+    lower_date = max(state.high_water, freshness_floor)
+    try:
+        async for attempt in stamina.retry_context(
+            on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS,
+            wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX,
+        ):
+            with attempt:
+                positions = await client.get_positions(
+                    device.nDeviceID, auth, integration, lower_date, present_time, True
+                )
+        logger.info(
+            f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} "
+            f"between {lower_date} and {present_time}."
+        )
+        cdip_positions = filter_and_transform_positions(positions, integration, action_config)
+    except LotekUnauthorizedException:
+        # Credentials are an integration-wide problem: every remaining device
+        # would fail the same way, so fail fast instead of N identical errors.
+        raise
+    except Exception as e:
+        # WARNING, not ERROR: these recur daily while Lotek is slow, health
+        # keys on ERROR count alone, and devices_failed already tracks them.
+        message = (
+            f"Error fetching positions from Lotek. Device: {device.nDeviceID}. "
+            f"Dates: [{lower_date},{present_time}]. Integration ID: {integration_id} "
+            f"Exception: {describe_exception(e)}"
+        )
+        logger.warning(message, exc_info=True)
+        await log_action_activity(
+            integration_id=integration_id,
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING,
+        )
+        return 0, True, state
+
+    # ... no-positions info WARNING block: unchanged from the old function ...
+
+    observations_sent = 0
+    # ... send loop with the ERROR + needs_attention handler: unchanged, but on
+    #     failure `return observations_sent, True, state` (high_water untouched;
+    #     the head window is re-fetched next run — re-sends are tolerated,
+    #     silent skips are not) ...
+
+    # Advance the cursor to the queried upper bound (upload time). Must advance
+    # even when the device returned no positions.
+    state.high_water = present_time
+    # ... checkpoint save with the ERROR handler: unchanged, but save
+    #     `state.dict()` instead of {"updated_at": ...};
+    #     on failure `return observations_sent, True, state` ...
+    return observations_sent, False, state
+```
+
+Rewritten action loop (structure of `action_pull_observations` after `get_devices`):
+
+```python
+    present_time = datetime.now(tz=timezone.utc)
+    observations_extracted = 0
+    failed_devices = []
+    deferred_devices = []
+    serviced_devices = 0
+    any_open_gap = False
+    for device in device_list:
+        try:
+            sent, device_failed, state = await _head_pass_device(
+                device, integration, auth, action_config, present_time
+            )
+        except LotekUnauthorizedException:
+            raise
+        except Exception as e:
+            message = (
+                f"Failed to process device {device.nDeviceID} for integration "
+                f"{integration.id}: {describe_exception(e)}"
+            )
+            logger.exception(message)
+            await log_action_activity(
+                integration_id=str(integration.id),
+                action_id="pull_observations",
+                title=message,
+                level=LogLevel.ERROR,
+            )
+            failed_devices.append(device.nDeviceID)
+            continue
+        observations_extracted += sent
+        if state is not None and state.has_gap:
+            any_open_gap = True
+        if device_failed:
+            failed_devices.append(device.nDeviceID)
+        else:
+            serviced_devices += 1
+```
+
+Keep the failed-device summary WARNING block unchanged. Keep the all-failed raise for now (Task 7 generalizes it). Then before the return:
+
+```python
+    if any_open_gap:
+        try:
+            lease = await state_manager.get_state(
+                str(integration.id), "backfill_observations", BACKFILL_LEASE_SOURCE
+            )
+            if not lease:
+                await trigger_action(str(integration.id), "backfill_observations")
+        except Exception as e:
+            # The head pass succeeded; a failed trigger must not fail the run.
+            logger.warning(
+                f"Could not trigger backfill for integration {integration.id}: {describe_exception(e)}"
+            )
+
+    return {
+        'observations_extracted': observations_extracted,
+        'devices_failed': failed_devices,
+        'devices_deferred': deferred_devices,
+    }
+```
+
+- [ ] **Step 4: Update existing tests that pinned the old chunk-walk semantics**
+
+These existing tests change meaning — update, don't delete their intent:
+- `test_lookback_days_config_sets_first_run_window` → first run makes exactly **1** head call spanning `max_data_age_hours`, and opens the gap (covered by new tests; rewrite this one to assert the gap span honors `default_lookback_days=30`).
+- `test_action_pull_observations_keeps_successful_chunks_when_later_chunk_fails` → chunk-walk is gone from the head pass; DELETE (the equivalent per-window checkpoint behavior is pinned in backfill, Task 10).
+- `test_action_pull_observations_does_not_advance_state_for_failed_device` → keep intent; state shape is now `DeviceState` and failure level is WARNING.
+- Every `result == {...}` assertion gains `'devices_deferred': []`.
+- Error-level assertions on per-device fetch failures flip ERROR → WARNING (`test_action_pull_observations_continues_after_one_device_fails`, `..._continues_after_lotek_error_status`, `..._continues_after_malformed_device_data`, `..._isolates_persistent_401_on_one_device`, `..._logs_exception_type_when_message_is_empty`, `..._retries_transient_timeout`).
+- `test_action_pull_observations_aborts_when_login_is_rejected`, `..._aborts_on_auth_failure`, `..._does_not_retry_rejected_login_at_get_devices`, auth tests: unchanged.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS, < 2 s.
+
+- [ ] **Step 6: Flip-verify two critical lines**
+
+1. Change `state.high_water = present_time` to `state.high_water = state.high_water` → steady-state test must fail. Restore.
+2. In the stale-drop branch, add `state.gap_start = state.high_water; state.gap_end = freshness_floor` (growing the gap) → `test_stale_span_is_dropped_with_warning_and_not_added_to_gap` must fail. Restore byte-identical.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: newest-first head pass with bounded staleness (GUNDI-5602)"
+```
+
+---
+
+### Task 7: Zero-progress guard
+
+Generalize the all-failed raise: a run where **no device was serviced and nothing was delivered** is systemic degradation and must ERROR, including when everything was deferred by the rails (Tasks 8–9).
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py`
+
+**Interfaces:**
+- Produces: the raise fires on `device_list and serviced_devices == 0 and observations_extracted == 0`. Backfill (Task 10) reuses the same predicate shape inline.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_zero_progress_run_raises_even_when_devices_were_only_deferred(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A run that services nothing is systemic degradation — it must alert
+    # (ERROR/raise), not warn forever. Deferring every device counts.
+    _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)
+```
+
+(This test needs Task 8's `_deadline_exceeded` to exist; write it as `@pytest.mark.skip(reason="needs deadline rail")` now and un-skip in Task 8, OR reorder Steps so the message change is tested via the all-failed path:)
+
+```python
+@pytest.mark.asyncio
+async def test_all_failed_run_raises_zero_progress(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+    get_positions.side_effect = httpx.ReadTimeout("")
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations(lotek_integration, pull_config)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_handlers.py::test_all_failed_run_raises_zero_progress -q`
+Expected: FAIL — old message is "All N device(s) failed…".
+
+- [ ] **Step 3: Replace the all-failed raise**
+
+```python
+    if device_list and serviced_devices == 0 and observations_extracted == 0:
+        # Zero progress: nothing serviced and nothing delivered — whether every
+        # device failed or the rails deferred them all, this is systemic
+        # degradation and must alert rather than publish action_complete. A
+        # device that delivered part of its window before failing still counts
+        # as progress, so partial runs stay warnings.
+        raise LotekException(
+            message=(
+                f"No devices could be serviced for integration {integration.id}: "
+                f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+                f"{len(device_list)}. See the per-device errors in this action's activity log."
+            )
+        )
+```
+
+- [ ] **Step 4: Update `test_action_pull_observations_fails_when_every_device_fails` to the new message; run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: zero-progress guard — raise when a run services no devices"
+```
+
+---
+
+### Task 8: Deadline rail
+
+Stop starting new device work past `DEADLINE_FRACTION` (80%) of `MAX_ACTION_EXECUTION_TIME`; defer the tail with a WARNING and `devices_deferred`. Also gate retry attempts on the deadline.
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py`
+
+**Interfaces:**
+- Produces:
+  - `def _deadline_exceeded(run_started_at: datetime) -> bool`
+  - `def _retry_attempts(run_started_at: datetime) -> int` — 1 past deadline, else `RETRY_ATTEMPTS`
+  - `class RunGuards` with `run_started_at`, `should_stop() -> Optional[str]` (returns `"deadline"` / `"circuit breaker"` / None) and `record(transport_failure: bool)`. Task 9 adds the breaker arm; Task 10 reuses the whole class.
+  - `async def _log_deferral(integration, action_id, reason, deferred_ids)` — WARNING activity log naming the reason and count.
+  - `_head_pass_device` gains a `guards` parameter (used for `_retry_attempts` and failure recording).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_deadline_defers_remaining_devices_with_warning(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Past ~80% of the action budget we stop STARTING device work and exit in
+    # control — never via the asyncio.wait_for guillotine. Call order per
+    # device: should_stop() then _retry_attempts(), hence the side_effect
+    # sequence [False(stop d1), False(retry d1), True(stop d2)].
+    _, _, _, log = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2", "3"))
+    mocker.patch(
+        "app.actions.handlers._deadline_exceeded", side_effect=[False, False, True]
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_deferred"] == ["2", "3"]
+    assert result["devices_failed"] == []
+    deferral_logs = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "deadline" in c.kwargs["title"].lower()
+    ]
+    assert len(deferral_logs) == 1
+
+
+def test_retry_attempts_drop_to_one_past_deadline(mocker):
+    from app.actions.handlers import _retry_attempts, RETRY_ATTEMPTS
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=False)
+    assert _retry_attempts(datetime.now(timezone.utc)) == RETRY_ATTEMPTS
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+    assert _retry_attempts(datetime.now(timezone.utc)) == 1
+
+
+def test_deadline_fraction_of_budget():
+    # 540s budget → soft deadline ~432s. Pin the fraction.
+    from app.actions.handlers import DEADLINE_FRACTION
+    assert DEADLINE_FRACTION == 0.8
+```
+
+Also un-skip / add `test_zero_progress_run_raises_even_when_devices_were_only_deferred` from Task 7.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_handlers.py -q -k "deadline or zero_progress"`
+Expected: FAIL — names don't exist.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _deadline_exceeded(run_started_at):
+    elapsed = (datetime.now(tz=timezone.utc) - run_started_at).total_seconds()
+    return elapsed > DEADLINE_FRACTION * settings.MAX_ACTION_EXECUTION_TIME
+
+
+def _retry_attempts(run_started_at):
+    # Past the soft deadline, don't spend the remaining budget on retries.
+    return 1 if _deadline_exceeded(run_started_at) else RETRY_ATTEMPTS
+
+
+class RunGuards:
+    """Per-run deadline + circuit-breaker state for a device loop."""
+
+    def __init__(self, run_started_at):
+        self.run_started_at = run_started_at
+        self.consecutive_transport_failures = 0
+
+    def should_stop(self):
+        if _deadline_exceeded(self.run_started_at):
+            return "deadline"
+        return None
+
+    def record(self, transport_failure: bool):
+        if transport_failure:
+            self.consecutive_transport_failures += 1
+        else:
+            self.consecutive_transport_failures = 0
+
+
+async def _log_deferral(integration, action_id, reason, deferred_ids):
+    listed = ', '.join(deferred_ids[:MAX_DEVICES_IN_SUMMARY])
+    if len(deferred_ids) > MAX_DEVICES_IN_SUMMARY:
+        listed += f" and {len(deferred_ids) - MAX_DEVICES_IN_SUMMARY} more"
+    message = (
+        f"Stopping early ({reason}) for integration {integration.id}: deferring "
+        f"{len(deferred_ids)} device(s) to the next run: {listed}."
+    )
+    logger.warning(message)
+    await log_action_activity(
+        integration_id=str(integration.id),
+        action_id=action_id,
+        title=message,
+        level=LogLevel.WARNING,
+    )
+```
+
+Wire into `action_pull_observations`: capture `run_started = datetime.now(tz=timezone.utc)` **before** `get_devices` (the devices call spends budget too); `guards = RunGuards(run_started)`; loop becomes:
+
+```python
+    for i, device in enumerate(device_list):
+        if reason := guards.should_stop():
+            deferred_devices = [d.nDeviceID for d in device_list[i:]]
+            await _log_deferral(integration, "pull_observations", reason, deferred_devices)
+            break
+        try:
+            sent, device_failed, state = await _head_pass_device(
+                device, integration, auth, action_config, present_time, guards
+            )
+        ...
+```
+
+In `_head_pass_device`, accept `guards` and use `attempts=_retry_attempts(guards.run_started_at)` in the position-fetch `retry_context`. In the outer per-device `except Exception` of the action loop, call `guards.record(transport_failure=False)`.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS.
+
+- [ ] **Step 5: Flip-verify**
+
+Change `should_stop`'s deadline branch to `return None` → deadline test fails. Restore byte-identical.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: soft deadline defers device work before the action-budget guillotine"
+```
+
+---
+
+### Task 9: Circuit breaker
+
+K=3 **consecutive** transport-class failures (timeouts/transport) → assume Lotek-wide degradation, stop, defer the remainder.
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py`
+
+**Interfaces:**
+- Consumes: `RunGuards` (Task 8).
+- Produces: `RunGuards.should_stop()` also returns `"circuit breaker"`; `_head_pass_device` calls `guards.record(transport_failure=True)` on `httpx.TransportError` fetch failures, `record(False)` on other fetch failures and on success.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_breaker_trips_after_three_consecutive_transport_failures(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # 3 consecutive timeouts = Lotek-wide degradation: stop early, defer the
+    # rest (WARNING), instead of grinding every device into the same wall.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    get_positions, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+    )
+    # device 1 succeeds; 2,3,4 exhaust retries on timeouts; 5 must be deferred
+    get_positions.side_effect = [[]] + [httpx.ReadTimeout("")] * (3 * RETRY_ATTEMPTS)
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == ["2", "3", "4"]
+    assert result["devices_deferred"] == ["5"]
+    breaker_logs = [
+        c for c in log.await_args_list
+        if c.kwargs["level"] == LogLevel.WARNING and "circuit breaker" in c.kwargs["title"].lower()
+    ]
+    assert len(breaker_logs) == 1
+
+
+@pytest.mark.asyncio
+async def test_breaker_counter_resets_on_success(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Failures interleaved with successes are per-device noise, not an outage.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    get_positions, _, _, _ = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+    )
+    fail = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS
+    get_positions.side_effect = fail + [[]] + fail + [[]] + fail  # F S F S F
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_deferred"] == []
+    assert result["devices_failed"] == ["1", "3", "5"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_handlers.py -q -k breaker`
+Expected: FAIL — device 5 not deferred.
+
+- [ ] **Step 3: Implement**
+
+In `RunGuards.should_stop`, after the deadline branch:
+
+```python
+        if self.consecutive_transport_failures >= BREAKER_THRESHOLD:
+            return "circuit breaker"
+```
+
+In `_head_pass_device`, split the fetch `except Exception` into:
+
+```python
+    except httpx.TransportError as e:
+        message = (...same message as the generic fetch failure...)
+        logger.warning(message, exc_info=True)
+        await log_action_activity(..., level=LogLevel.WARNING)
+        guards.record(transport_failure=True)
+        return 0, True, state
+    except Exception as e:
+        ...existing WARNING block...
+        guards.record(transport_failure=False)
+        return 0, True, state
+```
+
+and call `guards.record(transport_failure=False)` on the success path (after the checkpoint save succeeds). Delivery/checkpoint failures also `record(False)` — the breaker watches Lotek, not Gundi.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS.
+
+- [ ] **Step 5: Flip-verify**
+
+Change `BREAKER_THRESHOLD` to 30 → trip test fails. Restore to 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: per-run circuit breaker on consecutive Lotek transport failures"
+```
+
+---
+
+### Task 10: `backfill_observations` internal action
+
+Lease-guarded, least-recently-backfilled-first, max 2 windows per device per run, gap advanced only on delivered windows, same rails.
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py` (new section) — or `app/actions/tests/test_backfill.py` for readability; prefer the separate file.
+
+**Interfaces:**
+- Consumes: `DeviceState`, `BackfillObservationsConfig`, `RunGuards`, `_log_deferral`, `_retry_attempts`, `BACKFILL_WINDOW`, `BACKFILL_MAX_WINDOWS_PER_DEVICE`, `BACKFILL_LEASE_SOURCE`, `state_manager.set_if_absent` / `delete_state`.
+- Produces: `async def action_backfill_observations(integration, action_config: BackfillObservationsConfig)` returning `{'observations_extracted': int, 'devices_failed': list, 'devices_deferred': list, 'gaps_closed': int}` or `{'skipped': 'lease_held'}`; helper `async def _backfill_device(device, state, integration, auth, pull_config, guards) -> tuple[int, bool, bool]` (`sent, device_failed, gap_closed`).
+
+- [ ] **Step 1: Write the failing tests** (`app/actions/tests/test_backfill.py`)
+
+```python
+import pytest
+import httpx
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+from gundi_core.schemas.v2 import LogLevel
+from app.actions.handlers import (
+    BACKFILL_MAX_WINDOWS_PER_DEVICE,
+    RETRY_ATTEMPTS,
+    action_backfill_observations,
+)
+from app.actions.client import LotekDevice, LotekException
+from app.actions.configurations import BackfillObservationsConfig
+
+
+def _devices(*device_ids):
+    return [
+        LotekDevice(
+            nDeviceID=d, strSpecialID="s", dtCreated=datetime.now(), strSatellite="sat"
+        )
+        for d in device_ids
+    ]
+
+
+def _gap_state(days_back_start=7, days_back_end=1, last_backfilled=None):
+    now = datetime.now(timezone.utc)
+    state = {
+        "high_water": now.isoformat(),
+        "gap_start": (now - timedelta(days=days_back_start)).isoformat(),
+        "gap_end": (now - timedelta(days=days_back_end)).isoformat(),
+    }
+    if last_backfilled:
+        state["last_backfilled"] = last_backfilled.isoformat()
+    return state
+
+
+def _setup_backfill_mocks(mocker, mock_redis, devices, states_by_device):
+    # lotek_integration fixture only carries an auth config; backfill also
+    # reads the pull config for max_pdop — patch the config getters instead.
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=devices))
+    from app.actions.configurations import PullObservationsConfig
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=PullObservationsConfig())
+    get_positions = mocker.patch(
+        "app.actions.client.get_positions", new=AsyncMock(return_value=[])
+    )
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(side_effect=lambda i, a, d: states_by_device.get(d, {})),
+    )
+    set_state = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_state", new=AsyncMock()
+    )
+    lease = mocker.patch(
+        "app.services.state.IntegrationStateManager.set_if_absent",
+        new=AsyncMock(return_value=True),
+    )
+    release = mocker.patch(
+        "app.services.state.IntegrationStateManager.delete_state", new=AsyncMock()
+    )
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    return get_positions, set_state, lease, release, log
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_whole_run_when_lease_is_held(
+    mocker, lotek_integration, mock_redis
+):
+    get_positions, _, lease, release, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state()}
+    )
+    lease.return_value = False
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result == {"skipped": "lease_held"}
+    get_positions.assert_not_awaited()
+    release.assert_not_awaited()  # a lease we didn't take is not ours to release
+
+
+@pytest.mark.asyncio
+async def test_backfill_releases_lease_even_when_the_run_raises(
+    mocker, lotek_integration, mock_redis
+):
+    _, _, _, release, _ = _setup_backfill_mocks(mocker, mock_redis, [], {})
+    mocker.patch(
+        "app.actions.client.get_devices", new=AsyncMock(side_effect=httpx.ReadTimeout(""))
+    )
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_MAX", 0)
+    with pytest.raises(httpx.ReadTimeout):
+        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    release.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_backfill_caps_windows_per_device_and_advances_gap_start(
+    mocker, lotek_integration, mock_redis
+):
+    # A 20-day gap needs 3 seven-day windows; only 2 (the cap) may run,
+    # oldest-first, and gap_start must advance to the end of the last
+    # delivered window.
+    get_positions, set_state, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=21)}
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    assert get_positions.await_count == BACKFILL_MAX_WINDOWS_PER_DEVICE
+    first_start = get_positions.await_args_list[0].args[3]
+    second_start = get_positions.await_args_list[1].args[3]
+    assert second_start - first_start == timedelta(days=7)
+    final_state = set_state.await_args_list[-1].args[2]
+    assert final_state["gap_start"] - first_start == timedelta(days=14)
+    assert final_state["gap_end"] is not None  # 20d gap: still open after 2 windows
+
+
+@pytest.mark.asyncio
+async def test_backfill_closes_gap_to_null_when_fully_covered(
+    mocker, lotek_integration, mock_redis
+):
+    get_positions, set_state, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=5)}
+    )
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert get_positions.await_count == 1  # 4-day gap fits one 7-day window
+    final_state = set_state.await_args_list[-1].args[2]
+    assert final_state["gap_start"] is None and final_state["gap_end"] is None
+    assert final_state["last_backfilled"] is not None
+    assert result["gaps_closed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_orders_devices_least_recently_backfilled_first(
+    mocker, lotek_integration, mock_redis
+):
+    now = datetime.now(timezone.utc)
+    states = {
+        "recent": _gap_state(last_backfilled=now - timedelta(minutes=5)),
+        "never": _gap_state(),  # no last_backfilled → leads
+        "old": _gap_state(last_backfilled=now - timedelta(days=2)),
+    }
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("recent", "never", "old"), states
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    order = [c.args[0] for c in get_positions.await_args_list]
+    assert order == ["never", "old", "recent"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_does_not_advance_gap_when_send_fails(
+    mocker, lotek_integration, lotek_position, mock_redis
+):
+    get_positions, set_state, _, _, log = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1", "2"), {"1": _gap_state(), "2": _gap_state()}
+    )
+    get_positions.return_value = [lotek_position]
+    mocker.patch(
+        "app.actions.handlers.gundi_tools.send_observations_to_gundi",
+        new=AsyncMock(side_effect=[Exception("boom"), None]),
+    )
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["devices_failed"] == ["1"]
+    # device 1's gap untouched; only device 2 checkpointed a gap advance
+    gap_saves = [c for c in set_state.await_args_list if c.args[3] == "1" and c.args[2].get("gap_start") is None]
+    assert not gap_saves or all(c.args[2].get("gap_end") is not None for c in gap_saves)
+    error_logs = [c for c in log.await_args_list if c.kwargs["level"] == LogLevel.ERROR]
+    assert error_logs  # delivery failures stay ERROR in backfill too
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_devices_without_gaps(
+    mocker, lotek_integration, mock_redis
+):
+    now = datetime.now(timezone.utc)
+    states = {"1": {"high_water": now.isoformat()}, "2": _gap_state()}
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1", "2"), states
+    )
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    assert [c.args[0] for c in get_positions.await_args_list] == ["2"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_backfill.py -q`
+Expected: FAIL — `ImportError: action_backfill_observations`.
+
+- [ ] **Step 3: Implement**
+
+In `app/actions/handlers.py` (import `BackfillObservationsConfig` alongside the other configs):
+
+```python
+async def _backfill_device(device, state, integration, auth, pull_config, guards):
+    """Close up to BACKFILL_MAX_WINDOWS_PER_DEVICE oldest windows of one
+    device's gap. Returns (observations_sent, device_failed, gap_closed).
+    gap_start advances only past windows that were actually delivered, so a
+    failure re-fetches the same window next trigger (re-sends are tolerated,
+    silent skips are not)."""
+    integration_id = str(integration.id)
+    observations_sent = 0
+    device_failed = False
+    for _ in range(BACKFILL_MAX_WINDOWS_PER_DEVICE):
+        if not state.has_gap:
+            break
+        upper_date = min(state.gap_end, state.gap_start + BACKFILL_WINDOW)
+        try:
+            async for attempt in stamina.retry_context(
+                on=RETRYABLE_ERRORS, attempts=_retry_attempts(guards.run_started_at),
+                wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX,
+            ):
+                with attempt:
+                    positions = await client.get_positions(
+                        device.nDeviceID, auth, integration, state.gap_start, upper_date, True
+                    )
+            cdip_positions = filter_and_transform_positions(positions, integration, pull_config)
+        except LotekUnauthorizedException:
+            raise
+        except httpx.TransportError as e:
+            message = (
+                f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
+                f"Dates: [{state.gap_start},{upper_date}]. Integration ID: {integration_id} "
+                f"Exception: {describe_exception(e)}"
+            )
+            logger.warning(message, exc_info=True)
+            await log_action_activity(
+                integration_id=integration_id, action_id="backfill_observations",
+                title=message, level=LogLevel.WARNING,
+            )
+            guards.record(transport_failure=True)
+            device_failed = True
+            break
+        except Exception as e:
+            message = (
+                f"Error fetching backfill positions from Lotek. Device: {device.nDeviceID}. "
+                f"Dates: [{state.gap_start},{upper_date}]. Integration ID: {integration_id} "
+                f"Exception: {describe_exception(e)}"
+            )
+            logger.warning(message, exc_info=True)
+            await log_action_activity(
+                integration_id=integration_id, action_id="backfill_observations",
+                title=message, level=LogLevel.WARNING,
+            )
+            guards.record(transport_failure=False)
+            device_failed = True
+            break
+
+        try:
+            for batch in generate_batches(cdip_positions):
+                await gundi_tools.send_observations_to_gundi(
+                    observations=batch, integration_id=integration.id
+                )
+                observations_sent += len(batch)
+        except Exception as e:
+            message = (
+                f"Error delivering backfill observations for device {device.nDeviceID}. "
+                f"Integration ID: {integration_id} Exception: {describe_exception(e)}"
+            )
+            logger.exception(message, extra={
+                'needs_attention': True,
+                'integration_id': integration_id,
+                'action_id': "backfill_observations",
+            })
+            await log_action_activity(
+                integration_id=integration_id, action_id="backfill_observations",
+                title=message, level=LogLevel.ERROR,
+            )
+            guards.record(transport_failure=False)
+            device_failed = True
+            break
+
+        # Advance the gap only past the delivered window; close it when done.
+        state.gap_start = upper_date
+        if not state.has_gap:
+            state.gap_start = None
+            state.gap_end = None
+        await state_manager.set_state(
+            integration_id, "pull_observations", state.dict(), device.nDeviceID
+        )
+
+    if not device_failed:
+        guards.record(transport_failure=False)
+    state.last_backfilled = datetime.now(tz=timezone.utc)
+    await state_manager.set_state(
+        integration_id, "pull_observations", state.dict(), device.nDeviceID
+    )
+    return observations_sent, device_failed, not state.has_gap
+
+
+@action_title("Backfill Observations")
+@activity_logger()
+async def action_backfill_observations(integration, action_config: BackfillObservationsConfig):
+    """Internal action: closes per-device historical gaps opened by the head
+    pass, oldest-first, least-recently-backfilled device first. Triggered by
+    pull_observations; the Redis lease keeps overlapping triggers from
+    double-running when a backfill grinds past the next head-pass trigger."""
+    logger.info(f"Executing backfill_observations action with integration {integration}...")
+    integration_id = str(integration.id)
+    auth = get_auth_config(integration)
+    pull_config = get_pull_config(integration)  # max_pdop applies to backfilled data too
+    run_started = datetime.now(tz=timezone.utc)
+
+    got_lease = await state_manager.set_if_absent(
+        integration_id, "backfill_observations",
+        ttl_seconds=settings.MAX_ACTION_EXECUTION_TIME,
+        source_id=BACKFILL_LEASE_SOURCE,
+    )
+    if not got_lease:
+        logger.info(f"Backfill lease already held for integration {integration_id}; skipping run.")
+        return {"skipped": "lease_held"}
+
+    try:
+        try:
+            async for attempt in stamina.retry_context(
+                on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS,
+                wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX,
+            ):
+                with attempt:
+                    device_list = await client.get_devices(integration, auth)
+        except Exception as e:
+            message = (
+                f"Error fetching devices from Lotek for backfill. Integration ID: "
+                f"{integration_id} Exception: {describe_exception(e)}"
+            )
+            logger.exception(message)
+            await log_action_activity(
+                integration_id=integration_id, action_id="backfill_observations",
+                title=message, level=LogLevel.ERROR,
+            )
+            raise e
+
+        gapped = []
+        for device in device_list:
+            saved = await state_manager.get_state(
+                integration_id, "pull_observations", device.nDeviceID
+            )
+            if not saved:
+                continue
+            try:
+                state = DeviceState.parse_obj(saved)
+            except pydantic.ValidationError:
+                continue  # head pass will initialize it; nothing to backfill yet
+            if state.has_gap:
+                gapped.append((device, state))
+        # Least-recently-backfilled first keeps the import fair; devices never
+        # backfilled lead the queue.
+        epoch = datetime.min.replace(tzinfo=timezone.utc)
+        gapped.sort(key=lambda pair: pair[1].last_backfilled or epoch)
+
+        guards = RunGuards(run_started)
+        observations_extracted = 0
+        failed_devices = []
+        deferred_devices = []
+        serviced_devices = 0
+        gaps_closed = 0
+        for i, (device, state) in enumerate(gapped):
+            if reason := guards.should_stop():
+                deferred_devices = [d.nDeviceID for d, _ in gapped[i:]]
+                await _log_deferral(integration, "backfill_observations", reason, deferred_devices)
+                break
+            try:
+                sent, device_failed, gap_closed = await _backfill_device(
+                    device, state, integration, auth, pull_config, guards
+                )
+            except LotekUnauthorizedException:
+                raise
+            except Exception as e:
+                message = (
+                    f"Failed to backfill device {device.nDeviceID} for integration "
+                    f"{integration_id}: {describe_exception(e)}"
+                )
+                logger.exception(message)
+                await log_action_activity(
+                    integration_id=integration_id, action_id="backfill_observations",
+                    title=message, level=LogLevel.ERROR,
+                )
+                failed_devices.append(device.nDeviceID)
+                guards.record(transport_failure=False)
+                continue
+            observations_extracted += sent
+            gaps_closed += int(gap_closed)
+            if device_failed:
+                failed_devices.append(device.nDeviceID)
+            else:
+                serviced_devices += 1
+
+        if gapped and serviced_devices == 0 and observations_extracted == 0:
+            raise LotekException(
+                message=(
+                    f"No devices could be backfilled for integration {integration_id}: "
+                    f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+                    f"{len(gapped)}. See the per-device errors in this action's activity log."
+                )
+            )
+
+        return {
+            'observations_extracted': observations_extracted,
+            'devices_failed': failed_devices,
+            'devices_deferred': deferred_devices,
+            'gaps_closed': gaps_closed,
+        }
+    finally:
+        await state_manager.delete_state(
+            integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE
+        )
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS, < 2 s.
+
+- [ ] **Step 5: Flip-verify two critical lines**
+
+1. Change `state.gap_start = upper_date` to `state.gap_start = state.gap_start` → window-cap test fails on the final-state assertion. Restore.
+2. Swap the sort to `reverse=True` → LRS-ordering test fails. Restore byte-identical.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_backfill.py
+git commit -m "feat: internal backfill_observations action — lease, LRS ordering, 2-window cap"
+```
+
+---### Task 11: Trigger wiring + registration checks
+
+The trigger block landed in Task 6; now pin its behavior and the internal-action registration exclusion.
+
+**Files:**
+- Modify: none expected (tests only; fix if tests reveal gaps)
+- Test: `app/actions/tests/test_handlers.py`, `app/actions/tests/test_backfill.py`
+
+**Interfaces:**
+- Consumes: `trigger_action` (patched in tests at `app.actions.handlers.trigger_action`), `get_actions()` from `app.actions.core`.
+
+- [ ] **Step 1: Write the tests**
+
+```python
+@pytest.mark.asyncio
+async def test_head_pass_triggers_backfill_when_gap_open_and_lease_free(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # First run on default config opens a gap → backfill must be triggered.
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    await action_pull_observations(lotek_integration, pull_config)
+    trigger.assert_awaited_once_with(str(lotek_integration.id), "backfill_observations")
+
+
+@pytest.mark.asyncio
+async def test_head_pass_does_not_trigger_backfill_when_lease_held(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    # get_state is patched per-device in _setup_pull_mocks; re-patch to return
+    # the lease sentinel for the lease key and {} otherwise
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(side_effect=lambda i, a, s="no-source": "1" if s == "lease" else {}),
+    )
+    await action_pull_observations(lotek_integration, pull_config)
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_head_pass_does_not_trigger_backfill_without_gaps(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"), saved_state={"high_water": recent})
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    await action_pull_observations(lotek_integration, pull_config)
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_trigger_failure_does_not_fail_the_head_pass(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    mocker.patch(
+        "app.actions.handlers.trigger_action", new=AsyncMock(side_effect=Exception("pubsub down"))
+    )
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["devices_failed"] == []
+
+
+def test_backfill_action_is_discovered_but_internal():
+    from app.actions.core import discover_actions, InternalActionConfiguration
+    handlers = discover_actions(module_name="app.actions.handlers", prefix="action_")
+    assert "backfill_observations" in handlers
+    _, config_model, _ = handlers["backfill_observations"]
+    assert issubclass(config_model, InternalActionConfiguration)
+```
+
+Note: `_setup_pull_mocks` already patches `trigger_action`; re-patching in a test replaces it — keep the helper's patch and have it *return* the mock instead if that reads better.
+
+- [ ] **Step 2: Run the tests**
+
+Run: `./venv/bin/python -m pytest app/actions/tests -q -k "trigger or discovered"`
+Expected: PASS if Task 6/10 wiring is correct; fix any gaps revealed.
+
+- [ ] **Step 3: Dead-code sweep**
+
+`client.IntegrationState` and `client.default_updated_at` are now unused by handlers. Check references:
+
+```bash
+grep -rn "IntegrationState\b\|default_updated_at" app --include="*.py" | grep -v device_state | grep -v "IntegrationStateManager"
+```
+
+If only `client.py` defines them and no test uses them, delete both from `client.py` (and any orphaned tests). If tests elsewhere still exercise them, leave with a `# TODO(GUNDI-5602): remove with v1 cursor` — do NOT silently keep dead code without the marker.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS, < 2 s.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A app
+git commit -m "test: pin backfill trigger wiring and internal-action registration"
+```
+
+---
+
+### Task 12: Final verification, review loop, PR
+
+**Files:**
+- Modify: none (verification + PR)
+
+- [ ] **Step 1: Full-suite verification (superpowers:verification-before-completion)**
+
+```bash
+./venv/bin/python -m pytest app -q
+```
+
+Expected: all green, wall time < 2 s. Also sanity-check schema generation end-to-end:
+
+```bash
+./venv/bin/python -c "
+from app.actions.configurations import PullObservationsConfig
+import json
+print(json.dumps(PullObservationsConfig.schema(), indent=2))
+print(json.dumps(PullObservationsConfig.ui_schema(), indent=2))
+"
+```
+
+Expected: `max_data_age_hours` present with min 1 / max 12; ui order lists all four fields; widget `range`.
+
+- [ ] **Step 2: Read-only review loop (superpowers:requesting-code-review)**
+
+Dispatch reviewer agents (`er-developer:gundi-reviewer`) with NO Edit/Write tools against the pinned branch SHA. Freeze commits while a round runs. Max ~3 rounds; stop early when findings dry up. Address findings with the receiving-code-review skill (verify before implementing).
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/GUNDI-5602-head-pass-backfill
+gh pr create --repo PADAS/gundi-integration-lotek \
+  --title "GUNDI-5602: newest-first head pass + internal backfill with bounded staleness" \
+  --reviewer chrisdoehring \
+  --body-file /tmp/pr_body.md
+```
+
+PR body must include (draft in the scratchpad, then pass via `--body-file`):
+- Link to GUNDI-5602 and the spec file in-repo.
+- The architecture summary (head pass / internal backfill / single shrinking gap / lease).
+- **The bounded-staleness trade-off stated explicitly**: data older than `max_data_age_hours` that could not be fetched is dropped permanently (WARNING with device + range). This supersedes the earlier "no data loss, only delay" framing — deliberate call, approved by Victor: gaps can't grow, catch-up can't compound, rangers always get fresh positions. Default 12 h with a 10-min cadence ≈ 72 missed runs of slack.
+- Safety rails: soft deadline (80% of 540 s), circuit breaker (K=3 consecutive transport failures), zero-progress raise, backfill lease (NX + TTL).
+- Error-semantics table (what stays ERROR vs demoted to WARNING) and why (health = ERROR count in 60 min).
+- Load math: steady state 1 request/device/run vs up to ~27 today.
+- Thundering-herd note: `crontab_schedule` is type-wide with no per-integration jitter (verified in `app/services/action_scheduler.py`) — all 28 integrations still fire the same minutes; out of scope here, but the head pass shrinks each burst to its floor. Fewer, better-spaced requests is also the fastest path to fewer timeouts.
+- `🤖 Generated with [Claude Code](https://claude.com/claude-code)` footer.
+
+- [ ] **Step 4: Jira**
+
+Comment on GUNDI-5602 with the PR link. If a new ticket is created for anything, GUNDI project requires `customfield_11524 = {"id": "13872"}` (Gundi Theme: Connector work).
+
+---
+
+## Deliberately out of scope (do NOT fold into this branch)
+
+- Disabling the 5 login-broken integrations (needs a fresh bearer token from Victor; separate prod operation, recorded in `lotek_cutover_ALL.json`).
+- The action-runner `_handle_error` `config_data` credential leak — separate upstream ticket in `PADAS/gundi-integration-action-runner`; raise with Victor first.
+- Per-integration schedule stagger (template limitation, noted in PR body).
+- Post-deploy verification (`lotek_health_check.py`) — after merge + release, not part of the PR.
+
+## Self-review notes (spec coverage)
+
+- Head pass window formula, `high_water` advance → Task 6. First-run gap + no-gap case → Tasks 6.
+- Stale-drop WARNING, gap never grows → Task 6 (+ flip-verify).
+- Backfill: lease, LRS, N=2 cap, `gap_start` advances only on delivered windows, gap→null → Task 10.
+- Lease no-op on second trigger / reclaim on expiry → Task 10 (expiry is Redis TTL, exercised via `set_if_absent` contract — already covered by `test_state_manager.py`).
+- Deadline / breaker / zero-progress in BOTH actions → Tasks 7–9 wire pull; Task 10's implementation reuses `RunGuards` + zero-progress predicate; backfill deferral covered by lease/breaker tests.
+- Retry posture (2 attempts, deadline-gated, none after breaker trip — the breaker stops the loop before any further fetch) → Tasks 3, 8, 9.
+- Migration `updated_at` → `high_water` → Tasks 4, 6.
+- Config fields + ui:order + slider → Task 5.
+- Error-level table → Tasks 6 (WARNING demotion), 7 (zero-progress ERROR), 8–9 (deferral WARNINGs).
+- `describe_exception` fix → Task 2. Pending edits → Task 1.

--- a/docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md
+++ b/docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md
@@ -1,6 +1,6 @@
 # Lotek connector: newest-first fetching (head pass + internal backfill)
 
-**Ticket**: GUNDI-5602 · **Status**: approved by Victor 2026-08-13 · **Repo**: gundi-integration-lotek
+**Ticket**: GUNDI-5602 · **Status**: approved 2026-08-13 · **Repo**: gundi-integration-lotek
 
 ## Problem
 
@@ -65,7 +65,7 @@ Consequences, all intended:
 - The gap cannot grow → per-device catch-up cost cannot compound → runtime converges.
 - Rangers always get recent positions; history is best-effort.
 - **Data loss is possible** when an outage exceeds `max_data_age_hours`. This supersedes the
-  earlier "deferral = no data loss, only delay" framing; Victor's explicit call. The 12h
+  earlier "deferral = no data loss, only delay" framing. The 12h
   default with a 10-min cadence gives ~72 missed runs of slack before anything is lost.
 
 ER handles out-of-order arrival fine (live position = newest `recorded_at` regardless of

--- a/docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md
+++ b/docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md
@@ -1,0 +1,142 @@
+# Lotek connector: newest-first fetching (head pass + internal backfill)
+
+**Ticket**: GUNDI-5602 · **Status**: approved by Victor 2026-08-13 · **Repo**: gundi-integration-lotek
+
+## Problem
+
+A chronically slow Lotek API (`webservice.lotek.com`) times out our 9-minute action budget
+(~264 `ACTION_TIMEOUT_9MIN` ERRORs/day across all active connections). The current design
+walks each device's backlog oldest-first, so when the budget dies, the freshest positions
+are what never arrive — rangers can't see where the animal is *now*. Worse, a slow device's
+cursor pins, so it re-queries ever-wider windows next run (up to 9 windows × 3 retries = 27
+requests for one device), amplifying Lotek's load and our own timeouts.
+
+## Design
+
+Flip the fetch order: freshest data first, history second, and bound how much history we
+ever owe.
+
+### Two actions
+
+**`pull_observations`** (scheduled, cadence unchanged):
+1. `get_devices` (ERROR + raise on failure, as today).
+2. **Head pass** over every device: fetch `[max(high_water, now − max_data_age_hours), now]`
+   (upload-time query, as today), transform, send, set `high_water = now`.
+3. If any device has an open gap and the backfill lease is free:
+   `trigger_action(integration_id, "backfill_observations")`.
+
+**`backfill_observations`** (internal — `InternalActionConfiguration`, config never shown in
+the portal, only triggered by `pull_observations`):
+1. Acquire lease: `backfill_lease_until` in integration-level state; skip the whole run if an
+   unexpired lease exists (prevents overlapping backfills when a run grinds past the next
+   trigger). Lease TTL = `MAX_ACTION_EXECUTION_TIME`.
+2. Order gapped devices **least-recently-backfilled first** (persist `last_backfilled` per
+   device).
+3. Per device: fetch up to **N = 2 windows** (7-day chunks, oldest-first) from
+   `[gap_start, gap_end]`, send, advance `gap_start` per delivered window; gap closed →
+   null it out.
+4. Release lease.
+
+### State per device (Redis, keyed `(integration_id, action_id, device_id)` as today)
+
+| Field | Meaning |
+|---|---|
+| `high_water` | newest upload-time synced (replaces `updated_at`) |
+| `gap_start`, `gap_end` | single unfetched historical range; null when closed |
+| `last_backfilled` | LRS ordering key for backfill fairness |
+
+**Migration**: existing `updated_at` → `high_water`, no gap. First head pass after deploy
+covers `[max(updated_at, now − max_data_age_hours), now]`; anything older than
+`max_data_age_hours` that the old cursor still owed is dropped (see trade-off below).
+
+**Gap lifecycle**: created **once**, on a device's first run —
+`[now − default_lookback_days, now − max_data_age_hours]`, the deliberate historical import.
+It only ever shrinks. It is never extended, so there is no merge logic and no multi-gap
+bookkeeping.
+
+### Bounded staleness (the deliberate trade-off)
+
+In steady state the head pass never reaches back more than `max_data_age_hours`. If a device
+falls further behind (Lotek outage, repeated head-pass failures, integration disabled a
+while), the span `[high_water, now − max_data_age_hours]` is **dropped permanently** with a
+WARNING naming the device and range — it is not added to the gap.
+
+Consequences, all intended:
+- The gap cannot grow → per-device catch-up cost cannot compound → runtime converges.
+- Rangers always get recent positions; history is best-effort.
+- **Data loss is possible** when an outage exceeds `max_data_age_hours`. This supersedes the
+  earlier "deferral = no data loss, only delay" framing; Victor's explicit call. The 12h
+  default with a 10-min cadence gives ~72 missed runs of slack before anything is lost.
+
+ER handles out-of-order arrival fine (live position = newest `recorded_at` regardless of
+arrival order), so late backfill infill is harmless. All windows are defined in **upload
+time** (the existing query semantics), so collars that upload old points in bursts are not
+missed by the head pass.
+
+### Portal configuration (`PullObservationsConfig`)
+
+| Param | Default | Range | Notes |
+|---|---|---|---|
+| `default_lookback_days` | 7 | 1–60 | existing; description narrows to "historic data imported on the first run" |
+| `max_data_age_hours` | 12 | 1–12 | **new**; slider (`ui:widget: range`); "positions uploaded longer ago than this that could not be fetched are skipped permanently" |
+| `max_pdop` | — | ≥0 | unchanged |
+| `run_on_schedule` | true | hidden | unchanged; keep in `ui:order` |
+
+Not configurable (code constants — load-protection mechanics, not operator knobs): window
+cap N=2, deadline fraction, breaker K=3, retry attempts, window chunk size (7d), lease TTL.
+
+### Safety rails (both actions)
+
+- **Deadline**: stop starting new device work past ~80% of `MAX_ACTION_EXECUTION_TIME`
+  (540s → ~430s). Controlled exit: WARNING activity log + `devices_deferred` result key.
+  Never end via the `asyncio.wait_for` cancellation.
+- **Circuit breaker**: K=3 consecutive devices failing on timeout/transport errors → assume
+  Lotek-wide degradation, stop early, defer the remainder (WARNING). Also bounds login
+  storms.
+- **Zero-progress guard**: a run that services zero devices raises (ERROR) like the
+  all-failed case — systemic degradation must alert, not warn forever.
+- **Retry posture**: `RETRY_ATTEMPTS` 3 → 2 for position fetches; zero retries once the
+  breaker has tripped; Lotek-5xx retries gated on the deadline.
+
+### Error semantics (health keys on ERROR count only — cdip `calculate_integration_status`)
+
+| Event | Level |
+|---|---|
+| login refused, `get_devices` failure, all-heads-failed, delivery failure, zero-progress | ERROR |
+| per-device transient fetch timeout, deferrals (deadline/breaker), dropped stale ranges | WARNING |
+
+### Starvation
+
+Freshness starvation is impossible by construction: every device is head-fetched every run.
+Backfill fairness = LRS ordering + per-device window cap; a deadline-cut tail rotates to the
+front of the next trigger. Worst-case import delay ≈ gapped-devices ÷ (budget ÷ window-cost)
+× cadence, and the import is finite.
+
+### Load (this is also the Lotek load-relief fix)
+
+Steady state = **1 request/device/run**, the theoretical floor (vs. up to ~27 today for a
+pinned device). Backfill is a one-time bounded import — a 7-day lookback is a single window
+per device. Fewer, better-spaced requests is also the fastest path to fewer timeouts for us.
+
+## Testing
+
+TDD per the practices established this week: failing test first; flip-verify assertions on
+critical lines; suite < 2s (`RETRY_WAIT_INITIAL`/`RETRY_WAIT_JITTER` patched to 0). Key
+behaviors to pin:
+
+- head pass sends newest window and advances `high_water` even with an open gap
+- first-run gap creation `[now − lookback, now − max_age]`; no gap when lookback ≤ max_age
+- steady-state: no gap opened when `high_water` within `max_data_age_hours`
+- stale-span drop: outage > max_age → WARNING with range, gap unchanged
+- backfill: LRS ordering, N-window cap, `gap_start` advances only on delivered windows,
+  gap closes to null
+- lease: second trigger while lease held is a no-op; expired lease is reclaimed
+- deadline/breaker/zero-progress in both actions
+- migration: legacy `updated_at` state parses as `high_water`
+
+## Out of scope (tracked elsewhere in PROMPT_lotek_followup.md)
+
+- Thundering-herd stagger across the 28 integrations (verify `crontab_schedule` support
+  before the PR; open question, not part of this design).
+- Disabling the 5 login-broken integrations (task 1).
+- The action-runner template `config_data` credential-leak fix (separate ticket, upstream).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = app/actions/test
+testpaths = app


### PR DESCRIPTION
Implements [GUNDI-5602](https://earthranger.atlassian.net/browse/GUNDI-5602): newest-first fetching for the Lotek connector. Full design spec (approved 2026-08-13): `docs/superpowers/specs/2026-08-13-lotek-head-pass-design.md`.

## Problem → Architecture

The old oldest-first backlog walk meant that when the slow Lotek API blew the 9-minute budget (~264 timeout ERRORs/day), the *freshest* positions were what never arrived, and a pinned cursor could cost up to ~27 requests for one device. This PR flips the order:

- **`pull_observations`** (scheduled, cadence unchanged): a *head pass* — every device, every run, fetches `[max(high_water − 2h, now − max_data_age_hours), now]` and advances `high_water`. Steady state = **1 request/device/run** vs ~27 worst-case today. The 2 h trailing overlap re-covers late-visible uploads (re-sends are tolerated).
- **`backfill_observations`** (new, internal, never in the portal): closes each device's single historical gap (created once, on first run), oldest-first, least-recently-backfilled device first, max 2 windows/device/run, guarded by a Redis lease (`SET NX` + TTL), self-retriggering while gaps remain. Same head/backfill split the movebank connector uses in prod.
- **State**: `updated_at` cursor → `DeviceState {version, high_water, gap_start, gap_end, last_backfilled}`; legacy state migrates seamlessly. Each action **merge-saves only the fields it owns** (head pass: `high_water`; backfill: gap fields), so interleaved runs can't clobber each other.
- **Config**: new `max_data_age_hours` portal slider (default 12 h, range 1–12); `default_lookback_days` now = first-run import depth only.

## Bounded staleness

In steady state the head pass never reaches back more than `max_data_age_hours`. A span that falls further behind (an outage longer than that) is skipped rather than queued, with a WARNING naming the device and range. That bound is what makes the design work: gaps can't grow, catch-up cost can't compound, and recent positions always arrive first — history is best-effort. At the 12 h default with a 10-min cadence, there are ~72 consecutive missed runs of slack before anything is skipped.

## Safety rails (both actions)

| Rail | Behavior |
|---|---|
| Soft deadline | Stop starting device work past 80% of the action budget; WARNING + `devices_deferred`; retries drop to 1 past it. Never the `asyncio.wait_for` guillotine. |
| Circuit breaker | 3 consecutive transport failures → stop, defer the rest (WARNING). Resets on any success. |
| Zero-progress | Nothing serviced and nothing delivered → raise (ERROR); also breaks the retrigger cascade. |
| Cascade brakes | No self-retrigger while the breaker is hot; `run_on_schedule=false` stops the cascade too. |
| Lease | Second trigger while held = clean no-op; released in `finally`; retrigger only after release. |
| Retries | `RETRY_ATTEMPTS` 3 → 2. |

## Error levels (health alerts key on ERROR count only)

| Event | Level |
|---|---|
| Login refused, `get_devices` failure, delivery/checkpoint failure, zero-progress, malformed data, discarded-state reset | ERROR (reset: WARNING) |
| Transient per-device fetch timeouts, deferrals, dropped stale ranges, quiet devices | WARNING |

Should collapse the ~30 connections flapping UNHEALTHY daily on per-device timeout noise. (Thundering herd across the 28 integrations is out of scope — schedules are type-wide with no jitter — but the head pass shrinks each burst to its floor.)

## Verification

- **Unit**: TDD throughout; 207 tests, ~1 s; critical lines flip-verified (migration, cursor advance, gap lifecycle, rails, merge-save ownership, overlap, retrigger conditions).
- **Stage (live, this branch)**: real Lotek API + stage Gundi + real PubSub command topic, 3 accounts. Verified the exact window math, first-run gap → backfill → close lifecycle, the async trigger chain, lease acquire/release, steady-state cursoring, legacy-state migration, schema registration (slider renders), and real delivery: 24 head-pass observations landed before the 3-day backfill batches (all sensor POSTs 200). Zero ERROR-level activity events across all runs.
- **Review**: four passes (two read-only agent rounds, GitHub Copilot, one deep multi-angle round), all findings fixed on this branch — including a blocker (internal-action trigger published an empty config override and 404'd before the handler ran; now pinned by an end-to-end test) and a lost-update race between the two actions (fixed by the field-ownership merge-saves). Copilot's lease-race comment was refuted (the runner's timeout always fires before the lease TTL); its token-lease hardening goes to the upstream template ticket with the `_handle_error` credential leak.

Post-deploy: re-register the type (`python -m app.register --slug lotek`), then compare `lotek_health_check.py` against the 2026-08-12 baseline — expect the ~264 daily timeout ERRORs to collapse to ~0.

Also included: `needs_attention` extra restored on delivery errors, `pytest.ini` testpaths fix, exception types named in `get_devices` error logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[GUNDI-5602]: https://allenai.atlassian.net/browse/GUNDI-5602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ