### PR TITLE
feat: land PR #18 (chunked device fetching) onto main (GUNDI-5620)

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -2,6 +2,7 @@ import asyncio
 import httpx
 import logging
 import pydantic
+import time
 
 from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel
@@ -39,7 +40,11 @@ def _get_client() -> httpx.AsyncClient:
     if _client is None:
         _client = httpx.AsyncClient(
             timeout=httpx.Timeout(connect=10.0, read=30.0, write=15.0, pool=5.0),
-            limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
+            # Invariant: max_connections >= cloud_run_concurrency (4) *
+            # handlers.FETCH_CONCURRENCY (5) = 20 peak simultaneous requests.
+            # 32 leaves headroom so bumping either knob doesn't silently start
+            # queuing on the pool (PoolTimeout is breaker-feeding).
+            limits=httpx.Limits(max_connections=32, max_keepalive_connections=10),
         )
     return _client
 
@@ -120,26 +125,54 @@ def _to_utc(val: datetime) -> datetime:
     return val.astimezone(timezone.utc)
 
 
-# Serializes the read-login-store sequence below. Device fetches run with
-# bounded concurrency (handlers.FETCH_CONCURRENCY), so after a 401 clears the
-# cached token, several coroutines can find it missing at once — without the
-# lock each would log in separately, and Lotek logins invalidate the account's
-# previous token, so concurrent logins invalidate each other in a loop. The
-# lock makes one coroutine log in while the rest then read its cached result.
-_token_lock = asyncio.Lock()
+# Serializes the read-login-store sequence below, PER INTEGRATION. Device
+# fetches run with bounded concurrency (handlers.FETCH_CONCURRENCY), so after
+# a 401 clears the cached token, several coroutines can find it missing at
+# once — without the lock each would log in separately, and Lotek logins
+# invalidate the account's previous token, so concurrent logins invalidate
+# each other in a loop. Per-integration (not global) because a login is slow
+# network I/O (connect 10s + read 30s worst case): one integration's re-auth
+# must not stall every other integration's fetches on the worker.
+_token_locks: dict = {}
+# A refused login is cached briefly and re-raised to concurrent waiters:
+# without this, every task in an in-flight chunk performs its own real login
+# attempt against an account that just rejected the password — the exact
+# lockout risk the no-retry policy on LotekUnauthorizedException exists to
+# avoid. The cooldown clears well before the next scheduled run, so fixed
+# credentials are picked up on the following tick.
+_login_rejections: dict = {}
+LOGIN_REJECTION_COOLDOWN_SECONDS = 60.0
+
+
+def _get_token_lock(integration_id: str) -> asyncio.Lock:
+    lock = _token_locks.get(integration_id)
+    if lock is None:
+        lock = _token_locks[integration_id] = asyncio.Lock()
+    return lock
 
 
 async def get_token(integration, auth):
-    async with _token_lock:
+    integration_id = str(integration.id)
+    async with _get_token_lock(integration_id):
+        rejection = _login_rejections.get(integration_id)
+        if rejection is not None:
+            rejected_at, rejection_exc = rejection
+            if time.monotonic() - rejected_at < LOGIN_REJECTION_COOLDOWN_SECONDS:
+                raise rejection_exc
+            del _login_rejections[integration_id]
         saved_token = await state_manager.get_state(
-            str(integration.id),
+            integration_id,
             "pull_observations",
             "token"
         )
         if not saved_token:
