### PR TITLE
GUNDI-5602: timeout resilience — best-effort activity publishes, honest timeout labels, publish-volume cuts

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -502,9 +502,11 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
     except httpx.TransportError as e:
         # WARNING + breaker-feeding: enough timeouts/transport failures in a
         # row mean Lotek-wide degradation, not a bad device.
+        # Local log only: failed devices are aggregated into one end-of-run
+        # summary publish. Per-device publishes multiplied exactly when Lotek
+        # (or the instance) was already drowning — a congestion feedback loop.
         message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
         logger.warning(message, exc_info=True)
-        await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
         return None, True
     except LotekException as e:
         message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
@@ -513,9 +515,9 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
             # Lotek-wide degradation as a timeout: WARNING + breaker-feeding.
             # Before this branch it fell into the generic handler below, which
             # actively RESET the breaker streak — an HTTP-error outage could
-            # never trip the breaker (review finding).
+            # never trip the breaker (review finding). Local log only — same
+            # aggregation rationale as the transport branch above.
             logger.warning(message, exc_info=True)
-            await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
             return None, True
         # Other 4xx (incl. a token-expiry 401 that survived its retry): a
         # per-device/API-contract problem that won't self-heal — ERROR, and
@@ -607,11 +609,11 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
         return 0, True, transport_failure
 
     if not cdip_positions:
-        # Purely informational; must never affect the device's outcome. A pubsub blip
-        # here must not mark a healthy quiet device as failed or stall its cursor.
-        message = f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}."
-        logger.info(message)
-        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.WARNING)
+        # Local log only. This used to publish a portal WARNING per quiet
+        # device — on a mostly-dormant 400-device integration that was
+        # hundreds of pubsub publishes per tick, the single largest
+        # contributor to the publish congestion behind GUNDI-5602.
+        logger.info(f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}.")
 
     observations_sent, delivery_failed = await _deliver(cdip_positions, device, integration, "pull_observations")
     if delivery_failed:
@@ -650,13 +652,13 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
 
     if stale_from is not None:
         # Only now is the drop real: the cursor advanced past the owed range.
-        message = (
+        # Local log only: on migration/catch-up days this fires for hundreds
+        # of devices in one run — same publish-volume rationale as above.
+        logger.warning(
             f"Dropped stale range [{stale_from.isoformat()}, {freshness_floor.isoformat()}] "
             f"permanently for device {device.nDeviceID}: older than max_data_age_hours="
             f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
         )
-        logger.warning(message)
-        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.WARNING)
 
     return observations_sent, False, False
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -251,6 +251,30 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
                 device_list = await client.get_devices(integration, auth)