-            token = await get_token_from_api(integration, auth)
+            try:
+                token = await get_token_from_api(integration, auth)
+            except LotekUnauthorizedException as e:
+                _login_rejections[integration_id] = (time.monotonic(), e)
+                raise
             await state_manager.set_state(
-                str(integration.id),
+                integration_id,
                 "pull_observations",
                 {"token": token},
                 "token"
@@ -148,6 +181,27 @@ async def get_token(integration, auth):
             token = saved_token.get("token")
 
     return token
+
+
+async def invalidate_token(integration, token):
+    """Compare-and-delete the cached token after a 401 on a data call.
+
+    Unconditional deletion is wrong under concurrent fetches: a slow request
+    still carrying the OLD token can 401 after a peer has already re-logged-in
+    and cached a FRESH one — deleting then would discard the valid token and
+    force another login, which (per Lotek semantics) invalidates the fresh
+    token for every peer mid-request with it. Only delete if the cache still
+    holds the exact token that got the 401.
+    """
+    integration_id = str(integration.id)
+    async with _get_token_lock(integration_id):
+        saved_token = await state_manager.get_state(
+            integration_id, "pull_observations", "token"
+        )
+        if saved_token and saved_token.get("token") == token:
+            await state_manager.delete_state(
+                integration_id, "pull_observations", "token"
+            )
 
 async def get_token_from_api(integration, auth):
     params = {
@@ -191,11 +245,7 @@ async def get_devices(integration, auth):
         if ex.response.status_code == 401:
             msg = "Received status code 401 - Token expired, fetching a new one..."
             logger.info(msg)
-            await state_manager.delete_state(
-                str(integration.id),
-                "pull_observations",
-                "token"
-            )
+            await invalidate_token(integration, token)
             raise LotekTokenExpiredException(message=f"401 Response from Lotek API", error=ex)
         else:
             msg = f'Lotek get_devices failed for user {auth.username}. Caught exception: {ex}'
@@ -236,11 +286,7 @@ async def get_positions(device_id, auth, integration, start_datetime=None, end_d
         if ex.response.status_code == 401:
             msg = "Received status code 401 - Token expired, fetching a new one..."
             logger.info(msg)
-            await state_manager.delete_state(
-                str(integration.id),
-                "pull_observations",
-                "token"
-            )
+            await invalidate_token(integration, token)
             raise LotekTokenExpiredException(message=f"401 Response from Lotek API", error=ex)
 
         msg = f'Lotek get_positions failed for user {auth.username}. Caught exception: {ex}'

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -133,6 +133,10 @@ def _to_utc(val: datetime) -> datetime:
 # each other in a loop. Per-integration (not global) because a login is slow
 # network I/O (connect 10s + read 30s worst case): one integration's re-auth
 # must not stall every other integration's fetches on the worker.
+# Growth bound: keys are integration ids served by THIS connector's worker —
+# a config-bound set (~15 for Lotek), not unbounded user input. Locks are a
+# few hundred bytes each; no eviction needed. Rejection memos are pruned on
+# expiry in get_token.
 _token_locks: dict = {}
 # A refused login is cached briefly and re-raised to concurrent waiters:
 # without this, every task in an in-flight chunk performs its own real login

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import httpx
 import logging
 import pydantic
@@ -119,22 +120,32 @@ def _to_utc(val: datetime) -> datetime:
     return val.astimezone(timezone.utc)
 
 
+# Serializes the read-login-store sequence below. Device fetches run with
+# bounded concurrency (handlers.FETCH_CONCURRENCY), so after a 401 clears the
+# cached token, several coroutines can find it missing at once — without the
+# lock each would log in separately, and Lotek logins invalidate the account's
+# previous token, so concurrent logins invalidate each other in a loop. The
+# lock makes one coroutine log in while the rest then read its cached result.
+_token_lock = asyncio.Lock()
+
+
 async def get_token(integration, auth):
-    saved_token = await state_manager.get_state(
-        str(integration.id),
-        "pull_observations",
-        "token"
-    )
-    if not saved_token:
-        token = await get_token_from_api(integration, auth)
-        await state_manager.set_state(
+    async with _token_lock:
+        saved_token = await state_manager.get_state(
             str(integration.id),
             "pull_observations",
-            {"token": token},
             "token"
         )
-    else:
-        token = saved_token.get("token")
+        if not saved_token:
+            token = await get_token_from_api(integration, auth)
+            await state_manager.set_state(
+                str(integration.id),
+                "pull_observations",
+                {"token": token},
+                "token"
+            )
+        else:
+            token = saved_token.get("token")
 
     return token
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,3 +1,4 @@
+import asyncio
 import httpx
 import logging
 import stamina
@@ -44,6 +45,15 @@ BREAKER_THRESHOLD = 3
 BACKFILL_MAX_WINDOWS_PER_DEVICE = 2
 BACKFILL_WINDOW = timedelta(days=7)
 BACKFILL_LEASE_SOURCE = "lease"
+# Devices are fetched in bounded-concurrency chunks over the shared HTTP
+# client (GUNDI-5620). Sequential fetching put 400-600 Lotek round trips on
+# the action budget one at a time, which is what pushed the big integrations
+# into the MAX_ACTION_EXECUTION_TIME ceiling. Guards (deadline + breaker) are
+# checked between chunks, so their granularity coarsens from 1 device to
+# FETCH_CONCURRENCY devices — with the breaker threshold at 3, a fully-bad
+# chunk overshoots by at most 2 requests. Chunk results are recorded in list
+# order, preserving the sequential consecutive-failure semantics.
+FETCH_CONCURRENCY = 5
 # Head fetches re-cover this much of the cursor's trailing edge: rows whose
 # server-assigned UploadTimeStamp falls inside a window we already queried can
 # become queryable only after our request completed (write latency / clock
@@ -315,45 +325,58 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     # and triggers then, same as the worst-case import delay the design accepts.
     any_open_gap = False
     stale_drops = []
-    for i, (device, state, is_new) in enumerate(device_states):
+    for chunk_start in range(0, len(device_states), FETCH_CONCURRENCY):
         if reason := guards.should_stop():
-            deferred_devices = [d.nDeviceID for d, _, _ in device_states[i:]]
+            deferred_devices = [d.nDeviceID for d, _, _ in device_states[chunk_start:]]
             await _log_deferral(integration, "pull_observations", reason, deferred_devices)
             break
-        try:
-            sent, device_failed, transport_failure = await _head_pass_device(
-                device, state, is_new, integration, auth, action_config, present_time, guards,
-                stale_drops=stale_drops
-            )
-        except LotekUnauthorizedException:
-            raise
-        except Exception as e:
-            # Sending to Gundi and checkpointing can fail too, and a device that fetched
-            # fine but failed downstream must not take the rest of the batch with it.
-            message = (
-                f"Failed to process device {device.nDeviceID} for integration "
-                f"{integration.id}: {describe_exception(e)}"
-            )
-            logger.exception(message)
-            await log_action_activity(
-                integration_id=str(integration.id),
-                action_id="pull_observations",
-                title=message,
-                level=LogLevel.ERROR
-            )
-            failed_devices.append(device.nDeviceID)
-            guards.record(transport_failure=False)
-            continue
-        # Single recording site: transport failures arm the breaker, anything
-        # else (success included) breaks the consecutive streak.
-        guards.record(transport_failure=transport_failure)
-        observations_extracted += sent
-        if state.has_gap:
-            any_open_gap = True
-        if device_failed:
-            failed_devices.append(device.nDeviceID)
-        else:
-            serviced_devices += 1
+        chunk = device_states[chunk_start:chunk_start + FETCH_CONCURRENCY]
+        results = await asyncio.gather(
+            *(
+                _head_pass_device(
+                    device, state, is_new, integration, auth, action_config,
+                    present_time, guards, stale_drops=stale_drops
+                )
+                for device, state, is_new in chunk
+            ),
+            # Collect every task's outcome rather than aborting the chunk on
+            # the first exception: per-device failures must stay per-device.
+            return_exceptions=True,
+        )
+        # Credentials refused is integration-wide and fatal; re-raise it over
+        # any per-device outcomes in the same chunk.
+        for res in results:
+            if isinstance(res, LotekUnauthorizedException):
+                raise res
+        for (device, state, is_new), res in zip(chunk, results):
+            if isinstance(res, BaseException):
+                # Sending to Gundi and checkpointing can fail too, and a device that fetched
+                # fine but failed downstream must not take the rest of the batch with it.
+                message = (
+                    f"Failed to process device {device.nDeviceID} for integration "
+                    f"{integration.id}: {describe_exception(res)}"
+                )
+                logger.error(message, exc_info=res)
+                await log_action_activity(
+                    integration_id=str(integration.id),
+                    action_id="pull_observations",
+                    title=message,
+                    level=LogLevel.ERROR
+                )
+                failed_devices.append(device.nDeviceID)
+                guards.record(transport_failure=False)
+                continue
+            sent, device_failed, transport_failure = res
+            # Single recording site: transport failures arm the breaker, anything
+            # else (success included) breaks the consecutive streak.
+            guards.record(transport_failure=transport_failure)
+            observations_extracted += sent
+            if state.has_gap:
+                any_open_gap = True
+            if device_failed:
+                failed_devices.append(device.nDeviceID)
+            else:
+                serviced_devices += 1
 
     if failed_devices:
         message = (
@@ -846,41 +869,52 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         serviced_devices = 0
         gaps_closed = 0
         windows_advanced_total = 0
-        for i, (device, state) in enumerate(gapped):
+        for chunk_start in range(0, len(gapped), FETCH_CONCURRENCY):
             if reason := guards.should_stop():
-                deferred_devices = [d.nDeviceID for d, _ in gapped[i:]]
+                deferred_devices = [d.nDeviceID for d, _ in gapped[chunk_start:]]
                 await _log_deferral(integration, "backfill_observations", reason, deferred_devices)
                 break
-            try:
-                sent, device_failed, transport_failure, gap_closed, windows_advanced = await _backfill_device(
-                    device, state, integration, auth, pull_config, guards
-                )
-            except LotekUnauthorizedException:
-                raise
-            except Exception as e:
-                message = (
-                    f"Failed to backfill device {device.nDeviceID} for integration "
-                    f"{integration_id}: {describe_exception(e)}"
-                )
-                logger.exception(message)
-                await log_action_activity(
-                    integration_id=integration_id,
-                    action_id="backfill_observations",
-                    title=message,
-                    level=LogLevel.ERROR
-                )
-                failed_devices.append(device.nDeviceID)
-                guards.record(transport_failure=False)
-                continue
-            # Single recording site, mirroring the head-pass loop.
-            guards.record(transport_failure=transport_failure)
-            observations_extracted += sent
-            gaps_closed += int(gap_closed)
-            windows_advanced_total += windows_advanced
-            if device_failed:
-                failed_devices.append(device.nDeviceID)
-            else:
-                serviced_devices += 1
+            chunk = gapped[chunk_start:chunk_start + FETCH_CONCURRENCY]
+            results = await asyncio.gather(
+                *(
+                    _backfill_device(device, state, integration, auth, pull_config, guards)
+                    for device, state in chunk
+                ),
+                # Collect every task's outcome rather than aborting the chunk
+                # on the first exception: per-device failures stay per-device.
+                return_exceptions=True,
+            )
+            # Credentials refused is integration-wide and fatal; re-raise it
+            # over any per-device outcomes in the same chunk.
+            for res in results:
+                if isinstance(res, LotekUnauthorizedException):
+                    raise res
+            for (device, state), res in zip(chunk, results):
+                if isinstance(res, BaseException):
+                    message = (
+                        f"Failed to backfill device {device.nDeviceID} for integration "
+                        f"{integration_id}: {describe_exception(res)}"
+                    )
+                    logger.error(message, exc_info=res)
+                    await log_action_activity(
+                        integration_id=integration_id,
+                        action_id="backfill_observations",
+                        title=message,
+                        level=LogLevel.ERROR
+                    )
+                    failed_devices.append(device.nDeviceID)
+                    guards.record(transport_failure=False)
+                    continue
+                sent, device_failed, transport_failure, gap_closed, windows_advanced = res
+                # Single recording site, mirroring the head-pass loop.
+                guards.record(transport_failure=transport_failure)
+                observations_extracted += sent
+                gaps_closed += int(gap_closed)
+                windows_advanced_total += windows_advanced
+                if device_failed:
+                    failed_devices.append(device.nDeviceID)
+                else:
+                    serviced_devices += 1
 
         if failed_devices:
             message = (

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -344,9 +344,12 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             return_exceptions=True,
         )
         # Credentials refused is integration-wide and fatal; re-raise it over
-        # any per-device outcomes in the same chunk.
+        # any per-device outcomes in the same chunk. Cancellation must also
+        # propagate: with return_exceptions=True a task's CancelledError comes
+        # back as a result, and treating it as a device failure would swallow
+        # shutdown/timeout cancellation and keep the run going.
         for res in results:
-            if isinstance(res, LotekUnauthorizedException):
+            if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
                 raise res
         for (device, state, is_new), res in zip(chunk, results):
             if isinstance(res, BaseException):
@@ -885,9 +888,10 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 return_exceptions=True,
             )
             # Credentials refused is integration-wide and fatal; re-raise it
-            # over any per-device outcomes in the same chunk.
+            # over any per-device outcomes in the same chunk. Cancellation
+            # must also propagate (see the head-pass loop).
             for res in results:
-                if isinstance(res, LotekUnauthorizedException):
+                if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
                     raise res
             for (device, state), res in zip(chunk, results):
                 if isinstance(res, BaseException):

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -35,11 +35,19 @@ def _reset_shared_http_client():
     # it around every test so (a) a test's `mocker.patch(...httpx.AsyncClient)`
     # mock is never cached and leaked into later tests, and (b) no real client
     # outlives the pytest-asyncio event loop it was created on.
+    # Locks and login-rejection memos are also reset: a Lock binds to the
+    # event loop of the first test that CONTENDS it, and pytest-asyncio runs
+    # a fresh loop per test; a cached rejection would leak a fake auth
+    # failure into unrelated tests.
     import app.actions.client as lotek_client
 
     lotek_client._client = None
+    lotek_client._token_locks.clear()
+    lotek_client._login_rejections.clear()
     yield
     lotek_client._client = None
+    lotek_client._token_locks.clear()
+    lotek_client._login_rejections.clear()
 
 
 @pytest.fixture(autouse=True)

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 from gundi_core.schemas.v2 import LogLevel
 from app.actions.handlers import (
     BACKFILL_MAX_WINDOWS_PER_DEVICE,
-    RETRY_ATTEMPTS,
     action_backfill_observations,
 )
 from app.actions.client import LotekDevice, LotekException
@@ -110,19 +109,28 @@ async def test_backfill_does_not_retrigger_while_breaker_is_hot(
     # one that should re-trigger, ~cadence later.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
-    states = {d: _gap_state(days_back_start=5) for d in ("1", "2", "3", "4", "5")}
+    device_ids = ("1", "2", "3", "4", "5", "6", "7", "8")
+    states = {d: _gap_state(days_back_start=5) for d in device_ids}
     get_positions, _, _, _, _ = _setup_backfill_mocks(
-        mocker, mock_redis, _devices("1", "2", "3", "4", "5"), states
+        mocker, mock_redis, _devices(*device_ids), states
     )
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
-    # device 1 succeeds (its 4-day gap closes in one window); 2, 3, 4 exhaust
-    # retries on timeouts and trip the breaker; 5 is deferred with its gap open
-    fail = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS
-    get_positions.side_effect = [[]] + fail * 3
+
+    # Device 1 succeeds (its 4-day gap closes in one window); 2-5 exhaust
+    # retries on timeouts, so the breaker is hot (streak 4 >= 3) at the chunk
+    # boundary and devices 6-8 (chunk 2) are deferred with their gaps open.
+    # Per-device behavior: chunked-concurrent fetching makes the call order
+    # nondeterministic, so an ordered side_effect list would misfire.
+    async def get_positions_side_effect(device_id, *args, **kwargs):
+        if device_id == "1":
+            return []
+        raise httpx.ReadTimeout("")
+
+    get_positions.side_effect = get_positions_side_effect
     result = await action_backfill_observations(
         lotek_integration, BackfillObservationsConfig()
     )
-    assert result["devices_deferred"] == ["5"]
+    assert result["devices_deferred"] == ["6", "7", "8"]
     trigger.assert_not_awaited()
 
 

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -85,6 +85,9 @@ async def test_get_devices_unauthorized_raises(mocker, lotek_integration, auth_c
     exc = httpx.HTTPStatusError("401", request=resp.request, response=resp)
     mock_client = _make_mock_client(raise_exc=exc, method="get")
     mocker.patch("app.actions.client.get_token", return_value="token")
+    # invalidate_token compare-and-deletes: it reads the cached token first and
+    # only deletes when it still matches the one that got the 401.
+    mocker.patch("app.actions.client.state_manager.get_state", return_value={"token": "token"})
     mocker.patch("app.actions.client.state_manager.delete_state", return_value=None)
     mocker.patch("app.actions.client.httpx.AsyncClient", return_value=mock_client)
 
@@ -126,6 +129,9 @@ async def test_get_positions_unauthorized_raises(mocker, lotek_integration, auth
     exc = httpx.HTTPStatusError("401", request=resp.request, response=resp)
     mock_client = _make_mock_client(raise_exc=exc, method="get")
     mocker.patch("app.actions.client.get_token", return_value="token")
+    # invalidate_token compare-and-deletes: it reads the cached token first and
+    # only deletes when it still matches the one that got the 401.
+    mocker.patch("app.actions.client.state_manager.get_state", return_value={"token": "token"})
     mocker.patch("app.actions.client.state_manager.delete_state", return_value=None)
     mocker.patch("app.actions.client.httpx.AsyncClient", return_value=mock_client)
 
@@ -209,3 +215,45 @@ async def test_close_client_closes_and_clears_the_singleton(mocker):
 
     mock_client.aclose.assert_awaited_once()
     assert lotek_client._client is None
+
+
+@pytest.mark.asyncio
+async def test_stale_401_does_not_invalidate_a_fresh_token(mocker, lotek_integration):
+    # A slow request carrying the OLD token can 401 after a peer already
+    # re-logged-in and cached a FRESH one. Deleting then would discard the
+    # valid token and force another login, which (per Lotek semantics)
+    # invalidates the fresh token for every peer mid-request with it.
+    from app.actions import client as lotek_client
+
+    mocker.patch.object(lotek_client.state_manager, "get_state", AsyncMock(return_value={"token": "FRESH"}))
+    delete = mocker.patch.object(lotek_client.state_manager, "delete_state", AsyncMock())
+
+    await lotek_client.invalidate_token(lotek_integration, "STALE")
+    delete.assert_not_awaited()
+
+    await lotek_client.invalidate_token(lotek_integration, "FRESH")
+    delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rejected_login_is_memoized_for_concurrent_waiters(mocker, lotek_integration, auth_config):
+    # Only ONE real login attempt may hit Lotek per run when credentials are
+    # refused — concurrent waiters get the cached rejection re-raised.
+    from app.actions import client as lotek_client
+
+    mocker.patch.object(lotek_client.state_manager, "get_state", AsyncMock(return_value=None))
+    attempts = []
+
+    async def refused(integration, auth):
+        attempts.append(1)
+        raise LotekUnauthorizedException(message="refused", status_code=400)
+
+    mocker.patch.object(lotek_client, "get_token_from_api", refused)
+
+    import asyncio as _asyncio
+    results = await _asyncio.gather(
+        *(lotek_client.get_token(lotek_integration, auth_config) for _ in range(5)),
+        return_exceptions=True,
+    )
+    assert all(isinstance(r, LotekUnauthorizedException) for r in results)
+    assert len(attempts) == 1

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -279,8 +279,10 @@ async def test_action_pull_observations_aborts_when_login_is_rejected(
     with pytest.raises(LotekUnauthorizedException):
         await action_pull_observations(lotek_integration, pull_config)
 
-    assert len(logins) <= FETCH_CONCURRENCY, (
-        f"login attempted beyond the aborting chunk: {len(logins)} attempts"
+    # The rejection memo in get_token means concurrent waiters re-raise the
+    # cached refusal instead of each attempting a real login (lockout risk).
+    assert len(logins) == 1, (
+        f"a refused login must be attempted exactly once per run: {len(logins)} attempts"
     )
 
 

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 from gundi_core.schemas.v2 import LogLevel
 from app.actions.handlers import (
+    FETCH_CONCURRENCY,
     RETRY_ATTEMPTS,
     action_auth,
     action_pull_observations,
@@ -543,7 +544,8 @@ async def test_action_pull_observations_aborts_on_auth_failure(
     with pytest.raises(LotekUnauthorizedException):
         await action_pull_observations(lotek_integration, pull_config)
 
-    assert set(queried) == {"1", "2", "3", "4", "5"}, (
+    first_chunk = {str(i) for i in range(1, FETCH_CONCURRENCY + 1)}
+    assert set(queried) == first_chunk, (
         "should not have dispatched any chunk beyond the aborting one"
     )
 

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -173,9 +173,11 @@ async def test_action_pull_observations_continues_after_one_device_fails(
 
     result = await action_pull_observations(lotek_integration, pull_config)
 
-    # Device 2 exhausts its retries and is given up on, but device 3 is still reached.
-    assert queried[0] == "1"
-    assert queried[-1] == "3"
+    # Device 2 exhausts its retries and is given up on, but devices 1 and 3 are
+    # still serviced. Devices fetch concurrently within a chunk, so only the
+    # per-device call counts are deterministic, not the interleaving.
+    assert queried.count("1") == 1
+    assert queried.count("3") == 1
     assert queried.count("2") == RETRY_ATTEMPTS
     assert result == {"observations_extracted": 2, "devices_failed": ["2"], "devices_deferred": []}
     assert mock_send.call_count == 2
@@ -248,12 +250,16 @@ async def test_action_pull_observations_aborts_when_login_is_rejected(
 ):
     # A rejected login is integration-wide. It reaches the handler from inside
     # get_positions (cached token expires mid-run), and must not be retried once per
-    # device against a rejecting endpoint.
+    # device against a rejecting endpoint. Devices fetch concurrently in chunks of
+    # FETCH_CONCURRENCY, so the tightest stop the loop can offer is the chunk
+    # boundary: at most one chunk's worth of devices may attempt a login before
+    # the abort — later chunks must never dispatch.
+    from app.actions.handlers import FETCH_CONCURRENCY
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     mocker.patch("app.services.state.redis", mock_redis)
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
-    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3", "4", "5", "6", "7", "8")))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
 
@@ -273,7 +279,9 @@ async def test_action_pull_observations_aborts_when_login_is_rejected(
     with pytest.raises(LotekUnauthorizedException):
         await action_pull_observations(lotek_integration, pull_config)
 
-    assert len(logins) <= RETRY_ATTEMPTS, f"login retried per device: {len(logins)} attempts"
+    assert len(logins) <= FETCH_CONCURRENCY, (
+        f"login attempted beyond the aborting chunk: {len(logins)} attempts"
+    )
 
 
 @pytest.mark.asyncio
@@ -509,13 +517,16 @@ async def test_action_pull_observations_aborts_on_auth_failure(
     mocker, lotek_integration, pull_config, mock_redis
 ):
     # Bad credentials affect every device, so the run must stop instead of
-    # repeating the same failure once per device.
+    # repeating the same failure once per device. Devices fetch concurrently in
+    # chunks of FETCH_CONCURRENCY, so the whole first chunk is already in flight
+    # when the rejection surfaces — the guarantee is that no later chunk
+    # dispatches.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     mocker.patch("app.services.state.redis", mock_redis)
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
     mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
-    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3")))
+    mocker.patch("app.actions.client.get_devices", new=AsyncMock(return_value=_devices("1", "2", "3", "4", "5", "6", "7", "8")))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
 
@@ -530,7 +541,9 @@ async def test_action_pull_observations_aborts_on_auth_failure(
     with pytest.raises(LotekUnauthorizedException):
         await action_pull_observations(lotek_integration, pull_config)
 
-    assert set(queried) == {"1"}, "should not have moved on to other devices"
+    assert set(queried) == {"1", "2", "3", "4", "5"}, (
+        "should not have dispatched any chunk beyond the aborting one"
+    )
 
 
 @pytest.mark.asyncio
@@ -584,7 +597,7 @@ async def test_action_pull_observations_isolates_persistent_401_on_one_device(
 
     result = await action_pull_observations(lotek_integration, pull_config)
 
-    assert queried[-1] == "3", "devices after the 401 device were never queried"
+    assert "3" in queried, "devices after the 401 device were never queried"
     assert result["devices_failed"] == ["2"]
 
 
@@ -963,7 +976,15 @@ async def test_transient_fetch_failure_logs_warning_not_error(
     get_positions, _, set_state, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1", "2")
     )
-    get_positions.side_effect = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS + [[]]
+
+    # Per-device behavior: chunked-concurrent fetching makes the call order
+    # nondeterministic, so an ordered side_effect list would misfire.
+    async def get_positions_side_effect(device_id, *args, **kwargs):
+        if device_id == "1":
+            raise httpx.ReadTimeout("")
+        return []
+
+    get_positions.side_effect = get_positions_side_effect
     result = await action_pull_observations(lotek_integration, pull_config)
     assert result["devices_failed"] == ["1"]
     # Transport failures are local-log only; the end-of-run summary is the
@@ -1050,15 +1071,22 @@ async def test_deadline_defers_remaining_devices_with_warning(
     mocker, lotek_integration, pull_config, mock_redis
 ):
     # Past ~80% of the action budget we stop STARTING device work and exit in
-    # control — never via the asyncio.wait_for guillotine. Call order per
-    # device: should_stop() then _fetch_retry_kwargs(), hence the side_effect
-    # sequence [False(stop d1), False(retry d1), True(stop d2)].
-    _, _, _, log = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2", "3"))
+    # control — never via the asyncio.wait_for guillotine. The deadline is
+    # checked at chunk boundaries (devices fetch concurrently in chunks of
+    # FETCH_CONCURRENCY=5), so with 8 devices the calls are: should_stop()
+    # before chunk 1, then _fetch_retry_kwargs() once per device in the chunk
+    # (5), then should_stop() before chunk 2 — where the deadline hits and
+    # devices 6-8 are deferred.
+    import itertools
+    _, _, _, log = _setup_pull_mocks(
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5", "6", "7", "8")
+    )
     mocker.patch(
-        "app.actions.handlers._deadline_exceeded", side_effect=[False, False, True]
+        "app.actions.handlers._deadline_exceeded",
+        side_effect=itertools.chain([False] * 6, itertools.repeat(True)),
     )
     result = await action_pull_observations(lotek_integration, pull_config)
-    assert result["devices_deferred"] == ["2", "3"]
+    assert result["devices_deferred"] == ["6", "7", "8"]
     assert result["devices_failed"] == []
     deferral_logs = [
         c for c in log.await_args_list
@@ -1094,18 +1122,29 @@ def test_deadline_fraction_of_budget():
 async def test_breaker_trips_after_three_consecutive_transport_failures(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # 3 consecutive timeouts = Lotek-wide degradation: stop early, defer the
+    # 3+ consecutive timeouts = Lotek-wide degradation: stop early, defer the
     # rest (WARNING), instead of grinding every device into the same wall.
+    # The breaker is checked at chunk boundaries (devices fetch concurrently in
+    # chunks of FETCH_CONCURRENCY=5), so the whole first chunk runs — the
+    # streak overshoots the threshold within the chunk — and deferral starts
+    # at the next chunk: devices 6-8 are never dispatched.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     get_positions, _, _, log = _setup_pull_mocks(
-        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5", "6", "7", "8")
     )
-    # device 1 succeeds; 2,3,4 exhaust retries on timeouts; 5 must be deferred
-    get_positions.side_effect = [[]] + [httpx.ReadTimeout("")] * (3 * RETRY_ATTEMPTS)
+
+    # device 1 succeeds; 2-5 exhaust retries on timeouts (streak 4 >= 3 at the
+    # chunk boundary); 6-8 must be deferred
+    async def get_positions_side_effect(device_id, *args, **kwargs):
+        if device_id == "1":
+            return []
+        raise httpx.ReadTimeout("")
+
+    get_positions.side_effect = get_positions_side_effect
     result = await action_pull_observations(lotek_integration, pull_config)
-    assert result["devices_failed"] == ["2", "3", "4"]
-    assert result["devices_deferred"] == ["5"]
+    assert result["devices_failed"] == ["2", "3", "4", "5"]
+    assert result["devices_deferred"] == ["6", "7", "8"]
     breaker_logs = [
         c for c in log.await_args_list
         if c.kwargs["level"] == LogLevel.WARNING and "circuit breaker" in c.kwargs["title"].lower()
@@ -1118,13 +1157,21 @@ async def test_breaker_counter_resets_on_success(
     mocker, lotek_integration, pull_config, mock_redis
 ):
     # Failures interleaved with successes are per-device noise, not an outage.
+    # Chunk results are recorded in list order, so chunk 1 (devices 1-5) plays
+    # F S F S F: three failures but a max streak of 1 — without the reset the
+    # streak would be 3 at the chunk boundary and device 6 would be deferred.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     get_positions, _, _, _ = _setup_pull_mocks(
-        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5", "6")
     )
-    fail = [httpx.ReadTimeout("")] * RETRY_ATTEMPTS
-    get_positions.side_effect = fail + [[]] + fail + [[]] + fail  # F S F S F
+
+    async def get_positions_side_effect(device_id, *args, **kwargs):
+        if device_id in ("1", "3", "5"):
+            raise httpx.ReadTimeout("")
+        return []
+
+    get_positions.side_effect = get_positions_side_effect
     result = await action_pull_observations(lotek_integration, pull_config)
     assert result["devices_deferred"] == []
     assert result["devices_failed"] == ["1", "3", "5"]
@@ -1338,20 +1385,21 @@ async def test_lotek_5xx_failures_feed_the_circuit_breaker(
     # fell into the generic handler, which RESET the breaker streak — an
     # HTTP-error outage could never trip the breaker and the run ground
     # through every device. 5xx/429 must arm the breaker like timeouts.
-    from app.actions.handlers import BREAKER_THRESHOLD
+    from app.actions.handlers import FETCH_CONCURRENCY
     get_positions, _, _, log = _setup_pull_mocks(
-        mocker, mock_redis, _devices("1", "2", "3", "4", "5")
+        mocker, mock_redis, _devices("1", "2", "3", "4", "5", "6", "7", "8")
     )
     get_positions.side_effect = LotekException(message="down", status_code=503)
     with pytest.raises(LotekException, match="No devices could be serviced"):
         await action_pull_observations(lotek_integration, pull_config)
-    # breaker trips after 3 consecutive 503s; devices 4 and 5 are deferred
+    # the first chunk's 5 consecutive 503s trip the breaker at the chunk
+    # boundary; devices 6-8 (chunk 2) are deferred and never dispatched
     deferral_logs = [
         c for c in log.await_args_list
         if "circuit breaker" in c.kwargs.get("title", "").lower()
     ]
     assert len(deferral_logs) == 1
-    assert get_positions.await_count == BREAKER_THRESHOLD
+    assert get_positions.await_count == FETCH_CONCURRENCY
     # Outage (5xx/429) failures are local-log only (publish-volume fix): no
     # per-device portal publishes, and in particular no ERRORs.
     device_logs = [c for c in log.await_args_list if "Device:" in c.kwargs.get("title", "")]
@@ -1453,10 +1501,20 @@ async def test_fetch_error_publish_failure_stays_contained_to_the_device(
     # handlers was unguarded — a pubsub blip escaped the per-device isolation
     # and reset the breaker streak with a failure that says nothing about
     # Lotek. It must be best-effort like the other per-device publishes.
+    mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
+    mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     get_positions, _, _, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1", "2")
     )
-    get_positions.side_effect = [httpx.ReadTimeout(""), httpx.ReadTimeout(""), []]
+
+    # Per-device behavior: chunked-concurrent fetching makes the call order
+    # nondeterministic. Device 1 times out through both retry attempts.
+    async def get_positions_side_effect(device_id, *args, **kwargs):
+        if device_id == "1":
+            raise httpx.ReadTimeout("")
+        return []
+
+    get_positions.side_effect = get_positions_side_effect
 
     async def flaky_publish(**kwargs):
         if "Error fetching positions" in kwargs.get("title", ""):


### PR DESCRIPTION
#18 was merged while its base still pointed at `feat/GUNDI-5620-shared-http-client` (the base was never retargeted after #17 merged), so its changes never reached `main` — the 21:51Z prod deploy rebuilt PR #17-only code under a new tag. This PR carries exactly #18's commits to `main`; the diff vs main is identical to what was reviewed and approved there (concurrent chunked fetching, token-lifecycle hardening, Copilot fixes — see #18 for the full description, review trail, and the clean stage run). 234 tests passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)