+    except httpx.TransportError as e:
+        # Transport failures reaching Lotek are the same class the per-device
+        # breaker treats as WARNING; classifying them ERROR here marked every
+        # connection unhealthy during fleet-wide Lotek congestion even though
+        # the next tick usually succeeds (GUNDI-5602 prod finding 2026-08-16).
+        # Clean return: the run made no progress but the schedule retries it.
+        message = (
+            f"Lotek API unreachable while listing devices for integration {integration.id}: "
+            f"{describe_exception(e)}. The run will be retried on the next schedule."
+        )
+        logger.warning(message)
+        await log_action_activity(
+            integration_id=str(integration.id),
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+        return {
+            "observations_extracted": 0,
+            "devices_failed": [],
+            "devices_deferred": [],
+            "skipped": True,
+            "reason": "lotek_unreachable",
+        }
     except Exception as e:
         message = f"Error fetching devices from Lotek. Integration ID: {integration.id} Exception: {describe_exception(e)}"
         logger.exception(message)
@@ -745,6 +769,24 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
                 with attempt:
                     device_list = await client.get_devices(integration, auth)
+        except httpx.TransportError as e:
+            # Same WARNING classification as the head pass: an unreachable
+            # Lotek must not mark the connection unhealthy. The early return
+            # releases the lease via the finally below, and skipping the
+            # self-retrigger throttles the cascade to the head-pass cadence —
+            # the open gaps re-trigger backfill on the next scheduled run.
+            message = (
+                f"Lotek API unreachable while listing devices for backfill on integration "
+                f"{integration_id}: {describe_exception(e)}. Open gaps are retried on the next trigger."
+            )
+            logger.warning(message)
+            await log_action_activity(
+                integration_id=integration_id,
+                action_id="backfill_observations",
+                title=message,
+                level=LogLevel.WARNING
+            )
+            return {"skipped": True, "reason": "lotek_unreachable"}
         except Exception as e:
             message = (
                 f"Error fetching devices from Lotek for backfill. Integration ID: "

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -314,6 +314,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     # backfill this cycle. Self-correcting: the next run's head pass reaches it
     # and triggers then, same as the worst-case import delay the design accepts.
     any_open_gap = False
+    stale_drops = []
     for i, (device, state, is_new) in enumerate(device_states):
         if reason := guards.should_stop():
             deferred_devices = [d.nDeviceID for d, _, _ in device_states[i:]]
@@ -321,7 +322,8 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             break
         try:
             sent, device_failed, transport_failure = await _head_pass_device(
-                device, state, is_new, integration, auth, action_config, present_time, guards
+                device, state, is_new, integration, auth, action_config, present_time, guards,
+                stale_drops=stale_drops
             )
         except LotekUnauthorizedException:
             raise
@@ -358,6 +360,24 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             f"Pulled observations with {len(failed_devices)} of {len(device_list)} device(s) "
             f"failing for integration {integration.id}: {_summarize_ids(failed_devices)}. "
             f"They will be retried on the next run."
+        )
+        logger.warning(message)
+        await log_action_activity(
+            integration_id=str(integration.id),
+            action_id="pull_observations",
+            title=message,
+            level=LogLevel.WARNING
+        )
+
+    if stale_drops:
+        # Permanent data loss must stay visible in the portal: one aggregated
+        # WARNING per run instead of the old per-device publish (review
+        # finding on the publish-volume fix). Per-device ranges are in the
+        # local log.
+        message = (
+            f"Dropped data older than max_data_age_hours={action_config.max_data_age_hours} "
+            f"permanently for {len(stale_drops)} device(s) on integration {integration.id}: "
+            f"{_summarize_ids(stale_drops)}. See the application log for per-device ranges."
         )
         logger.warning(message)
         await log_action_activity(
@@ -579,7 +599,7 @@ async def _deliver(cdip_positions, device, integration, action_id):
     return observations_sent, False
 
 
-async def _head_pass_device(device, state, is_new, integration, auth, action_config, present_time, guards):
+async def _head_pass_device(device, state, is_new, integration, auth, action_config, present_time, guards, stale_drops=None):
     """Fetch, deliver and checkpoint one device's freshest window.
 
     Returns (observations_sent, device_failed, transport_failure).
@@ -652,13 +672,17 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
 
     if stale_from is not None:
         # Only now is the drop real: the cursor advanced past the owed range.
-        # Local log only: on migration/catch-up days this fires for hundreds
-        # of devices in one run — same publish-volume rationale as above.
+        # Per-device detail is local-log only (migration/catch-up days fire
+        # this for hundreds of devices in one run), but a permanent drop must
+        # not vanish from the portal — the caller aggregates stale_drops into
+        # one end-of-run summary publish (review finding).
         logger.warning(
             f"Dropped stale range [{stale_from.isoformat()}, {freshness_floor.isoformat()}] "
             f"permanently for device {device.nDeviceID}: older than max_data_age_hours="
             f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
         )
+        if stale_drops is not None:
+            stale_drops.append(device.nDeviceID)
 
     return observations_sent, False, False
 

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -160,10 +160,12 @@ async def test_backfill_releases_lease_even_when_the_run_raises(
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     _, _, _, release, _ = _setup_backfill_mocks(mocker, mock_redis, [], {})
+    # A non-transport failure: transport errors return cleanly (WARNING) since
+    # the 2026-08-16 congestion fix, so they no longer exercise the raise path.
     mocker.patch(
-        "app.actions.client.get_devices", new=AsyncMock(side_effect=httpx.ReadTimeout(""))
+        "app.actions.client.get_devices", new=AsyncMock(side_effect=ValueError("boom"))
     )
-    with pytest.raises(httpx.ReadTimeout):
+    with pytest.raises(ValueError):
         await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
     release.assert_awaited_once()
 

--- a/app/actions/tests/test_backfill_trigger_e2e.py
+++ b/app/actions/tests/test_backfill_trigger_e2e.py
@@ -40,7 +40,7 @@ async def test_pull_observations_trigger_actually_runs_backfill_end_to_end(mocke
     )
     mocker.patch("app.services.action_scheduler.settings.TRIGGER_ACTIONS_ALWAYS_SYNC", True)
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
-    mocker.patch("app.services.action_runner.publish_event", new=AsyncMock())
+    mocker.patch("app.services.action_runner._publish_activity_event", new=AsyncMock())
     mock_config_manager = mocker.patch("app.services.action_runner.config_manager")
     mock_config_manager.get_integration_details = AsyncMock(return_value=lotek_integration)
     # No stored config for the internal action — this is the actual production

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -100,12 +100,13 @@ async def test_invalid_position_filtered_and_logs_warning_when_no_valid_observat
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
     result = await action_pull_observations(lotek_integration, pull_config)
     assert result == {'observations_extracted': 0, 'devices_failed': [], 'devices_deferred': []}
-    mock_log_action_activity.assert_any_call(
-        integration_id=str(lotek_integration.id),
-        action_id="pull_observations",
-        level=LogLevel.WARNING,
-        title=f"No positions fetched for device {lotek_position.DeviceID} integration ID: {lotek_integration.id}."
-    )
+    # Publish-volume fix: quiet devices are local-log only — one portal WARNING
+    # per dormant device was the largest pubsub-congestion contributor.
+    quiet_publishes = [
+        c for c in mock_log_action_activity.call_args_list
+        if "No positions fetched" in c.kwargs.get("title", "")
+    ]
+    assert quiet_publishes == []
 
 @pytest.mark.asyncio
 async def test_lookback_days_config_sets_first_run_gap_depth(mocker, lotek_integration, pull_config, mock_redis):
@@ -445,7 +446,7 @@ async def test_action_pull_observations_does_not_advance_state_for_failed_device
 
 @pytest.mark.asyncio
 async def test_action_pull_observations_logs_exception_type_when_message_is_empty(
-    mocker, lotek_integration, pull_config, mock_redis
+    mocker, lotek_integration, pull_config, mock_redis, caplog
 ):
     # httpx timeouts stringify to "", which produced logs ending in a bare "Exception: ".
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
@@ -463,10 +464,13 @@ async def test_action_pull_observations_logs_exception_type_when_message_is_empt
     with pytest.raises(LotekException):
         await action_pull_observations(lotek_integration, pull_config)
 
-    titles = [call.kwargs["title"] for call in mock_log_action_activity.call_args_list]
-    error_titles = [t for t in titles if "Error fetching positions" in t]
-    assert error_titles, "expected a per-device error to be logged"
-    assert "ReadTimeout" in error_titles[0]
+    # Transport failures are local-log only (publish-volume fix); the
+    # exception type must still be named in the local warning.
+    fetch_logs = [r.message for r in caplog.records if "Error fetching positions" in r.message]
+    assert fetch_logs, "expected a per-device fetch failure to be logged locally"
+    assert "ReadTimeout" in fetch_logs[0]
+    published = [c.kwargs.get("title", "") for c in mock_log_action_activity.call_args_list]
+    assert not any("Error fetching positions" in t for t in published)
 
 
 @pytest.mark.asyncio
@@ -897,7 +901,7 @@ async def test_steady_state_advances_high_water_and_keeps_gap_closed(
 
 @pytest.mark.asyncio
 async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
-    mocker, lotek_integration, pull_config, mock_redis
+    mocker, lotek_integration, pull_config, mock_redis, caplog
 ):
     # Bounded staleness (agreed design decision): a cursor further back than max_age
     # means that span is dropped permanently — WARNING with the range, gap unchanged.
@@ -915,12 +919,12 @@ async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
     ) < timedelta(minutes=1)
     saved = set_state.call_args.args[2]
     assert saved.get("gap_start") is None  # NOT added to the gap
-    drop_warnings = [
-        c for c in log.await_args_list
-        if c.kwargs["level"] == LogLevel.WARNING and "Dropped stale range" in c.kwargs["title"]
-    ]
+    # Local-log only (publish-volume fix): migration days fire this for
+    # hundreds of devices in one run.
+    drop_warnings = [r.message for r in caplog.records if "Dropped stale range" in r.message]
     assert len(drop_warnings) == 1
-    assert "device 1" in drop_warnings[0].kwargs["title"]
+    assert "device 1" in drop_warnings[0]
+    assert not any("Dropped stale range" in c.kwargs.get("title", "") for c in log.await_args_list)
 
 
 @pytest.mark.asyncio
@@ -955,10 +959,17 @@ async def test_transient_fetch_failure_logs_warning_not_error(
     get_positions.side_effect = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS + [[]]
     result = await action_pull_observations(lotek_integration, pull_config)
     assert result["devices_failed"] == ["1"]
-    device_1_logs = [
+    # Transport failures are local-log only; the end-of-run summary is the
+    # single portal publish and it is a WARNING, not an ERROR.
+    device_1_publishes = [
         c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")
     ]
-    assert device_1_logs and all(c.kwargs["level"] == LogLevel.WARNING for c in device_1_logs)
+    assert device_1_publishes == []
+    summaries = [
+        c for c in log.await_args_list
+        if "failing for integration" in c.kwargs.get("title", "")
+    ]
+    assert summaries and all(c.kwargs["level"] == LogLevel.WARNING for c in summaries)
 
 
 @pytest.mark.asyncio
@@ -1334,9 +1345,10 @@ async def test_lotek_5xx_failures_feed_the_circuit_breaker(
     ]
     assert len(deferral_logs) == 1
     assert get_positions.await_count == BREAKER_THRESHOLD
-    # outage failures are WARNINGs (transient), not ERRORs
+    # Outage (5xx/429) failures are local-log only (publish-volume fix): no
+    # per-device portal publishes, and in particular no ERRORs.
     device_logs = [c for c in log.await_args_list if "Device:" in c.kwargs.get("title", "")]
-    assert device_logs and all(c.kwargs["level"] == LogLevel.WARNING for c in device_logs)
+    assert device_logs == []
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -771,7 +771,8 @@ async def test_get_devices_failure_logs_exception_type_when_message_is_empty(
     mocker, lotek_integration, pull_config, mock_redis
 ):
     # httpx timeouts stringify to "" — the activity log must name the type,
-    # not render a bare "Exception: ".
+    # not render a bare ": ". (Transport failures classify WARNING and return
+    # cleanly since the 2026-08-16 congestion fix, so no raise here.)
     mocker.patch("app.services.state.redis", mock_redis)
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
@@ -781,8 +782,8 @@ async def test_get_devices_failure_logs_exception_type_when_message_is_empty(
         new=AsyncMock(side_effect=httpx.ReadTimeout("")),
     )
     mock_log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
-    with pytest.raises(httpx.ReadTimeout):
-        await action_pull_observations(lotek_integration, pull_config)
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["reason"] == "lotek_unreachable"
     title = mock_log.call_args.kwargs["title"]
     assert "ReadTimeout" in title
 

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -919,12 +919,19 @@ async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
     ) < timedelta(minutes=1)
     saved = set_state.call_args.args[2]
     assert saved.get("gap_start") is None  # NOT added to the gap
-    # Local-log only (publish-volume fix): migration days fire this for
-    # hundreds of devices in one run.
+    # Per-device detail is local-log only (publish-volume fix), but permanent
+    # loss stays portal-visible as ONE aggregated end-of-run summary.
     drop_warnings = [r.message for r in caplog.records if "Dropped stale range" in r.message]
     assert len(drop_warnings) == 1
     assert "device 1" in drop_warnings[0]
     assert not any("Dropped stale range" in c.kwargs.get("title", "") for c in log.await_args_list)
+    summaries = [
+        c for c in log.await_args_list
+        if "Dropped data older than" in c.kwargs.get("title", "")
+    ]
+    assert len(summaries) == 1
+    assert summaries[0].kwargs["level"] == LogLevel.WARNING
+    assert "1" in summaries[0].kwargs["title"]
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_transport_failures.py
+++ b/app/actions/tests/test_transport_failures.py
@@ -1,0 +1,116 @@
+import pytest
+
+import httpx
+from unittest.mock import AsyncMock
+
+from app.actions.handlers import action_pull_observations, action_backfill_observations
+from app.actions.configurations import BackfillObservationsConfig
+
+
+def _patch_retry_waits(mocker):
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    # The @activity_logger decorator publishes to real PubSub otherwise.
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+
+
+def _levels(mock_log_activity):
+    from gundi_core.schemas.v2 import LogLevel
+
+    levels = []
+    for call in mock_log_activity.mock_calls:
+        level = call.kwargs.get("level")
+        if level is None:
+            continue
+        levels.append(level.upper() if isinstance(level, str) else LogLevel(int(level)).name)
+    return levels
+
+
+# GUNDI-5602 prod finding: fleet-wide Lotek congestion makes get_devices fail
+# with httpx.ConnectTimeout on many integrations at once. That is a transport
+# failure — the same class the per-device breaker treats as WARNING — but the
+# get_devices error path classified it ERROR and re-raised, marking every
+# connection unhealthy over a transient upstream condition.
+
+
+@pytest.mark.asyncio
+async def test_pull_get_devices_transport_failure_is_warning_and_clean_return(
+        mocker, lotek_integration, pull_config
+):
+    _patch_retry_waits(mocker)
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch(
+        "app.actions.client.get_devices",
+        new=AsyncMock(side_effect=httpx.ConnectTimeout("connection timed out")),
+    )
+    mock_log = mocker.patch(
+        "app.actions.handlers.log_action_activity", new=AsyncMock()
+    )
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result["skipped"] is True
+    assert result["reason"] == "lotek_unreachable"
+    assert result["observations_extracted"] == 0
+    levels = _levels(mock_log)
+    assert "WARNING" in levels
+    assert "ERROR" not in levels
+
+
+@pytest.mark.asyncio
+async def test_pull_get_devices_non_transport_failure_stays_error_and_raises(
+        mocker, lotek_integration, pull_config
+):
+    _patch_retry_waits(mocker)
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch(
+        "app.actions.client.get_devices",
+        new=AsyncMock(side_effect=ValueError("unexpected devices payload")),
+    )
+    mock_log = mocker.patch(
+        "app.actions.handlers.log_action_activity", new=AsyncMock()
+    )
+
+    with pytest.raises(ValueError, match="unexpected devices payload"):
+        await action_pull_observations(lotek_integration, pull_config)
+
+    assert "ERROR" in _levels(mock_log)
+
+
+@pytest.mark.asyncio
+async def test_backfill_get_devices_transport_failure_is_warning_and_releases_lease(
+        mocker, lotek_integration, mock_redis
+):
+    from app.actions.configurations import PullObservationsConfig
+
+    _patch_retry_waits(mocker)
+    mocker.patch("app.services.state.redis", mock_redis)
+    mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
+    mocker.patch(
+        "app.actions.client.get_devices",
+        new=AsyncMock(side_effect=httpx.ConnectTimeout("connection timed out")),
+    )
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=PullObservationsConfig())
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.acquire_lease",
+        new=AsyncMock(return_value="lease-token"),
+    )
+    release = mocker.patch(
+        "app.services.state.IntegrationStateManager.release_lease",
+        new=AsyncMock(return_value=True),
+    )
+    mock_log = mocker.patch(
+        "app.actions.handlers.log_action_activity", new=AsyncMock()
+    )
+
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig(triggered_by="pull_observations")
+    )
+
+    assert result["skipped"] is True
+    assert result["reason"] == "lotek_unreachable"
+    release.assert_awaited()
+    levels = _levels(mock_log)
+    assert "WARNING" in levels
+    assert "ERROR" not in levels

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -269,12 +269,30 @@ async def execute_action(
             handler(**handler_kwargs),
             timeout=settings.MAX_ACTION_EXECUTION_TIME
         )
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as e:
+        # Two very different failures land here: the wait_for ceiling above,
+        # and an asyncio.TimeoutError raised INSIDE the handler by a
+        # dependency (aiohttp/redis/pubsub). Conflating them mislabeled
+        # ~90-second dependency failures as "Action timed out" and hid the
+        # real cause during the 2026-08-16 PubSub congestion (GUNDI-5602).
+        # Elapsed time tells them apart (with 1s of scheduling slack).
+        elapsed = time.monotonic() - start_time
+        if elapsed >= settings.MAX_ACTION_EXECUTION_TIME - 1:
+            return await _handle_error(
+                asyncio.TimeoutError(f"Action '{action_id}' timed out"),
+                integration_id, action_id,
+                config_data={"configurations": [c.dict() for c in integration.configurations]},
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT
+            )
         return await _handle_error(
-            asyncio.TimeoutError(f"Action '{action_id}' timed out"),
+            asyncio.TimeoutError(
+                f"A dependency call raised asyncio.TimeoutError after {elapsed:.0f}s "
+                f"while executing action '{action_id}' (the "
+                f"{settings.MAX_ACTION_EXECUTION_TIME}s action deadline was not reached)"
+            ),
             integration_id, action_id,
             config_data={"configurations": [c.dict() for c in integration.configurations]},
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
     except Exception as e:
         return await _handle_error(e, integration_id, action_id,

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -21,7 +21,7 @@ from app.actions.core import PullActionConfiguration
 from .config_manager import IntegrationConfigurationManager
 from .state import IntegrationStateManager
 from .utils import find_config_for_action
-from .activity_logger import publish_event, log_action_activity
+from .activity_logger import _publish_activity_event, log_action_activity
 
 _portal = GundiClient()
 config_manager = IntegrationConfigurationManager()
@@ -88,8 +88,12 @@ async def _handle_error(
             "server_response_body": str(getattr(response, "text", getattr(response, "content", None)) or "")
         })
 
-    # Publish the error event
-    await publish_event(
+    # Publish the error event. Best-effort: under the exact congestion this
+    # handler reports on, a raising publish here would escape execute_action,
+    # 500 the route, and (on the pubsub-push path) redeliver → re-run the
+    # action during congestion. The JSONResponse below still carries the full
+    # error_details either way (review finding).
+    await _publish_activity_event(
         event=IntegrationActionFailed(
             payload=ActionExecutionFailed(**error_details)
         ),

--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -31,16 +31,21 @@ from app import settings
 logger = logging.getLogger(__name__)
 
 
-# Publish events for other services or system components
+# Publish events for other services or system components.
+# Retry budget: an action runs under MAX_ACTION_EXECUTION_TIME (540s) and may
+# publish several activity events; the previous budget (5 attempts x 20s
+# timeout + waits up to 60s) let a single publish burn 100-250s of that under
+# PubSub egress congestion — enough to kill whole runs (GUNDI-5602 prod
+# finding on 2026-08-16). Worst case now is ~36s per publish.
 @stamina.retry(
     on=(aiohttp.ClientError, asyncio.TimeoutError),
-    attempts=5,
-    wait_initial=4.0,
-    wait_max=60,
-    wait_jitter=5.0
+    attempts=3,
+    wait_initial=1.0,
+    wait_max=8.0,
+    wait_jitter=2.0
 )
 async def publish_event(event: SystemEventBaseModel, topic_name: str):
-    timeout_settings = aiohttp.ClientTimeout(total=20.0)
+    timeout_settings = aiohttp.ClientTimeout(total=10.0)
     async with aiohttp.ClientSession(
         raise_for_status=True, timeout=timeout_settings
     ) as session:
@@ -64,6 +69,29 @@ async def publish_event(event: SystemEventBaseModel, topic_name: str):
             return response
 
 
+async def _publish_activity_event(event: SystemEventBaseModel, topic_name: str):
+    """Best-effort publish for activity/telemetry events.
+
+    Activity logs are observability: failing to publish one must never fail
+    the action being logged. Before this existed, PubSub egress congestion
+    made publish_event exhaust its retries and re-raise asyncio.TimeoutError,
+    which escaped through the activity_logger decorator into execute_action's
+    `except asyncio.TimeoutError` — every run died in ~90s mislabeled as
+    "Action timed out" (GUNDI-5602 prod finding). Command publishes
+    (action_scheduler.trigger_action) keep using publish_event directly,
+    which still raises: a lost command means the action never runs, and the
+    caller must know.
+    """
+    try:
+        return await publish_event(event=event, topic_name=topic_name)
+    except Exception as e:
+        logger.error(
+            f"Dropping activity event {type(event).__name__} for topic {topic_name} "
+            f"after retries: {type(e).__name__}: {e}"
+        )
+        return None
+
+
 async def log_activity(integration_id: str, action_id: str, title: str, level="INFO", config_data: dict = None, data: dict = None):
     # Show a deprecation warning in favor of using either log_action_activity or log_webhook_activity
     logger.warning("log_activity is deprecated. Please use log_action_activity or log_webhook_activity instead.")
@@ -81,7 +109,7 @@ async def log_action_activity(integration_id: str, action_id: str, title: str, l
         :return: None
         """
     logger.debug(f"Logging custom activity: {title}. Integration: {integration_id}. Action: {action_id}.")
-    await publish_event(
+    await _publish_activity_event(
         event=IntegrationActionCustomLog(
             payload=CustomActivityLog(
                 integration_id=integration_id,
@@ -109,7 +137,7 @@ async def log_webhook_activity(
         :return: None
         """
     logger.debug(f"Logging custom activity: {title}. Integration: {integration_id}. Webhook: {webhook_id}.")
-    await publish_event(
+    await _publish_activity_event(
         event=IntegrationWebhookCustomLog(
             payload=CustomWebhookLog(
                 integration_id=integration_id,
@@ -134,7 +162,7 @@ def activity_logger(on_start=True, on_completion=True, on_error=True):
             action_config = kwargs.get("action_config")
             config_data = action_config.dict() if action_config else {} or {}
             if on_start:
-                await publish_event(
+                await _publish_activity_event(
                     event=IntegrationActionStarted(
                         payload=ActionExecutionStarted(
                             integration_id=integration_id,
@@ -148,7 +176,7 @@ def activity_logger(on_start=True, on_completion=True, on_error=True):
                 result = await func(*args, **kwargs)
             except Exception as e:
                 if on_error:
-                    await publish_event(
+                    await _publish_activity_event(
                         event=IntegrationActionFailed(
                             payload=ActionExecutionFailed(
                                 integration_id=integration_id,
@@ -162,7 +190,7 @@ def activity_logger(on_start=True, on_completion=True, on_error=True):
                 raise e
             else:
                 if on_completion:
-                    await publish_event(
+                    await _publish_activity_event(
                         event=IntegrationActionComplete(
                             payload=ActionExecutionComplete(
                                 integration_id=integration_id,
@@ -188,7 +216,7 @@ def webhook_activity_logger(on_start=True, on_completion=True, on_error=True):
             config_data = webhook_config.dict() if webhook_config else {} or {}
             webhook_id = str(integration.webhook_configuration.webhook.value) if integration and integration.webhook_configuration else "webhook"
             if on_start:
-                await publish_event(
+                await _publish_activity_event(
                     event=IntegrationWebhookStarted(
                         payload=WebhookExecutionStarted(
                             integration_id=integration_id,
@@ -202,7 +230,7 @@ def webhook_activity_logger(on_start=True, on_completion=True, on_error=True):
                 result = await func(*args, **kwargs)
             except Exception as e:
                 if on_error:
-                    await publish_event(
+                    await _publish_activity_event(
                         event=IntegrationWebhookFailed(
                             payload=WebhookExecutionFailed(
                                 integration_id=integration_id,
@@ -216,7 +244,7 @@ def webhook_activity_logger(on_start=True, on_completion=True, on_error=True):
                 raise e
             else:
                 if on_completion:
-                    await publish_event(
+                    await _publish_activity_event(
                         event=IntegrationWebhookComplete(
                             payload=WebhookExecutionComplete(
                                 integration_id=integration_id,

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -41,7 +41,7 @@ async def test_execute_pull_action_from_pubsub(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     response = api_client.post(
         "/",
@@ -71,7 +71,7 @@ async def test_execute_push_action_from_pubsub(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     response = api_client.post(
         "/push-data",
@@ -111,7 +111,7 @@ async def test_execute_action_from_api(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     integration_id = str(integration_v2.id)
     action_id = "pull_observations"
 
@@ -140,7 +140,7 @@ async def test_execute_action_from_api_with_config_overrides(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     config_overrides = {"lookback_days": 3}
     response = api_client.post(
@@ -171,7 +171,7 @@ async def test_execute_action_from_pubsub_with_config_overrides(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     response = api_client.post(
         "/",
@@ -203,7 +203,7 @@ async def test_manual_pull_action_with_invalid_config_still_errors(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     response = api_client.post(
         "/v1/actions/execute/",
@@ -231,7 +231,7 @@ async def test_triggered_by_marker_is_case_insensitive(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     bad_config = mocker.MagicMock()
     bad_config.data = {"lookback_days": "two"}  # should be an integer
     mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
@@ -267,7 +267,7 @@ async def test_scheduled_pull_action_with_invalid_config_is_skipped(
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mock_state_manager.set_if_absent.return_value = async_return(True)  # window open
     bad_config = mocker.MagicMock()
     bad_config.data = {"lookback_days": "two"}  # should be an integer
@@ -301,7 +301,7 @@ async def test_scheduled_pull_action_invalid_config_warning_is_throttled(
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mock_state_manager.set_if_absent.return_value = async_return(False)  # window closed
     bad_config = mocker.MagicMock()
     bad_config.data = {"lookback_days": "two"}
@@ -332,7 +332,7 @@ async def test_scheduled_pull_action_invalid_config_skip_survives_throttle_failu
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.action_runner.state_manager", mock_state_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mock_state_manager.set_if_absent.side_effect = Exception("redis unavailable")
     bad_config = mocker.MagicMock()
     bad_config.data = {"lookback_days": "two"}
@@ -364,7 +364,7 @@ async def test_scheduled_pull_action_with_missing_config_is_skipped(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mock_config_manager.get_action_configuration.return_value = async_return(None)
 
     response = api_client.post(
@@ -389,7 +389,7 @@ async def test_scheduled_pull_action_skipped_when_run_on_schedule_disabled(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     paused_config = mocker.MagicMock()
     paused_config.data = {"lookback_days": 10, "run_on_schedule": False}
     mock_config_manager.get_action_configuration.return_value = async_return(paused_config)
@@ -415,7 +415,7 @@ async def test_manual_pull_action_runs_even_when_run_on_schedule_disabled(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     paused_config = mocker.MagicMock()
     paused_config.data = {"lookback_days": 10, "run_on_schedule": False}
     mock_config_manager.get_action_configuration.return_value = async_return(paused_config)
@@ -444,7 +444,7 @@ async def test_non_pull_action_still_errors_on_invalid_config(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     bad_config = mocker.MagicMock()
     bad_config.data = {"start_datetime": "not-a-datetime", "end_datetime": "also-bad"}
     mock_config_manager.get_action_configuration.return_value = async_return(bad_config)
@@ -473,7 +473,7 @@ async def test_trigger_subaction(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
     integration_id = str(integration_v2.id)
     action_id = "pull_observations_by_date"
@@ -512,7 +512,7 @@ async def test_trigger_subaction_sync(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
     integration_id = str(integration_v2.id)
     action_id = "pull_observations_by_date"
@@ -547,7 +547,7 @@ async def test_execute_action_with_handler_error(
     mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     response = api_client.post(
         "/v1/actions/execute/",

--- a/app/services/tests/test_timeout_resilience.py
+++ b/app/services/tests/test_timeout_resilience.py
@@ -1,0 +1,166 @@
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock
+
+from gundi_core.events import IntegrationActionFailed
+
+from app.conftest import MockPullActionConfiguration
+from app.services.activity_logger import activity_logger, log_action_activity
+from app.services.action_runner import execute_action
+
+
+def _failed_events(mock_publish_event):
+    events = []
+    for call in mock_publish_event.mock_calls:
+        event = call.kwargs.get("event")
+        if event is None and call.args:
+            event = call.args[0]
+        if isinstance(event, IntegrationActionFailed):
+            events.append(event)
+    return events
+
+
+# --- Telemetry must be best-effort (GUNDI-5602 prod finding) ---------------
+# Under PubSub egress congestion, publish_event exhausts its retries and
+# re-raises asyncio.TimeoutError. Before the fix that escaped through the
+# activity_logger decorator into execute_action's `except asyncio.TimeoutError`
+# and every run died in ~90s labeled "Action 'pull_observations' timed out".
+
+
+@pytest.mark.asyncio
+async def test_log_action_activity_survives_publish_failure(mocker):
+    mocker.patch(
+        "app.services.activity_logger.publish_event",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    from gundi_core.schemas.v2 import LogLevel
+
+    # Must not raise: an activity log that can't be published is dropped.
+    await log_action_activity(
+        integration_id="6cf5b0eb-4d5d-42e0-9d5c-8b4d9d545c9a",
+        action_id="pull_observations",
+        title="No positions fetched for device 12345",
+        level=LogLevel.WARNING,
+    )
+
+
+@pytest.mark.asyncio
+async def test_activity_logger_decorator_survives_publish_failures(
+        mocker, integration_v2, pull_observations_config
+):
+    mocker.patch(
+        "app.services.activity_logger.publish_event",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    @activity_logger()
+    async def action_pull_observations(integration, action_config):
+        return {"observations_extracted": 10}
+
+    # on_start and on_completion publishes both fail; the action must still
+    # run and its result must come back.
+    result = await action_pull_observations(
+        integration=integration_v2, action_config=pull_observations_config
+    )
+
+    assert result == {"observations_extracted": 10}
+
+
+@pytest.mark.asyncio
+async def test_activity_logger_decorator_preserves_handler_error_when_publish_fails(
+        mocker, integration_v2, pull_observations_config
+):
+    mocker.patch(
+        "app.services.activity_logger.publish_event",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    @activity_logger()
+    async def action_pull_observations(integration, action_config):
+        raise ValueError("malformed device payload")
+
+    # The handler's real error must propagate, not the publish failure.
+    with pytest.raises(ValueError, match="malformed device payload"):
+        await action_pull_observations(
+            integration=integration_v2, action_config=pull_observations_config
+        )
+
+
+@pytest.mark.asyncio
+async def test_trigger_action_publish_failure_still_raises(mocker, integration_v2):
+    """The command path is NOT best-effort: a lost RunIntegrationAction command
+    means the triggered action never runs, so the caller must see the failure
+    (handlers wrap their trigger_action calls in try/except for this)."""
+    from app.services.action_scheduler import trigger_action
+    from app.actions.configurations import BackfillObservationsConfig
+
+    mocker.patch("app.services.action_scheduler.settings.TRIGGER_ACTIONS_ALWAYS_SYNC", False)
+    mocker.patch("app.services.action_scheduler.settings.INTEGRATION_COMMANDS_TOPIC", "test-topic")
+    mocker.patch(
+        "app.services.action_scheduler.publish_event",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await trigger_action(
+            str(integration_v2.id), "backfill_observations",
+            config=BackfillObservationsConfig(triggered_by="pull_observations"),
+        )
+
+
+# --- The runner must not conflate internal timeouts with its own deadline --
+
+
+@pytest.mark.asyncio
+async def test_internal_asyncio_timeout_is_not_labeled_as_action_deadline(
+        mocker, mock_config_manager, mock_publish_event, integration_v2
+):
+    async def handler(integration, action_config):
+        raise asyncio.TimeoutError()  # e.g. redis/aiohttp dependency timeout
+
+    mocker.patch(
+        "app.services.action_runner.action_handlers",
+        {"pull_observations": (handler, MockPullActionConfiguration, None)},
+    )
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+
+    await execute_action(
+        integration_id=str(integration_v2.id), action_id="pull_observations"
+    )
+
+    failed = _failed_events(mock_publish_event)
+    assert failed, "an action failure event must still be published"
+    error_text = failed[-1].payload.error
+    # The handler died ~instantly, nowhere near the deadline — the error must
+    # say so instead of masquerading as the wait_for ceiling.
+    assert "deadline" in error_text
+    assert f"Action 'pull_observations' timed out" not in error_text
+
+
+@pytest.mark.asyncio
+async def test_wait_for_ceiling_is_still_reported_as_timeout(
+        mocker, mock_config_manager, mock_publish_event, integration_v2
+):
+    async def handler(integration, action_config):
+        await asyncio.sleep(5)
+
+    mocker.patch(
+        "app.services.action_runner.action_handlers",
+        {"pull_observations": (handler, MockPullActionConfiguration, None)},
+    )
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.settings.MAX_ACTION_EXECUTION_TIME", 0.2)
+
+    await execute_action(
+        integration_id=str(integration_v2.id), action_id="pull_observations"
+    )
+
+    failed = _failed_events(mock_publish_event)
+    assert failed
+    assert "Action 'pull_observations' timed out" in failed[-1].payload.error

--- a/app/services/tests/test_timeout_resilience.py
+++ b/app/services/tests/test_timeout_resilience.py
@@ -126,7 +126,7 @@ async def test_internal_asyncio_timeout_is_not_labeled_as_action_deadline(
     )
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
 
     await execute_action(
         integration_id=str(integration_v2.id), action_id="pull_observations"
@@ -154,7 +154,7 @@ async def test_wait_for_ceiling_is_still_reported_as_timeout(
     )
     mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
     mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
-    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner._publish_activity_event", mock_publish_event)
     mocker.patch("app.services.action_runner.settings.MAX_ACTION_EXECUTION_TIME", 0.2)
 
     await execute_action(
@@ -164,3 +164,25 @@ async def test_wait_for_ceiling_is_still_reported_as_timeout(
     failed = _failed_events(mock_publish_event)
     assert failed
     assert "Action 'pull_observations' timed out" in failed[-1].payload.error
+
+
+@pytest.mark.asyncio
+async def test_handle_error_survives_publish_failure(
+    mocker, mock_config_manager, integration_v2
+):
+    # Review finding: _handle_error's own IntegrationActionFailed publish went
+    # through raising publish_event — under the exact congestion it reports
+    # on, the publish timeout escaped execute_action, 500'd the route and
+    # caused pubsub redelivery. It must be best-effort like other activity
+    # events (the JSONResponse still carries error_details).
+    from app.services import action_runner
+    mocker.patch.object(action_runner, "config_manager", mock_config_manager)
+    mocker.patch(
+        "app.services.activity_logger.publish_event",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+    response = await action_runner._handle_error(
+        ValueError("boom"), integration_id=str(integration_v2.id), action_id="pull_observations"
+    )
+    assert response.status_code == 500
+    assert b"boom" in response.body

--- a/app/services/tests/test_webhooks.py
+++ b/app/services/tests/test_webhooks.py
@@ -151,7 +151,7 @@ async def test_get_integration_handles_config_manager_exception(
     mock_config_manager.get_integration_details = AsyncMock(side_effect=Exception("Config manager error"))
     
     # Mock the publish_event function
-    mocker.patch("app.services.webhooks.publish_event", mock_publish_event)
+    mocker.patch("app.services.webhooks._publish_activity_event", mock_publish_event)
     
     from app.services.webhooks import get_integration
     from fastapi import Request
@@ -363,7 +363,7 @@ async def test_process_webhook_handles_gundi_api_failure_gracefully(
     mocker.patch("app.services.webhooks.config_manager", config_manager)
     
     # Mock publish_event to capture the error event
-    mocker.patch("app.services.webhooks.publish_event", mock_publish_event)
+    mocker.patch("app.services.webhooks._publish_activity_event", mock_publish_event)
     
     from app.services.webhooks import get_integration
     from fastapi import Request

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -9,7 +9,7 @@ import httpx
 import stamina
 from fastapi import Request
 from app import settings
-from app.services.activity_logger import log_activity, publish_event
+from app.services.activity_logger import log_activity, _publish_activity_event
 from gundi_client_v2 import GundiClient
 from gundi_core.events import IntegrationWebhookFailed, WebhookExecutionFailed
 from app.services.utils import DyntamicFactory
@@ -135,7 +135,7 @@ async def get_integration(request):
         except Exception as e:
             error_message = f"Error retrieving integration '{integration_id}': {type(e).__name__}: {e}"
             logger.exception(error_message)
-            await publish_event(
+            await _publish_activity_event(
                 event=IntegrationWebhookFailed(
                     payload=WebhookExecutionFailed(
                         integration_id=str(integration_id),
@@ -196,7 +196,7 @@ async def process_webhook(request: Request):
             except Exception as e:
                 message = f"Error parsing payload: {type(e).__name__}: {str(e)}. Please review configurations."
                 logger.exception(message)
-                await publish_event(
+                await _publish_activity_event(
                     event=IntegrationWebhookFailed(
                         payload=WebhookExecutionFailed(
                             integration_id=str(integration.id),
@@ -214,7 +214,7 @@ async def process_webhook(request: Request):
     except (ImportError, AttributeError, NotImplementedError) as e:
         message = "Webhooks handler not found. Please implement a 'webhook_handler' function in app/webhooks/handlers.py"
         logger.exception(message)
-        await publish_event(
+        await _publish_activity_event(
             event=IntegrationWebhookFailed(
                 payload=WebhookExecutionFailed(
                     integration_id=str(integration.id),
@@ -227,7 +227,7 @@ async def process_webhook(request: Request):
     except Exception as e:
         message = f"Error processing webhook: {type(e).__name__}: {str(e)}"
         logger.exception(message)
-        await publish_event(
+        await _publish_activity_event(
             event=IntegrationWebhookFailed(
                 payload=WebhookExecutionFailed(
                     integration_id=str(integration.id) if integration else None,


### PR DESCRIPTION
## Problem (prod, 2026-08-16)

After deploying the head-pass redesign, ~19 Lotek integrations stayed unhealthy. GCP logs showed two error families, both congestion signatures:

- **Fake \"Action 'pull_observations' timed out\"** after only 65–142s (the 540s ceiling was never reached): PubSub egress congestion made `publish_event` burn 100–250s per activity event (5 retries × 20s timeout, waits to 60s) and re-raise `asyncio.TimeoutError`, which escaped the `@activity_logger` decorator into `execute_action`'s timeout catch. 300+ publish retries/hour observed.
- **`httpx.ConnectTimeout` from `get_devices`** → ERROR + raise → unhealthy, for a transient reachability blip that self-heals next tick.

Dominant publish volume: a portal WARNING per quiet device per tick (~400 publishes/run on a 424-device integration) — a congestion feedback loop.

## Fix

1. **Activity publishes are best-effort** (`_publish_activity_event`): a dropped event logs a local ERROR and never fails the action. Command publishes (`action_scheduler.trigger_action`) still raise — a lost command means the action never runs. Retry budget 5×20s → 3×10s (~36s worst case).
2. **Honest timeout labels**: `execute_action` disambiguates via elapsed time — only the real 540s deadline reports \"Action timed out\" (504); dependency-raised TimeoutErrors report elapsed time (500).
3. **Transport failures at `get_devices` → WARNING + clean skip** (pull and backfill; backfill releases its lease and suppresses the self-retrigger cascade).
4. **Per-device publish cuts**: quiet-device, transport/5xx, and stale-drop publishes are local-log only. The portal keeps end-of-run summaries (failed devices, deferrals, an aggregated stale-drop WARNING) and permanent-problem ERRORs (data-shape 4xx, delivery, cursor-save).
5. **Review round applied**: `_handle_error`'s own failure publish and the four webhook failure publishes are best-effort too; stale drops aggregate into one portal summary per run.

## Verification

- 230 tests pass (`test_timeout_resilience.py`, `test_transport_failures.py` new).
- Reviewed by gundi-reviewer agent: no critical findings; both pre-merge items (best-effort `_handle_error` publish, stale-drop visibility) addressed in cc49706.
- Two-agent design debate converged on keep-as-committed, with follow-ups below.

## Follow-ups (upstream, not this PR)

- Shared warm `PublisherClient`/session in the action-runner template: today every publish pays a fresh OAuth token fetch + TLS handshake (why maxScale 1→3 helped only modestly).
- Strip `config_data` from activity events (payload + credential hygiene).
- Consecutive-skip escalation for prolonged Lotek outages (skips currently publish complete + WARNING every tick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)