### PR TITLE
feat: shard the head pass into per-device-batch sub-actions (GUNDI-5620)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ sample-docs
 local/docker-compose.override.yml
 local/.env
 local/.env.prod-peninsula
+
+# SDD scratch workspace (ledger, briefs, review packages)
+.superpowers/

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,6 +1,6 @@
 import pydantic
 
-from typing import Optional
+from typing import List, Optional
 
 from .core import (
     AuthActionConfiguration,
@@ -69,6 +69,26 @@ class PullObservationsConfig(PullActionConfiguration, ExecutableActionMixin):
             "max_pdop",
             "run_on_schedule",
         ],
+    )
+
+
+class PullObservationsShardConfig(InternalActionConfiguration):
+    """Internal-only: one shard of the head pass (GUNDI-5620). The scheduled
+    pull_observations action only lists devices and dispatches shards; each
+    shard invocation gets its own MAX_ACTION_EXECUTION_TIME budget, so a large
+    account's fleet no longer has to fit one 540s window. The devices list is
+    always non-empty, which also keeps the config_overrides payload non-empty
+    (see BackfillObservationsConfig for why that matters)."""
+    devices: List[str] = pydantic.Field(
+        ...,
+        min_items=1,
+        title="Devices",
+        description="Device ids this shard is responsible for.",
+    )
+    triggered_by: str = pydantic.Field(
+        "pull_observations",
+        title="Triggered By",
+        description="Which action triggered this shard.",
     )
 
 

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -90,6 +90,15 @@ class PullObservationsShardConfig(InternalActionConfiguration):
         title="Triggered By",
         description="Which action triggered this shard.",
     )
+    manual_run: bool = pydantic.Field(
+        False,
+        title="Manual Run",
+        description=(
+            "True when the dispatching pull_observations run was operator-"
+            "triggered while the integration is paused; exempts this shard "
+            "from the pause skip so the portal's Trigger button still pulls."
+        ),
+    )
     generation: int = pydantic.Field(
         0,
         ge=0,

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -129,3 +129,12 @@ class BackfillObservationsConfig(InternalActionConfiguration):
         title="Triggered By",
         description="Which action triggered this backfill run.",
     )
+    manual_run: bool = pydantic.Field(
+        False,
+        title="Manual Run",
+        description=(
+            "True when this backfill descends from an operator-triggered head "
+            "pass on a paused integration; exempts it from the pause skip so a "
+            "manual run imports history instead of stopping at the head window."
+        ),
+    )

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -90,6 +90,17 @@ class PullObservationsShardConfig(InternalActionConfiguration):
         title="Triggered By",
         description="Which action triggered this shard.",
     )
+    generation: int = pydantic.Field(
+        0,
+        ge=0,
+        title="Generation",
+        description=(
+            "Re-trigger hop count. The dispatcher publishes generation 0; each "
+            "deferred-tail re-trigger increments it. Capped in the handler so a "
+            "shard that keeps deferring falls back to the next scheduled tick "
+            "instead of looping."
+        ),
+    )
 
 
 class BackfillObservationsConfig(InternalActionConfiguration):

--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -40,6 +40,12 @@ class ExecutableActionMixin:
     pass
 
 
+def describe_exception(exc):
+    # httpx timeout exceptions carry an empty message, which used to render as a bare
+    # "Exception: " in the activity log and told operators nothing.
+    return str(exc) or type(exc).__name__
+
+
 def action_title(title: str):
     """Set the display name used when registering the action in Gundi,
     instead of the default derived from the handler function name."""

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -336,6 +336,10 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             title=message,
             level=LogLevel.WARNING
         )
+        # Any non-starved outcome breaks the "consecutive" skip streak — a
+        # transport skip between two slot skips must not let them read as
+        # adjacent (review finding).
+        await _reset_dispatcher_skip_streak(integration_id)
         return {
             "devices_found": 0,
             "shards_triggered": 0,
@@ -380,13 +384,54 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     staleness.sort(key=lambda entry: entry[1])
     device_ids = [device_id for device_id, _ in staleness]
 
+    # Manual-run marker: the runner's pause check only skips SCHEDULED runs,
+    # so if this dispatcher is executing while run_on_schedule is off, the run
+    # is manual — the shards it publishes are machine-triggered and would
+    # otherwise skip on the pause, silently breaking the portal's Trigger
+    # button for the whole head pass (review finding).
+    manual_run = not action_config.run_on_schedule
+
+    # Per-shard guard (review finding): an unguarded loop let one pubsub blip
+    # abort every remaining shard AND escape through the runner's generic
+    # error handler (whose ERROR event embeds the integration's full config,
+    # auth included). Failures are collected, not fatal — the next tick
+    # re-lists and re-shards everything.
     shards = list(generate_batches(device_ids, SHARD_SIZE))
+    dispatched = 0
+    undispatched_devices = []
     for shard in shards:
-        await trigger_action(
-            integration_id, "pull_observations_shard",
-            config=PullObservationsShardConfig(devices=shard, triggered_by="pull_observations")
+        try:
+            await trigger_action(
+                integration_id, "pull_observations_shard",
+                config=PullObservationsShardConfig(
+                    devices=shard, triggered_by="pull_observations", manual_run=manual_run
+                )
+            )
+            dispatched += 1
+        except Exception as e:
+            undispatched_devices.extend(shard)
+            logger.warning(
+                f"Could not dispatch a shard of {len(shard)} device(s) for integration "
+                f"{integration_id}: {describe_exception(e)}"
+            )
+    if undispatched_devices:
+        message = (
+            f"Dispatched {dispatched} of {len(shards)} shard(s) for integration "
+            f"{integration_id}; {len(undispatched_devices)} device(s) get no pull this "
+            f"tick and are retried on the next schedule: {_summarize_ids(undispatched_devices)}."
         )
-    return {"devices_found": len(device_list), "shards_triggered": len(shards)}
+        logger.warning(message)
+        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.WARNING)
+    if shards and dispatched == 0:
+        # Nothing was handed off at all: systemic (commands topic down), must
+        # alert rather than publish action_complete.
+        raise LotekException(
+            message=(
+                f"Could not dispatch any of {len(shards)} shard(s) for integration "
+                f"{integration_id}; see the application log for the publish errors."
+            )
+        )
+    return {"devices_found": len(device_list), "shards_triggered": dispatched}
 
 
 async def _bump_dispatcher_skip_streak(integration_id):
@@ -419,7 +464,7 @@ async def _reset_dispatcher_skip_streak(integration_id):
         )
 
 
-async def _retrigger_shard(integration, device_ids, generation):
+async def _retrigger_shard(integration, device_ids, generation, manual_run=False):
     """Re-dispatch deferred devices as a fresh shard with its own budget,
     instead of parking them until the next scheduled tick.
 
@@ -454,6 +499,7 @@ async def _retrigger_shard(integration, device_ids, generation):
                 devices=device_ids,
                 triggered_by="pull_observations_shard",
                 generation=generation + 1,
+                manual_run=manual_run,
             )
         )
         return True
@@ -487,9 +533,13 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
         )
         return {"skipped": True, "reason": "configuration_missing"}
 
-    if not pull_config.run_on_schedule:
+    if not pull_config.run_on_schedule and not action_config.manual_run:
         # The operator's pause toggle must also stop the shard cascade:
         # internal actions bypass the runner's skippable_pull pause check.
+        # manual_run exempts shards belonging to a portal-triggered run — the
+        # runner only pauses SCHEDULED runs, and without the exemption a
+        # manual Trigger on a paused integration dispatched shards that all
+        # skipped, showing success while pulling nothing (review finding).
         logger.info(f"Integration {integration_id} is paused (run_on_schedule=false); skipping shard.")
         return {"skipped": True, "reason": "integration_paused"}
 
@@ -523,7 +573,8 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             # exists to buy. Its devices wait for the next scheduled tick.
             if reason == "deadline":
                 retriggered = await _retrigger_shard(
-                    integration, deferred_devices, action_config.generation
+                    integration, deferred_devices, action_config.generation,
+                    manual_run=action_config.manual_run,
                 )
             disposition = (
                 "to an immediately re-triggered shard" if retriggered
@@ -597,12 +648,21 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
                 device_id for device_id, _, _ in device_states[chunk_start + FETCH_CONCURRENCY:]
             ]
             budget_starved = True
-            logger.info(
-                f"Deferring {len(deferred_devices)} device(s) for integration {integration_id}: "
-                f"Lotek connection budget exhausted."
-            )
             retriggered = await _retrigger_shard(
-                integration, deferred_devices, action_config.generation
+                integration, deferred_devices, action_config.generation,
+                manual_run=action_config.manual_run,
+            )
+            # Portal WARNING like every other deferral cause (review finding:
+            # this branch was logger.info only, so a starved tail whose
+            # re-trigger also failed parked with zero portal visibility —
+            # contradicting the zero-progress comment's claim).
+            await _log_deferral(
+                integration, "pull_observations_shard", "connection budget exhausted",
+                deferred_devices,
+                disposition=(
+                    "to an immediately re-triggered shard" if retriggered
+                    else "to the next scheduled run"
+                ),
             )
             break
 
@@ -648,7 +708,8 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
         # budget back-off, not degradation (mirrors backfill's budget_starved;
         # review finding — the old condition flipped a starvation + pubsub
         # blip into a false systemic ERROR). Starvation visibility comes from
-        # the deferral WARNING and the re-trigger cap's ERROR instead.
+        # the _log_deferral WARNING on the starved branch and the re-trigger
+        # cap's ERROR instead.
         raise LotekException(
             message=(
                 f"No devices could be serviced for integration {integration.id}: "
@@ -894,7 +955,7 @@ async def _head_pass_device(device_id, state, is_new, integration, auth, action_
 
     lower_date = max(state.high_water - HEAD_LATE_UPLOAD_OVERLAP, freshness_floor)
     cdip_positions, transport_failure = await _fetch_window(
-        device_id, integration, auth, action_config, lower_date, present_time, guards, "pull_observations"
+        device_id, integration, auth, action_config, lower_date, present_time, guards, "pull_observations_shard"
     )
     if cdip_positions is None:
         return 0, True, transport_failure
@@ -906,7 +967,7 @@ async def _head_pass_device(device_id, state, is_new, integration, auth, action_
         # contributor to the publish congestion behind GUNDI-5602.
         logger.info(f"No positions fetched for device {device_id} integration ID: {integration.id}.")
 
-    observations_sent, delivery_failed = await _deliver(cdip_positions, device_id, integration, "pull_observations")
+    observations_sent, delivery_failed = await _deliver(cdip_positions, device_id, integration, "pull_observations_shard")
     if delivery_failed:
         # The breaker watches Lotek, not Gundi: a delivery failure is not
         # evidence of Lotek-wide degradation.
@@ -938,7 +999,7 @@ async def _head_pass_device(device_id, state, is_new, integration, auth, action_
             f"{integration.id} Exception: {describe_exception(e)}"
         )
         logger.exception(message)
-        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.ERROR)
+        await _try_log_activity(integration_id, "pull_observations_shard", message, LogLevel.ERROR)
         return observations_sent, True, False
 
     if stale_from is not None:
@@ -1189,9 +1250,9 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                     d.nDeviceID for d, _ in gapped[chunk_start + FETCH_CONCURRENCY:]
                 ]
                 budget_starved = True
-                logger.info(
-                    f"Deferring {len(deferred_devices)} gapped device(s) for integration "
-                    f"{integration_id}: Lotek connection budget exhausted."
+                await _log_deferral(
+                    integration, "backfill_observations", "connection budget exhausted",
+                    deferred_devices, disposition="to the next backfill trigger",
                 )
                 break
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -51,20 +51,15 @@ BREAKER_THRESHOLD = 3
 BACKFILL_MAX_WINDOWS_PER_DEVICE = 2
 BACKFILL_WINDOW = timedelta(days=7)
 BACKFILL_LEASE_SOURCE = "lease"
-# Devices are fetched in bounded-concurrency chunks over the shared HTTP
-# client (GUNDI-5620). Sequential fetching put 400-600 Lotek round trips on
-# the action budget one at a time, which is what pushed the big integrations
-# into the MAX_ACTION_EXECUTION_TIME ceiling. Guards (deadline + breaker) are
-# checked between chunks, so their granularity coarsens from 1 device to
-# FETCH_CONCURRENCY devices — with the breaker threshold at 3, a fully-bad
-# chunk overshoots by at most 2 requests. Chunk results are recorded in list
-# order, preserving the sequential consecutive-failure semantics.
+# How many devices one invocation processes per chunk. WORK PARTITIONING, not a
+# concurrency limit: the account-wide ceiling is LOTEK_MAX_CONNECTIONS, enforced
+# in Redis by lotek_slot, which now WAITS rather than refusing. Chunk size may
+# freely oversubscribe that ceiling — the budget applies backpressure (spec D1).
 FETCH_CONCURRENCY = 5
-# Sharded head pass (GUNDI-5620, movebank-connector pattern): the scheduled
-# pull_observations only lists devices and dispatches shards of this many
-# device ids as pull_observations_shard sub-actions, each with its own action
-# budget. Sized so a shard finishes comfortably inside one budget even on a
-# slow tick (25 devices / FETCH_CONCURRENCY = 5 chunks of round trips).
+# How much work fits in one action budget, i.e. how the dispatcher partitions
+# the fleet across sub-actions. WORK PARTITIONING, not a concurrency limit —
+# see FETCH_CONCURRENCY. Do not shrink this to "fit" LOTEK_MAX_CONNECTIONS;
+# that reintroduces the coupling spec D1 removed.
 SHARD_SIZE = 25
 # Re-trigger governor (review finding, PR #20 discussion): a deferred tail may
 # hop to a fresh shard at most this many times before falling back to the next

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -20,8 +20,9 @@ from app.actions.configurations import (
     PullObservationsConfig,
     PullObservationsShardConfig,
 )
-from app.actions.core import action_title
+from app.actions.core import action_title, describe_exception
 from app.actions.device_state import DeviceState
+from app.actions.traversal import DeviceTraversal
 from app.services.action_scheduler import trigger_action
 from app.services.lotek_connections import lotek_slot, NoConnectionSlot
 from app.services.activity_logger import activity_logger, log_action_activity
@@ -187,12 +188,6 @@ async def _try_log_activity(integration_id, action_id, title, level):
         logger.warning(
             f"Could not publish activity log for integration {integration_id}: {describe_exception(e)}"
         )
-
-
-def describe_exception(exc):
-    # httpx timeout exceptions carry an empty message, which used to render as a bare
-    # "Exception: " in the activity log and told operators nothing.
-    return str(exc) or type(exc).__name__
 
 
 def generate_batches(iterable, n=settings.OBSERVATIONS_BATCH_SIZE):
@@ -602,110 +597,60 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
     device_states.sort(key=lambda entry: entry[1].high_water)
 
     guards = RunGuards(run_started)
+    traversal = DeviceTraversal(
+        integration, "pull_observations_shard", guards, concurrency=FETCH_CONCURRENCY
+    )
     observations_extracted = 0
-    failed_devices = []
-    deferred_devices = []
-    retriggered = False
-    budget_starved = False
-    cap_reached = False
-    serviced_devices = 0
+    stale_drops = []
     # Only reflects devices actually processed this run — a device deferred by
     # the rails before its gap status is checked doesn't trigger backfill this
     # cycle. Self-correcting: the re-triggered tail (or the next tick) reaches it.
     any_open_gap = False
-    stale_drops = []
-    for chunk_start in range(0, len(device_states), FETCH_CONCURRENCY):
-        if reason := guards.should_stop():
-            deferred_devices = [device_id for device_id, _, _ in device_states[chunk_start:]]
-            # A deadline cut gets a fresh budget immediately; a hot breaker
-            # does NOT re-trigger — that would defeat the pause the breaker
-            # exists to buy. Its devices wait for the next scheduled tick.
-            if reason == "deadline":
-                outcome = await _retrigger_shard(
-                    integration, deferred_devices, action_config.generation,
-                    manual_run=action_config.manual_run,
-                )
-                retriggered = outcome == RETRIGGER_HANDED_OFF
-                # A cap-reached deferral already alerted at ERROR; suppress the
-                # zero-progress alert so one load event yields one signal.
-                cap_reached = outcome == RETRIGGER_CAP_REACHED
-            disposition = (
-                "to an immediately re-triggered shard" if retriggered
-                else "to the next scheduled run"
-            )
-            await _log_deferral(
-                integration, "pull_observations_shard", reason, deferred_devices,
-                disposition=disposition,
-            )
-            break
-        chunk = device_states[chunk_start:chunk_start + FETCH_CONCURRENCY]
-        results = await asyncio.gather(
-            *(
-                _head_pass_device(
-                    device_id, state, is_new, integration, auth, pull_config,
-                    present_time, guards, stale_drops=stale_drops
-                )
-                for device_id, state, is_new in chunk
-            ),
-            # Collect every task's outcome rather than aborting the chunk on
-            # the first exception: per-device failures must stay per-device.
-            return_exceptions=True,
-        )
-        # Credentials refused is integration-wide and fatal; re-raise it over
-        # any per-device outcomes in the same chunk. Cancellation must also
-        # propagate: with return_exceptions=True a task's CancelledError comes
-        # back as a result, and treating it as a device failure would swallow
-        # shutdown/timeout cancellation and keep the run going.
-        for res in results:
-            if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
-                raise res
-        slot_starved = []
-        for (device_id, state, is_new), res in zip(chunk, results):
-            if isinstance(res, NoConnectionSlot):
-                # Account connection budget exhausted: not a device failure and
-                # not evidence about Lotek — defer this device with the rest of
-                # the shard and re-trigger (the pubsub round trip is the backoff,
-                # movebank-connector pattern).
-                slot_starved.append(device_id)
-                continue
-            if isinstance(res, BaseException):
-                # Sending to Gundi and checkpointing can fail too, and a device that fetched
-                # fine but failed downstream must not take the rest of the batch with it.
-                message = (
-                    f"Failed to process device {device_id} for integration "
-                    f"{integration.id}: {describe_exception(res)}"
-                )
-                logger.error(message, exc_info=res)
-                await log_action_activity(
-                    integration_id=integration_id,
-                    action_id="pull_observations_shard",
-                    title=message,
-                    level=LogLevel.ERROR
-                )
-                failed_devices.append(device_id)
-                guards.record(transport_failure=False)
-                continue
-            sent, device_failed, transport_failure = res
-            # Single recording site: transport failures arm the breaker, anything
-            # else (success included) breaks the consecutive streak.
-            guards.record(transport_failure=transport_failure)
-            observations_extracted += sent
-            if state.has_gap:
-                any_open_gap = True
-            if device_failed:
-                failed_devices.append(device_id)
-            else:
-                serviced_devices += 1
-        if slot_starved:
-            # Defer ONLY the devices that lost the slot race — their in-chunk
-            # peers keep their results and later chunks still run (spec D3).
-            # Before this, one starved device aborted the shard's entire tail,
-            # which on an oversubscribed fan-out made mass deferral the normal
-            # outcome rather than an exceptional one (review finding).
-            deferred_devices.extend(slot_starved)
-            budget_starved = True
 
-    if budget_starved:
+    async for (device_id, state, is_new), res in traversal.run(
+        device_states,
+        key=lambda entry: entry[0],
+        process=lambda entry: _head_pass_device(
+            entry[0], entry[1], entry[2], integration, auth, pull_config,
+            present_time, guards, stale_drops=stale_drops,
+        ),
+    ):
+        sent, device_failed, transport_failure = res
+        # Single recording site: transport failures arm the breaker, anything
+        # else (success included) breaks the consecutive streak.
+        guards.record(transport_failure=transport_failure)
+        observations_extracted += sent
+        if state.has_gap:
+            any_open_gap = True
+        if device_failed:
+            traversal.mark_failed(device_id)
+
+    failed_devices = traversal.failed_devices
+    deferred_devices = traversal.deferred_devices
+
+    # Policy, deliberately NOT in the traversal (spec D6): a deadline cut gets a
+    # fresh budget immediately; a hot breaker does NOT re-trigger — that would
+    # defeat the pause the breaker exists to buy. Its devices wait for the next
+    # scheduled tick.
+    retrigger_outcome = None
+    if traversal.stop_reason == "deadline" and deferred_devices:
+        retrigger_outcome = await _retrigger_shard(
+            integration, deferred_devices, action_config.generation,
+            manual_run=action_config.manual_run,
+        )
+    if traversal.stop_reason:
+        await _log_deferral(
+            integration, "pull_observations_shard", traversal.stop_reason,
+            deferred_devices,
+            disposition=(
+                "to an immediately re-triggered shard"
+                if retrigger_outcome == RETRIGGER_HANDED_OFF
+                else "to the next scheduled run"
+            ),
+        )
+    if traversal.budget_starved:
+        # Portal WARNING like every other deferral cause: a starved tail must
+        # not park with zero portal visibility (review finding).
         await _log_deferral(
             integration, "pull_observations_shard", "connection budget exhausted",
             deferred_devices, disposition="to the next scheduled run",
@@ -743,9 +688,19 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             level=LogLevel.WARNING
         )
 
+    # Suppression policy, preserved EXACTLY as it was before the traversal
+    # existed: a successful hand-off, a cap-reached deferral (which already
+    # alerted at ERROR inside _retrigger_shard), or slot starvation all explain
+    # the lack of progress. A BREAKER stop deliberately does not — a Lotek-wide
+    # outage must still raise the zero-progress ERROR that the cdip health
+    # metric counts.
+    deferred_cleanly = (
+        retrigger_outcome in (RETRIGGER_HANDED_OFF, RETRIGGER_CAP_REACHED)
+        or traversal.budget_starved
+    )
     zero_progress = (
-        device_states and serviced_devices == 0 and observations_extracted == 0
-        and not retriggered and not budget_starved and not cap_reached
+        device_states and traversal.serviced_devices == 0
+        and observations_extracted == 0 and not deferred_cleanly
     )
     if zero_progress:
         # Zero progress: nothing serviced, nothing delivered, and no deferred

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -729,6 +729,8 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
         )
 
     if any_open_gap and not zero_progress:
+        claimed = False
+        published = False
         try:
             # Atomic per-window claim first: concurrent shards all reach this
             # point within seconds of each other, and the lease below is only
@@ -760,11 +762,29 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
                         manual_run=action_config.manual_run,
                     )
                 )
+                published = True
         except Exception as e:
             # The shard succeeded; a failed trigger must not fail the run.
             logger.warning(
                 f"Could not trigger backfill for integration {integration.id}: {describe_exception(e)}"
             )
+        finally:
+            if claimed and not published:
+                # We consumed the per-window claim but never published, so no
+                # backfill command exists. Leaving the claim would suppress
+                # every other shard this tick AND the next (TTL is a full
+                # action budget); pre-sharding a lost trigger self-healed on
+                # the next run. Give the claim back (review finding).
+                try:
+                    await state_manager.delete_state(
+                        integration_id, "backfill_observations",
+                        source_id=BACKFILL_TRIGGER_CLAIM_SOURCE,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Could not release the backfill trigger claim for integration "
+                        f"{integration.id} (the TTL will expire it): {describe_exception(e)}"
+                    )
 
     result = {
         'observations_extracted': observations_extracted,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -587,12 +587,24 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
         return {"skipped": True, "reason": "integration_paused"}
 
     present_time = datetime.now(tz=timezone.utc)
+    # Batched like the dispatcher's fleet-ordering reads: the sort below forces
+    # every state eager anyway, so sequential awaits were a flat ~SHARD_SIZE
+    # round-trip startup tax per invocation and per re-trigger hop.
+    # _load_device_state performs no Redis write (its legacy-migration branch
+    # only mutates the in-memory state and returns is_new=True for a later
+    # save), so it is side-effect-free and order-independent.
     device_states = []
-    for device_id in action_config.devices:
-        state, is_new = await _load_device_state(
-            integration_id, device_id, present_time, pull_config
+    for batch in generate_batches(list(action_config.devices), STATE_READ_CONCURRENCY):
+        loaded = await asyncio.gather(
+            *(
+                _load_device_state(integration_id, device_id, present_time, pull_config)
+                for device_id in batch
+            )
         )
-        device_states.append((device_id, state, is_new))
+        device_states.extend(
+            (device_id, state, is_new)
+            for device_id, (state, is_new) in zip(batch, loaded)
+        )
     # Least-fresh first within the shard too: a rail cut defers the freshest tail.
     device_states.sort(key=lambda entry: entry[1].high_water)
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1232,73 +1232,41 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         gapped.sort(key=lambda pair: pair[1].last_backfilled or epoch)
 
         guards = RunGuards(run_started)
+        traversal = DeviceTraversal(
+            integration, "backfill_observations", guards, concurrency=FETCH_CONCURRENCY
+        )
         observations_extracted = 0
-        failed_devices = []
-        deferred_devices = []
-        serviced_devices = 0
         gaps_closed = 0
         windows_advanced_total = 0
-        budget_starved = False
-        for chunk_start in range(0, len(gapped), FETCH_CONCURRENCY):
-            if reason := guards.should_stop():
-                deferred_devices = [d.nDeviceID for d, _ in gapped[chunk_start:]]
-                await _log_deferral(integration, "backfill_observations", reason, deferred_devices)
-                break
-            chunk = gapped[chunk_start:chunk_start + FETCH_CONCURRENCY]
-            results = await asyncio.gather(
-                *(
-                    _backfill_device(device, state, integration, auth, pull_config, guards)
-                    for device, state in chunk
-                ),
-                # Collect every task's outcome rather than aborting the chunk
-                # on the first exception: per-device failures stay per-device.
-                return_exceptions=True,
-            )
-            # Credentials refused is integration-wide and fatal; re-raise it
-            # over any per-device outcomes in the same chunk. Cancellation
-            # must also propagate (see the head-pass loop).
-            for res in results:
-                if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
-                    raise res
-            slot_starved = []
-            for (device, state), res in zip(chunk, results):
-                if isinstance(res, NoConnectionSlot):
-                    # Account connection budget exhausted (head-pass shards are
-                    # saturating it): not a device failure, not evidence about
-                    # Lotek. Defer the rest and let the next trigger retry.
-                    slot_starved.append(device.nDeviceID)
-                    continue
-                if isinstance(res, BaseException):
-                    message = (
-                        f"Failed to backfill device {device.nDeviceID} for integration "
-                        f"{integration_id}: {describe_exception(res)}"
-                    )
-                    logger.error(message, exc_info=res)
-                    await log_action_activity(
-                        integration_id=integration_id,
-                        action_id="backfill_observations",
-                        title=message,
-                        level=LogLevel.ERROR
-                    )
-                    failed_devices.append(device.nDeviceID)
-                    guards.record(transport_failure=False)
-                    continue
-                sent, device_failed, transport_failure, gap_closed, windows_advanced = res
-                # Single recording site, mirroring the head-pass loop.
-                guards.record(transport_failure=transport_failure)
-                observations_extracted += sent
-                gaps_closed += int(gap_closed)
-                windows_advanced_total += windows_advanced
-                if device_failed:
-                    failed_devices.append(device.nDeviceID)
-                else:
-                    serviced_devices += 1
-            if slot_starved:
-                # Defer only the starved devices (spec D3); see the head pass.
-                deferred_devices.extend(slot_starved)
-                budget_starved = True
 
-        if budget_starved:
+        async for (device, state), res in traversal.run(
+            gapped,
+            key=lambda pair: pair[0].nDeviceID,
+            process=lambda pair: _backfill_device(
+                pair[0], pair[1], integration, auth, pull_config, guards
+            ),
+        ):
+            sent, device_failed, transport_failure, gap_closed, windows_advanced = res
+            # Single recording site, mirroring the head pass.
+            guards.record(transport_failure=transport_failure)
+            observations_extracted += sent
+            gaps_closed += int(gap_closed)
+            windows_advanced_total += windows_advanced
+            if device_failed:
+                traversal.mark_failed(device.nDeviceID)
+
+        failed_devices = traversal.failed_devices
+        deferred_devices = traversal.deferred_devices
+
+        # Policy, deliberately NOT in the traversal (spec D6): unlike the shard,
+        # backfill never re-triggers its own tail from here — the cascade below
+        # owns that, throttled by gaps_remaining.
+        if traversal.stop_reason:
+            await _log_deferral(
+                integration, "backfill_observations", traversal.stop_reason,
+                deferred_devices,
+            )
+        if traversal.budget_starved:
             await _log_deferral(
                 integration, "backfill_observations", "connection budget exhausted",
                 deferred_devices, disposition="to the next backfill trigger",
@@ -1318,17 +1286,29 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 level=LogLevel.WARNING
             )
 
-        if gapped and serviced_devices == 0 and observations_extracted == 0 and not budget_starved:
-            # Same systemic-degradation contract as the head pass (a
-            # budget-starved run is a clean back-off, not degradation). The raise
-            # also breaks the self-retrigger cascade below — a wholly-failing
-            # backfill must not re-trigger itself forever.
-            raise LotekException(
-                message=(
-                    f"No devices could be backfilled for integration {integration_id}: "
-                    f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
-                    f"{len(gapped)}. See the per-device errors in this action's activity log."
-                )
+        # Backfill's suppression policy differs from the shard's and is
+        # preserved exactly: ONLY starvation explains a no-progress run here (a
+        # budget-starved run is a clean back-off, not degradation). Deadline and
+        # breaker stops must still alert.
+        zero_progress = (
+            gapped and traversal.serviced_devices == 0
+            and observations_extracted == 0 and not traversal.budget_starved
+        )
+        if zero_progress:
+            # Same systemic-degradation contract as the head pass. Reported, NOT
+            # raised: raising routes through the runner's generic _handle_error,
+            # which publishes config_data containing every integration
+            # configuration — the auth action's plaintext Lotek password
+            # included (GUNDI-5628). An ERROR activity event carries the same
+            # health signal without the credential exposure (spec D7).
+            message = (
+                f"No devices could be backfilled for integration {integration_id}: "
+                f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+                f"{len(gapped)}. See the per-device errors in this action's activity log."
+            )
+            logger.error(message)
+            await _try_log_activity(
+                integration_id, "backfill_observations", message, LogLevel.ERROR
             )
 
         # _backfill_device mutates the states in place, so this reflects
@@ -1353,7 +1333,11 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             # holding it. Unlike the shard cascade this one has no generation
             # cap, so the throttle has to come from here; the next scheduled
             # head pass re-triggers it once the budget frees up.
-            and not budget_starved
+            and not traversal.budget_starved
+            # A wholly-failing backfill must not re-trigger itself forever. The
+            # removed raise used to guarantee this by unwinding before the
+            # re-trigger below; now it has to be explicit (spec D7).
+            and not zero_progress
         )
         result = {
             'observations_extracted': observations_extracted,
@@ -1361,6 +1345,11 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             'devices_deferred': deferred_devices,
             'gaps_closed': gaps_closed,
         }
+        if zero_progress:
+            # Only present on the bad path (like `skipped`/`reason` elsewhere),
+            # so the systemic-degradation signal is machine-readable in the
+            # completion event without changing every healthy result's shape.
+            result['zero_progress'] = True
     finally:
         # Ownership-checked release: an unconditional DEL could outlive this
         # run's TTL (e.g. retried through a Redis blip after a cancellation)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -702,27 +702,19 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             else:
                 serviced_devices += 1
         if slot_starved:
-            deferred_devices = slot_starved + [
-                device_id for device_id, _, _ in device_states[chunk_start + FETCH_CONCURRENCY:]
-            ]
+            # Defer ONLY the devices that lost the slot race — their in-chunk
+            # peers keep their results and later chunks still run (spec D3).
+            # Before this, one starved device aborted the shard's entire tail,
+            # which on an oversubscribed fan-out made mass deferral the normal
+            # outcome rather than an exceptional one (review finding).
+            deferred_devices.extend(slot_starved)
             budget_starved = True
-            retriggered = await _retrigger_shard(
-                integration, deferred_devices, action_config.generation,
-                manual_run=action_config.manual_run,
-            ) == RETRIGGER_HANDED_OFF
-            # Portal WARNING like every other deferral cause (review finding:
-            # this branch was logger.info only, so a starved tail whose
-            # re-trigger also failed parked with zero portal visibility —
-            # contradicting the zero-progress comment's claim).
-            await _log_deferral(
-                integration, "pull_observations_shard", "connection budget exhausted",
-                deferred_devices,
-                disposition=(
-                    "to an immediately re-triggered shard" if retriggered
-                    else "to the next scheduled run"
-                ),
-            )
-            break
+
+    if budget_starved:
+        await _log_deferral(
+            integration, "pull_observations_shard", "connection budget exhausted",
+            deferred_devices, disposition="to the next scheduled run",
+        )
 
     if failed_devices:
         message = (
@@ -1352,15 +1344,15 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 else:
                     serviced_devices += 1
             if slot_starved:
-                deferred_devices = slot_starved + [
-                    d.nDeviceID for d, _ in gapped[chunk_start + FETCH_CONCURRENCY:]
-                ]
+                # Defer only the starved devices (spec D3); see the head pass.
+                deferred_devices.extend(slot_starved)
                 budget_starved = True
-                await _log_deferral(
-                    integration, "backfill_observations", "connection budget exhausted",
-                    deferred_devices, disposition="to the next backfill trigger",
-                )
-                break
+
+        if budget_starved:
+            await _log_deferral(
+                integration, "backfill_observations", "connection budget exhausted",
+                deferred_devices, disposition="to the next backfill trigger",
+            )
 
         if failed_devices:
             message = (

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -468,17 +468,17 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
 
 async def _bump_dispatcher_skip_streak(integration_id):
-    """Best-effort consecutive-skip counter for the dispatcher's slot-starved
-    tick skips. A Redis blip must not turn a clean skip into a failure."""
+    """Count consecutive dispatcher runs that pulled nothing because the account
+    connection budget was saturated. Atomic INCR: two dispatcher runs in the
+    same window (schedule tick plus a redelivery or manual trigger) both
+    starving would lose an increment under a client-side read-modify-write, and
+    the counter would silently never reach DISPATCHER_SKIP_WARN_AFTER."""
     try:
-        saved = await state_manager.get_state(
-            integration_id, "pull_observations", DISPATCHER_SKIP_STREAK_SOURCE
+        return await state_manager.increment_counter(
+            integration_id, "pull_observations",
+            source_id=DISPATCHER_SKIP_STREAK_SOURCE,
+            ttl_seconds=24 * 3600,
         )
-        streak = int((saved or {}).get("streak", 0)) + 1
-        await state_manager.set_state(
-            integration_id, "pull_observations", {"streak": streak}, DISPATCHER_SKIP_STREAK_SOURCE
-        )
-        return streak
     except Exception as e:
         logger.warning(
             f"Could not track skip streak for integration {integration_id}: {describe_exception(e)}"

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -109,6 +109,14 @@ def _deadline_exceeded(run_started_at):
     return elapsed > DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME
 
 
+def _slot_wait_budget(run_started_at):
+    """Seconds this run can still afford to spend queueing for a connection
+    slot. Mirrors _deadline_exceeded's fraction so waiting stops exactly when
+    the traversal would have stopped anyway."""
+    elapsed = (datetime.now(tz=timezone.utc) - run_started_at).total_seconds()
+    return max(0.0, DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME - elapsed)
+
+
 def _fetch_retry_kwargs(run_started_at):
     # Past the soft deadline, don't spend the remaining budget re-trying slow
     # transport failures — but keep the token-expiry retry: it is a cheap
@@ -926,7 +934,10 @@ async def _fetch_window(device_id, integration, auth, config, lower_date, upper_
                 await client.get_token(integration, auth)
                 # The slot is held for exactly one request and re-acquired on
                 # retry, so a stamina backoff never parks a slot idle.
-                async with lotek_slot(auth.username):
+                async with lotek_slot(
+                    auth.username,
+                    max_wait_seconds=_slot_wait_budget(guards.run_started_at),
+                ):
                     positions = await client.get_positions(device_id, auth, integration, lower_date, upper_date, True)
         logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device_id} between {lower_date} and {upper_date}.")
         # Transform inside the try: a malformed payload is a per-device, fetch-class
@@ -1221,7 +1232,9 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 with attempt:
                     # Token outside the slot — see _fetch_window.
                     await client.get_token(integration, auth)
-                    async with lotek_slot(auth.username):
+                    async with lotek_slot(
+                        auth.username, max_wait_seconds=_slot_wait_budget(run_started)
+                    ):
                         device_list = await client.get_devices(integration, auth)
         except NoConnectionSlot:
             # Account budget saturated by head-pass shards: back off quietly.

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -319,6 +319,18 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             with attempt:
                 # Token outside the slot — see _fetch_window.
                 await client.get_token(integration, auth)
+                # Deliberately fail-fast here (no max_wait_seconds), unlike
+                # every per-device/backfill acquire, which now waits. This is
+                # not an inconsistency to "harmonise" away — it is the
+                # system's anti-tick-overlap governor. A saturated shard can
+                # legitimately occupy its whole invocation for up to
+                # DEADLINE_FRACTION * MAX_ACTION_EXECUTION_TIME (~432s)
+                # waiting for a slot instead of exiting in seconds. If this
+                # dispatcher acquire also waited, tick N+1's shards would pile
+                # onto tick N's queue and the account would never drain — a
+                # positive feedback loop. Refusing fast here skips the whole
+                # tick instead, and SHARD_RETRIGGER_CAP is the secondary
+                # damper. Do not add max_wait_seconds to this call.
                 async with lotek_slot(auth.username):
                     device_list = await client.get_devices(integration, auth)
     except NoConnectionSlot:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -134,10 +134,15 @@ def _summarize_ids(ids):
     return listed
 
 
-async def _log_deferral(integration, action_id, reason, deferred_ids):
+async def _log_deferral(integration, action_id, reason, deferred_ids, disposition="to the next run"):
+    # disposition tells the operator what actually happens to the tail: a
+    # deadline-cut shard hands it to a re-triggered shard immediately, while a
+    # breaker stop really does wait for the next scheduled tick (Copilot
+    # review: the fixed "to the next run" text was misleading under deadline
+    # pressure).
     message = (
         f"Stopping early ({reason}) for integration {integration.id}: deferring "
-        f"{len(deferred_ids)} device(s) to the next run: {_summarize_ids(deferred_ids)}."
+        f"{len(deferred_ids)} device(s) {disposition}: {_summarize_ids(deferred_ids)}."
     )
     logger.warning(message)
     await log_action_activity(
@@ -359,10 +364,19 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     # only the saved cursor (one Redis get per device); devices with no state
     # yet sort first (most behind by definition).
     epoch = datetime.min.replace(tzinfo=timezone.utc)
+
+    async def read_high_water(device_id):
+        state = await _read_device_state(integration_id, device_id)
+        return device_id, state.high_water if state else epoch
+
+    # Bounded-concurrency reads (Copilot review): sequential awaits made this
+    # sort a per-device Redis round trip — a latency multiplier on exactly the
+    # large fleets sharding exists to serve. Chunks of 25 keep the dispatcher
+    # fast without a thundering herd on Redis.
     staleness = []
-    for device in device_list:
-        state = await _read_device_state(integration_id, device.nDeviceID)
-        staleness.append((device.nDeviceID, state.high_water if state else epoch))
+    all_ids = [device.nDeviceID for device in device_list]
+    for i in range(0, len(all_ids), 25):
+        staleness.extend(await asyncio.gather(*(read_high_water(d) for d in all_ids[i:i + 25])))
     staleness.sort(key=lambda entry: entry[1])
     device_ids = [device_id for device_id, _ in staleness]
 
@@ -504,7 +518,6 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
     for chunk_start in range(0, len(device_states), FETCH_CONCURRENCY):
         if reason := guards.should_stop():
             deferred_devices = [device_id for device_id, _, _ in device_states[chunk_start:]]
-            await _log_deferral(integration, "pull_observations_shard", reason, deferred_devices)
             # A deadline cut gets a fresh budget immediately; a hot breaker
             # does NOT re-trigger — that would defeat the pause the breaker
             # exists to buy. Its devices wait for the next scheduled tick.
@@ -512,6 +525,14 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
                 retriggered = await _retrigger_shard(
                     integration, deferred_devices, action_config.generation
                 )
+            disposition = (
+                "to an immediately re-triggered shard" if retriggered
+                else "to the next scheduled run"
+            )
+            await _log_deferral(
+                integration, "pull_observations_shard", reason, deferred_devices,
+                disposition=disposition,
+            )
             break
         chunk = device_states[chunk_start:chunk_start + FETCH_CONCURRENCY]
         results = await asyncio.gather(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -14,10 +14,16 @@ from datetime import datetime, timezone, timedelta
 from app.services.errors import ConfigurationNotFound
 from app.actions.client import LotekException, LotekTokenExpiredException, LotekUnauthorizedException
 from app.services.utils import find_config_for_action
-from app.actions.configurations import AuthenticateConfig, BackfillObservationsConfig, PullObservationsConfig
+from app.actions.configurations import (
+    AuthenticateConfig,
+    BackfillObservationsConfig,
+    PullObservationsConfig,
+    PullObservationsShardConfig,
+)
 from app.actions.core import action_title
 from app.actions.device_state import DeviceState
 from app.services.action_scheduler import trigger_action
+from app.services.lotek_connections import lotek_slot, NoConnectionSlot
 from app.services.activity_logger import activity_logger, log_action_activity
 from app.services.state import IntegrationStateManager
 from gundi_core.schemas.v2.gundi import LogLevel
@@ -54,6 +60,12 @@ BACKFILL_LEASE_SOURCE = "lease"
 # chunk overshoots by at most 2 requests. Chunk results are recorded in list
 # order, preserving the sequential consecutive-failure semantics.
 FETCH_CONCURRENCY = 5
+# Sharded head pass (GUNDI-5620, movebank-connector pattern): the scheduled
+# pull_observations only lists devices and dispatches shards of this many
+# device ids as pull_observations_shard sub-actions, each with its own action
+# budget. Sized so a shard finishes comfortably inside one budget even on a
+# slow tick (25 devices / FETCH_CONCURRENCY = 5 chunks of round trips).
+SHARD_SIZE = 25
 # Head fetches re-cover this much of the cursor's trailing edge: rows whose
 # server-assigned UploadTimeStamp falls inside a window we already queried can
 # become queryable only after our request completed (write latency / clock
@@ -250,17 +262,31 @@ def ensure_timezone_aware(val: datetime, default_tz: timezone = timezone.utc) ->
 @action_title("Integration Settings")
 @activity_logger()
 async def action_pull_observations(integration, action_config: PullObservationsConfig):
+    """Dispatcher (GUNDI-5620, movebank-connector pattern): list the account's
+    devices, order them least-fresh first, and fan the fleet out as
+    pull_observations_shard sub-actions of SHARD_SIZE ids each. Every shard
+    invocation gets its own MAX_ACTION_EXECUTION_TIME budget, so a 600-device
+    account no longer has to fit one 540s window."""
     # Log only the id: the full Integration object embeds auth config data in
     # plaintext (same leak family as the action-runner _handle_error ticket).
     logger.info(f"Executing pull_observations action for integration {integration.id}...")
 
-    # The clock starts before get_devices: it spends the same action budget.
-    run_started = datetime.now(tz=timezone.utc)
+    integration_id = str(integration.id)
     auth = get_auth_config(integration)
     try:
         async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
-                device_list = await client.get_devices(integration, auth)
+                async with lotek_slot(auth.username):
+                    device_list = await client.get_devices(integration, auth)
+    except NoConnectionSlot:
+        # Account budget saturated (shards/backfills from a previous tick are
+        # still draining). Scheduled tick — skip cleanly and let the next one
+        # retry, mirroring the movebank pull's no_connection_slot skip.
+        logger.info(
+            f"Skipping pull for integration {integration_id}: Lotek connection budget "
+            f"exhausted; the next scheduled tick will retry."
+        )
+        return {"skipped": True, "reason": "no_connection_slot"}
     except httpx.TransportError as e:
         # Transport failures reaching Lotek are the same class the per-device
         # breaker treats as WARNING; classifying them ERROR here marked every
@@ -273,15 +299,14 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         )
         logger.warning(message)
         await log_action_activity(
-            integration_id=str(integration.id),
+            integration_id=integration_id,
             action_id="pull_observations",
             title=message,
             level=LogLevel.WARNING
         )
         return {
-            "observations_extracted": 0,
-            "devices_failed": [],
-            "devices_deferred": [],
+            "devices_found": 0,
+            "shards_triggered": 0,
             "skipped": True,
             "reason": "lotek_unreachable",
         }
@@ -289,7 +314,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         message = f"Error fetching devices from Lotek. Integration ID: {integration.id} Exception: {describe_exception(e)}"
         logger.exception(message)
         await log_action_activity(
-            integration_id=str(integration.id),
+            integration_id=integration_id,
             action_id="pull_observations",
             title=message,
             level=LogLevel.ERROR
@@ -297,47 +322,116 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         raise  # bare: preserve the original traceback
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
-    present_time = datetime.now(tz=timezone.utc)
-    # Least-fresh first (mirrors the backfill's LRS ordering): the deadline and
-    # breaker always cut the tail of this list, and Lotek returns devices in a
-    # stable order — without re-ordering, sustained slowness starved the same
-    # tail devices every run until bounded staleness dropped their data
-    # permanently (review finding). Sorting by high_water puts the devices
-    # most behind first, so deferral rotates naturally as serviced devices
-    # move to the back.
-    integration_id = str(integration.id)
-    device_states = []
+    if not device_list:
+        return {"devices_found": 0, "shards_triggered": 0}
+
+    # Least-fresh first (mirrors the backfill's LRS ordering): if shards get
+    # cut by their rails, it's always the freshest tail that defers, and the
+    # ordering rotates naturally as serviced devices move to the back. Reads
+    # only the saved cursor (one Redis get per device); devices with no state
+    # yet sort first (most behind by definition).
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
+    staleness = []
     for device in device_list:
-        state, is_new = await _load_device_state(
-            integration_id, device.nDeviceID, present_time, action_config
+        state = await _read_device_state(integration_id, device.nDeviceID)
+        staleness.append((device.nDeviceID, state.high_water if state else epoch))
+    staleness.sort(key=lambda entry: entry[1])
+    device_ids = [device_id for device_id, _ in staleness]
+
+    shards = list(generate_batches(device_ids, SHARD_SIZE))
+    for shard in shards:
+        await trigger_action(
+            integration_id, "pull_observations_shard",
+            config=PullObservationsShardConfig(devices=shard, triggered_by="pull_observations")
         )
-        device_states.append((device, state, is_new))
+    return {"devices_found": len(device_list), "shards_triggered": len(shards)}
+
+
+async def _retrigger_shard(integration_id, device_ids):
+    """Re-dispatch deferred devices as a fresh shard with its own budget,
+    instead of parking them until the next scheduled tick. Best-effort: the
+    next tick re-lists and re-shards everything anyway."""
+    try:
+        await trigger_action(
+            integration_id, "pull_observations_shard",
+            config=PullObservationsShardConfig(devices=device_ids, triggered_by="pull_observations_shard")
+        )
+        return True
+    except Exception as e:
+        logger.warning(
+            f"Could not re-trigger shard for integration {integration_id}: {describe_exception(e)}"
+        )
+        return False
+
+
+@activity_logger()
+async def action_pull_observations_shard(integration, action_config: PullObservationsShardConfig):
+    """Internal action: process one shard of the head pass. Machine-triggered
+    by pull_observations (and by itself, for a deadline-deferred tail)."""
+    logger.info(
+        f"Executing pull_observations_shard ({len(action_config.devices)} devices) "
+        f"for integration {integration.id}..."
+    )
+    integration_id = str(integration.id)
+    run_started = datetime.now(tz=timezone.utc)
+    try:
+        auth = get_auth_config(integration)
+        pull_config = get_pull_config(integration)
+    except ConfigurationNotFound as e:
+        # Skip quietly, mirroring backfill: machine-triggered, so raising would
+        # route through the generic _handle_error — an ERROR event embedding
+        # the integration's full config (auth included). The scheduled parent
+        # is where a missing config gets surfaced.
+        logger.warning(
+            f"Skipping shard for integration {integration_id}: {describe_exception(e)}"
+        )
+        return {"skipped": True, "reason": "configuration_missing"}
+
+    if not pull_config.run_on_schedule:
+        # The operator's pause toggle must also stop the shard cascade:
+        # internal actions bypass the runner's skippable_pull pause check.
+        logger.info(f"Integration {integration_id} is paused (run_on_schedule=false); skipping shard.")
+        return {"skipped": True, "reason": "integration_paused"}
+
+    present_time = datetime.now(tz=timezone.utc)
+    device_states = []
+    for device_id in action_config.devices:
+        state, is_new = await _load_device_state(
+            integration_id, device_id, present_time, pull_config
+        )
+        device_states.append((device_id, state, is_new))
+    # Least-fresh first within the shard too: a rail cut defers the freshest tail.
     device_states.sort(key=lambda entry: entry[1].high_water)
 
     guards = RunGuards(run_started)
     observations_extracted = 0
     failed_devices = []
     deferred_devices = []
+    retriggered = False
     serviced_devices = 0
     # Only reflects devices actually processed this run — a device deferred by
-    # the deadline/breaker before its gap status is checked doesn't trigger
-    # backfill this cycle. Self-correcting: the next run's head pass reaches it
-    # and triggers then, same as the worst-case import delay the design accepts.
+    # the rails before its gap status is checked doesn't trigger backfill this
+    # cycle. Self-correcting: the re-triggered tail (or the next tick) reaches it.
     any_open_gap = False
     stale_drops = []
     for chunk_start in range(0, len(device_states), FETCH_CONCURRENCY):
         if reason := guards.should_stop():
-            deferred_devices = [d.nDeviceID for d, _, _ in device_states[chunk_start:]]
-            await _log_deferral(integration, "pull_observations", reason, deferred_devices)
+            deferred_devices = [device_id for device_id, _, _ in device_states[chunk_start:]]
+            await _log_deferral(integration, "pull_observations_shard", reason, deferred_devices)
+            # A deadline cut gets a fresh budget immediately; a hot breaker
+            # does NOT re-trigger — that would defeat the pause the breaker
+            # exists to buy. Its devices wait for the next scheduled tick.
+            if reason == "deadline":
+                retriggered = await _retrigger_shard(integration_id, deferred_devices)
             break
         chunk = device_states[chunk_start:chunk_start + FETCH_CONCURRENCY]
         results = await asyncio.gather(
             *(
                 _head_pass_device(
-                    device, state, is_new, integration, auth, action_config,
+                    device_id, state, is_new, integration, auth, pull_config,
                     present_time, guards, stale_drops=stale_drops
                 )
-                for device, state, is_new in chunk
+                for device_id, state, is_new in chunk
             ),
             # Collect every task's outcome rather than aborting the chunk on
             # the first exception: per-device failures must stay per-device.
@@ -351,22 +445,30 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         for res in results:
             if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
                 raise res
-        for (device, state, is_new), res in zip(chunk, results):
+        slot_starved = []
+        for (device_id, state, is_new), res in zip(chunk, results):
+            if isinstance(res, NoConnectionSlot):
+                # Account connection budget exhausted: not a device failure and
+                # not evidence about Lotek — defer this device with the rest of
+                # the shard and re-trigger (the pubsub round trip is the backoff,
+                # movebank-connector pattern).
+                slot_starved.append(device_id)
+                continue
             if isinstance(res, BaseException):
                 # Sending to Gundi and checkpointing can fail too, and a device that fetched
                 # fine but failed downstream must not take the rest of the batch with it.
                 message = (
-                    f"Failed to process device {device.nDeviceID} for integration "
+                    f"Failed to process device {device_id} for integration "
                     f"{integration.id}: {describe_exception(res)}"
                 )
                 logger.error(message, exc_info=res)
                 await log_action_activity(
-                    integration_id=str(integration.id),
-                    action_id="pull_observations",
+                    integration_id=integration_id,
+                    action_id="pull_observations_shard",
                     title=message,
                     level=LogLevel.ERROR
                 )
-                failed_devices.append(device.nDeviceID)
+                failed_devices.append(device_id)
                 guards.record(transport_failure=False)
                 continue
             sent, device_failed, transport_failure = res
@@ -377,20 +479,30 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             if state.has_gap:
                 any_open_gap = True
             if device_failed:
-                failed_devices.append(device.nDeviceID)
+                failed_devices.append(device_id)
             else:
                 serviced_devices += 1
+        if slot_starved:
+            deferred_devices = slot_starved + [
+                device_id for device_id, _, _ in device_states[chunk_start + FETCH_CONCURRENCY:]
+            ]
+            logger.info(
+                f"Deferring {len(deferred_devices)} device(s) for integration {integration_id}: "
+                f"Lotek connection budget exhausted."
+            )
+            retriggered = await _retrigger_shard(integration_id, deferred_devices)
+            break
 
     if failed_devices:
         message = (
-            f"Pulled observations with {len(failed_devices)} of {len(device_list)} device(s) "
+            f"Pulled observations with {len(failed_devices)} of {len(action_config.devices)} device(s) "
             f"failing for integration {integration.id}: {_summarize_ids(failed_devices)}. "
             f"They will be retried on the next run."
         )
         logger.warning(message)
         await log_action_activity(
-            integration_id=str(integration.id),
-            action_id="pull_observations",
+            integration_id=integration_id,
+            action_id="pull_observations_shard",
             title=message,
             level=LogLevel.WARNING
         )
@@ -401,37 +513,35 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         # finding on the publish-volume fix). Per-device ranges are in the
         # local log.
         message = (
-            f"Dropped data older than max_data_age_hours={action_config.max_data_age_hours} "
+            f"Dropped data older than max_data_age_hours={pull_config.max_data_age_hours} "
             f"permanently for {len(stale_drops)} device(s) on integration {integration.id}: "
             f"{_summarize_ids(stale_drops)}. See the application log for per-device ranges."
         )
         logger.warning(message)
         await log_action_activity(
-            integration_id=str(integration.id),
-            action_id="pull_observations",
+            integration_id=integration_id,
+            action_id="pull_observations_shard",
             title=message,
             level=LogLevel.WARNING
         )
 
-    if device_list and serviced_devices == 0 and observations_extracted == 0:
-        # Zero progress: nothing serviced and nothing delivered — whether every
-        # device failed or the rails deferred them all, this is systemic
-        # degradation and must alert rather than publish action_complete. A
-        # device that delivered part of its window before failing still counts
-        # as progress, so partial runs stay warnings. This comes after the
-        # summary so the worst case keeps its device-naming log.
+    if device_states and serviced_devices == 0 and observations_extracted == 0 and not retriggered:
+        # Zero progress: nothing serviced, nothing delivered, and no deferred
+        # tail re-dispatched — systemic degradation, must alert rather than
+        # publish action_complete. A successfully re-triggered deferral is
+        # progress (the work moved to a fresh budget), so it stays a warning.
         raise LotekException(
             message=(
                 f"No devices could be serviced for integration {integration.id}: "
                 f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
-                f"{len(device_list)}. See the per-device errors in this action's activity log."
+                f"{len(action_config.devices)}. See the per-device errors in this action's activity log."
             )
         )
 
     if any_open_gap:
         try:
             lease = await state_manager.get_state(
-                str(integration.id), "backfill_observations", BACKFILL_LEASE_SOURCE
+                integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE
             )
             if not lease:
                 # backfill_observations is an InternalActionConfiguration with no
@@ -440,11 +550,11 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                 # publishes an empty config_overrides, which execute_action reads
                 # as "no config at all" and 404s before the handler ever runs.
                 await trigger_action(
-                    str(integration.id), "backfill_observations",
-                    config=BackfillObservationsConfig(triggered_by="pull_observations")
+                    integration_id, "backfill_observations",
+                    config=BackfillObservationsConfig(triggered_by="pull_observations_shard")
                 )
         except Exception as e:
-            # The head pass succeeded; a failed trigger must not fail the run.
+            # The shard succeeded; a failed trigger must not fail the run.
             logger.warning(
                 f"Could not trigger backfill for integration {integration.id}: {describe_exception(e)}"
             )
@@ -524,20 +634,24 @@ async def _save_device_state_fields(integration_id, device_id, updates, init_onl
     )
 
 
-async def _fetch_window(device, integration, auth, config, lower_date, upper_date, guards, action_id):
+async def _fetch_window(device_id, integration, auth, config, lower_date, upper_date, guards, action_id):
     """Fetch + transform one window for one device.
 
     Returns (cdip_positions | None, transport_failure). None means the fetch
     failed — already logged and classified; the caller marks the device failed
     and records transport_failure for the circuit breaker. Raises only
-    LotekUnauthorizedException (integration-wide).
+    LotekUnauthorizedException (integration-wide) and NoConnectionSlot
+    (account-wide budget, the caller defers and re-triggers).
     """
     integration_id = str(integration.id)
     try:
         async for attempt in stamina.retry_context(**_fetch_retry_kwargs(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
-                positions = await client.get_positions(device.nDeviceID, auth, integration, lower_date, upper_date, True)
-        logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device.nDeviceID} between {lower_date} and {upper_date}.")
+                # The slot is held for exactly one request and re-acquired on
+                # retry, so a stamina backoff never parks a slot idle.
+                async with lotek_slot(auth.username):
+                    positions = await client.get_positions(device_id, auth, integration, lower_date, upper_date, True)
+        logger.info(f"Extracted {len(positions)} obs from Lotek for device: {device_id} between {lower_date} and {upper_date}.")
         # Transform inside the try: a malformed payload is a per-device, fetch-class
         # failure and must get the same device/date-window log and isolation.
         return filter_and_transform_positions(positions, integration, config), False
@@ -545,17 +659,22 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
         # Credentials are an integration-wide problem: every remaining device
         # would fail the same way, so fail fast instead of N identical errors.
         raise
+    except NoConnectionSlot:
+        # Account-wide connection budget exhausted (other shards/backfills are
+        # saturating it). Not a device failure and not evidence about Lotek —
+        # the caller defers the rest of its devices and re-triggers.
+        raise
     except httpx.TransportError as e:
         # WARNING + breaker-feeding: enough timeouts/transport failures in a
         # row mean Lotek-wide degradation, not a bad device.
         # Local log only: failed devices are aggregated into one end-of-run
         # summary publish. Per-device publishes multiplied exactly when Lotek
         # (or the instance) was already drowning — a congestion feedback loop.
-        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        message = f"Error fetching positions from Lotek. Device: {device_id}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
         logger.warning(message, exc_info=True)
         return None, True
     except LotekException as e:
-        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        message = f"Error fetching positions from Lotek. Device: {device_id}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
         if e.status_code >= 500 or e.status_code == 429:
             # A Lotek-side 5xx/429 is outage/throttling, the same class of
             # Lotek-wide degradation as a timeout: WARNING + breaker-feeding.
@@ -580,13 +699,13 @@ async def _fetch_window(device, integration, auth, config, lower_date, upper_dat
         # above), a data-shape break is permanent and won't self-heal on retry —
         # it must stay visible to health/alerting or it can persist unnoticed
         # forever (review finding).
-        message = f"Error fetching positions from Lotek. Device: {device.nDeviceID}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
+        message = f"Error fetching positions from Lotek. Device: {device_id}. Dates: [{lower_date},{upper_date}]. Integration ID: {integration_id} Exception: {describe_exception(e)}"
         logger.exception(message)
         await _try_log_activity(integration_id, action_id, message, LogLevel.ERROR)
         return None, False
 
 
-async def _deliver(cdip_positions, device, integration, action_id):
+async def _deliver(cdip_positions, device_id, integration, action_id):
     """Send one device's transformed positions to Gundi in batches.
 
     Returns (observations_sent, delivery_failed). Handled here rather than in
@@ -600,14 +719,14 @@ async def _deliver(cdip_positions, device, integration, action_id):
     observations_sent = 0
     try:
         if cdip_positions:
-            logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device.nDeviceID} integration ID: {integration.id}.")
+            logger.info(f"{len(cdip_positions)} observations pulled successfully for device {device_id} integration ID: {integration.id}.")
             for i, batch in enumerate(generate_batches(cdip_positions)):
-                logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device.nDeviceID}')
+                logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Device: {device_id}')
                 await gundi_tools.send_observations_to_gundi(observations=batch, integration_id=integration.id)
                 observations_sent += len(batch)
     except Exception as e:
         message = (
-            f"Error delivering observations for device {device.nDeviceID}. Integration ID: "
+            f"Error delivering observations for device {device_id}. Integration ID: "
             f"{integration.id} Exception: {describe_exception(e)}"
         )
         # needs_attention drives log-based alerting on delivery failures (template
@@ -625,7 +744,7 @@ async def _deliver(cdip_positions, device, integration, action_id):
     return observations_sent, False
 
 
-async def _head_pass_device(device, state, is_new, integration, auth, action_config, present_time, guards, stale_drops=None):
+async def _head_pass_device(device_id, state, is_new, integration, auth, action_config, present_time, guards, stale_drops=None):
     """Fetch, deliver and checkpoint one device's freshest window.
 
     Returns (observations_sent, device_failed, transport_failure).
@@ -649,7 +768,7 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
 
     lower_date = max(state.high_water - HEAD_LATE_UPLOAD_OVERLAP, freshness_floor)
     cdip_positions, transport_failure = await _fetch_window(
-        device, integration, auth, action_config, lower_date, present_time, guards, "pull_observations"
+        device_id, integration, auth, action_config, lower_date, present_time, guards, "pull_observations"
     )
     if cdip_positions is None:
         return 0, True, transport_failure
@@ -659,9 +778,9 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
         # device — on a mostly-dormant 400-device integration that was
         # hundreds of pubsub publishes per tick, the single largest
         # contributor to the publish congestion behind GUNDI-5602.
-        logger.info(f"No positions fetched for device {device.nDeviceID} integration ID: {integration.id}.")
+        logger.info(f"No positions fetched for device {device_id} integration ID: {integration.id}.")
 
-    observations_sent, delivery_failed = await _deliver(cdip_positions, device, integration, "pull_observations")
+    observations_sent, delivery_failed = await _deliver(cdip_positions, device_id, integration, "pull_observations")
     if delivery_failed:
         # The breaker watches Lotek, not Gundi: a delivery failure is not
         # evidence of Lotek-wide degradation.
@@ -686,10 +805,10 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
         updates["version"] = state.version
         init_only = {"gap_start": state.gap_start, "gap_end": state.gap_end}
     try:
-        await _save_device_state_fields(integration_id, device.nDeviceID, updates, init_only=init_only)
+        await _save_device_state_fields(integration_id, device_id, updates, init_only=init_only)
     except Exception as e:
         message = (
-            f"Error saving cursor for device {device.nDeviceID}. Integration ID: "
+            f"Error saving cursor for device {device_id}. Integration ID: "
             f"{integration.id} Exception: {describe_exception(e)}"
         )
         logger.exception(message)
@@ -704,11 +823,11 @@ async def _head_pass_device(device, state, is_new, integration, auth, action_con
         # one end-of-run summary publish (review finding).
         logger.warning(
             f"Dropped stale range [{stale_from.isoformat()}, {freshness_floor.isoformat()}] "
-            f"permanently for device {device.nDeviceID}: older than max_data_age_hours="
+            f"permanently for device {device_id}: older than max_data_age_hours="
             f"{action_config.max_data_age_hours}. Integration ID: {integration_id}"
         )
         if stale_drops is not None:
-            stale_drops.append(device.nDeviceID)
+            stale_drops.append(device_id)
 
     return observations_sent, False, False
 
@@ -736,13 +855,13 @@ async def _backfill_device(device, state, integration, auth, pull_config, guards
         upper_date = min(state.gap_end, state.gap_start + BACKFILL_WINDOW)
 
         cdip_positions, transport_failure = await _fetch_window(
-            device, integration, auth, pull_config, window_start, upper_date, guards, "backfill_observations"
+            device.nDeviceID, integration, auth, pull_config, window_start, upper_date, guards, "backfill_observations"
         )
         if cdip_positions is None:
             device_failed = True
             break
 
-        sent, delivery_failed = await _deliver(cdip_positions, device, integration, "backfill_observations")
+        sent, delivery_failed = await _deliver(cdip_positions, device.nDeviceID, integration, "backfill_observations")
         observations_sent += sent
         if delivery_failed:
             device_failed = True
@@ -820,7 +939,17 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         try:
             async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
                 with attempt:
-                    device_list = await client.get_devices(integration, auth)
+                    async with lotek_slot(auth.username):
+                        device_list = await client.get_devices(integration, auth)
+        except NoConnectionSlot:
+            # Account budget saturated by head-pass shards: back off quietly.
+            # The lease releases via the finally; open gaps re-trigger on the
+            # next scheduled head pass.
+            logger.info(
+                f"Skipping backfill for integration {integration_id}: Lotek connection "
+                f"budget exhausted; open gaps are retried on the next trigger."
+            )
+            return {"skipped": True, "reason": "no_connection_slot"}
         except httpx.TransportError as e:
             # Same WARNING classification as the head pass: an unreachable
             # Lotek must not mark the connection unhealthy. The early return
@@ -872,6 +1001,7 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         serviced_devices = 0
         gaps_closed = 0
         windows_advanced_total = 0
+        budget_starved = False
         for chunk_start in range(0, len(gapped), FETCH_CONCURRENCY):
             if reason := guards.should_stop():
                 deferred_devices = [d.nDeviceID for d, _ in gapped[chunk_start:]]
@@ -893,7 +1023,14 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             for res in results:
                 if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
                     raise res
+            slot_starved = []
             for (device, state), res in zip(chunk, results):
+                if isinstance(res, NoConnectionSlot):
+                    # Account connection budget exhausted (head-pass shards are
+                    # saturating it): not a device failure, not evidence about
+                    # Lotek. Defer the rest and let the next trigger retry.
+                    slot_starved.append(device.nDeviceID)
+                    continue
                 if isinstance(res, BaseException):
                     message = (
                         f"Failed to backfill device {device.nDeviceID} for integration "
@@ -919,6 +1056,16 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                     failed_devices.append(device.nDeviceID)
                 else:
                     serviced_devices += 1
+            if slot_starved:
+                deferred_devices = slot_starved + [
+                    d.nDeviceID for d, _ in gapped[chunk_start + FETCH_CONCURRENCY:]
+                ]
+                budget_starved = True
+                logger.info(
+                    f"Deferring {len(deferred_devices)} gapped device(s) for integration "
+                    f"{integration_id}: Lotek connection budget exhausted."
+                )
+                break
 
         if failed_devices:
             message = (
@@ -934,8 +1081,9 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 level=LogLevel.WARNING
             )
 
-        if gapped and serviced_devices == 0 and observations_extracted == 0:
-            # Same systemic-degradation contract as the head pass. The raise
+        if gapped and serviced_devices == 0 and observations_extracted == 0 and not budget_starved:
+            # Same systemic-degradation contract as the head pass (a
+            # budget-starved run is a clean back-off, not degradation). The raise
             # also breaks the self-retrigger cascade below — a wholly-failing
             # backfill must not re-trigger itself forever.
             raise LotekException(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -650,6 +650,11 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             traversal.mark_failed(device_id)
 
     failed_devices = traversal.failed_devices
+    # Union, for the overall count/result only (below). The retrigger and the
+    # two deferral logs each use their own reason-specific list — sharing one
+    # combined list here re-triggered/logged slot-starved devices under a
+    # "deadline" tail and vice versa, and double-reported any device covered
+    # by both conditions in the same run (review finding).
     deferred_devices = traversal.deferred_devices
 
     # Policy, deliberately NOT in the traversal (spec D6): a deadline cut gets a
@@ -657,15 +662,15 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
     # defeat the pause the breaker exists to buy. Its devices wait for the next
     # scheduled tick.
     retrigger_outcome = None
-    if traversal.stop_reason == "deadline" and deferred_devices:
+    if traversal.stop_reason == "deadline" and traversal.guard_stopped_devices:
         retrigger_outcome = await _retrigger_shard(
-            integration, deferred_devices, action_config.generation,
+            integration, traversal.guard_stopped_devices, action_config.generation,
             manual_run=action_config.manual_run,
         )
     if traversal.stop_reason:
         await _log_deferral(
             integration, "pull_observations_shard", traversal.stop_reason,
-            deferred_devices,
+            traversal.guard_stopped_devices,
             disposition=(
                 "to an immediately re-triggered shard"
                 if retrigger_outcome == RETRIGGER_HANDED_OFF
@@ -677,7 +682,7 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
         # not park with zero portal visibility (review finding).
         await _log_deferral(
             integration, "pull_observations_shard", "connection budget exhausted",
-            deferred_devices, disposition="to the next scheduled run",
+            traversal.slot_starved_devices, disposition="to the next scheduled run",
         )
 
     if failed_devices:
@@ -1300,6 +1305,10 @@ async def action_backfill_observations(integration, action_config: BackfillObser
                 traversal.mark_failed(device.nDeviceID)
 
         failed_devices = traversal.failed_devices
+        # Union, for the overall count/result only (below); the two deferral
+        # logs each use their own reason-specific list so a slot-starved
+        # device is never logged under the stop_reason tail or vice versa
+        # (review finding — see traversal.py).
         deferred_devices = traversal.deferred_devices
 
         # Policy, deliberately NOT in the traversal (spec D6): unlike the shard,
@@ -1308,12 +1317,12 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         if traversal.stop_reason:
             await _log_deferral(
                 integration, "backfill_observations", traversal.stop_reason,
-                deferred_devices,
+                traversal.guard_stopped_devices,
             )
         if traversal.budget_starved:
             await _log_deferral(
                 integration, "backfill_observations", "connection budget exhausted",
-                deferred_devices, disposition="to the next backfill trigger",
+                traversal.slot_starved_devices, disposition="to the next backfill trigger",
             )
 
         if failed_devices:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -80,6 +80,17 @@ SHARD_RETRIGGER_CAP = 3
 # saturated across ticks and must be visible in the portal.
 DISPATCHER_SKIP_WARN_AFTER = 2
 DISPATCHER_SKIP_STREAK_SOURCE = "slot_skip_streak"
+# Outcomes of a deferred-tail re-trigger attempt (see _retrigger_shard).
+RETRIGGER_HANDED_OFF = "handed_off"
+RETRIGGER_CAP_REACHED = "cap_reached"
+RETRIGGER_FAILED = "failed"
+# One backfill trigger per head-pass tick: every shard of a gapped fleet used
+# to read the lease and publish its own backfill command (the lease is only
+# created a pubsub hop later, when the backfill handler runs), so 25 shards
+# produced up to 25 commands — 24 of them full no-op invocations with their own
+# activity events (review finding). This claim is atomic, so exactly one shard
+# publishes per window.
+BACKFILL_TRIGGER_CLAIM_SOURCE = "backfill_trigger_claim"
 # Head fetches re-cover this much of the cursor's trailing edge: rows whose
 # server-assigned UploadTimeStamp falls inside a window we already queried can
 # become queryable only after our request completed (write latency / clock
@@ -355,6 +366,9 @@ async def action_pull_observations(integration, action_config: PullObservationsC
             title=message,
             level=LogLevel.ERROR
         )
+        # Same reason as the transport path: a non-starved outcome breaks the
+        # "consecutive" skip streak (review finding — this path was missed).
+        await _reset_dispatcher_skip_streak(integration_id)
         raise  # bare: preserve the original traceback
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
@@ -370,7 +384,9 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     epoch = datetime.min.replace(tzinfo=timezone.utc)
 
     async def read_high_water(device_id):
-        state = await _read_device_state(integration_id, device_id)
+        # quiet: the shard publishes the unparseable-state warning when it
+        # actually discards the cursor; this read only orders the fleet.
+        state = await _read_device_state(integration_id, device_id, quiet=True)
         return device_id, state.high_water if state else epoch
 
     # Bounded-concurrency reads (Copilot review): sequential awaits made this
@@ -423,15 +439,21 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         logger.warning(message)
         await _try_log_activity(integration_id, "pull_observations", message, LogLevel.WARNING)
     if shards and dispatched == 0:
-        # Nothing was handed off at all: systemic (commands topic down), must
-        # alert rather than publish action_complete.
-        raise LotekException(
-            message=(
-                f"Could not dispatch any of {len(shards)} shard(s) for integration "
-                f"{integration_id}; see the application log for the publish errors."
-            )
+        # Nothing was handed off at all: systemic (commands topic down). ERROR
+        # activity event rather than a raise, for the same reason as the shard's
+        # zero-progress path — a raise routes through the runner's generic
+        # _handle_error, which publishes every integration configuration
+        # (plaintext Lotek password included) into the event payload.
+        message = (
+            f"Could not dispatch any of {len(shards)} shard(s) for integration "
+            f"{integration_id}; see the application log for the publish errors."
         )
-    return {"devices_found": len(device_list), "shards_triggered": dispatched}
+        logger.error(message)
+        await _try_log_activity(integration_id, "pull_observations", message, LogLevel.ERROR)
+    result = {"devices_found": len(device_list), "shards_triggered": dispatched}
+    if undispatched_devices:
+        result["devices_undispatched"] = undispatched_devices
+    return result
 
 
 async def _bump_dispatcher_skip_streak(integration_id):
@@ -473,8 +495,14 @@ async def _retrigger_shard(integration, device_ids, generation, manual_run=False
     the tail falls back to the next scheduled tick — an ungoverned chain under
     sustained slot starvation was an unbounded busy-loop of zero-progress
     invocations, invisible because each hop reported success (review finding).
-    Returns True only when the tail was actually handed off. Best-effort
-    otherwise: the next tick re-lists and re-shards everything anyway.
+
+    Returns one of:
+      RETRIGGER_HANDED_OFF  — a fresh shard owns the tail
+      RETRIGGER_CAP_REACHED — cap hit; the tail waits for the next tick and the
+                              exhaustion was already reported at ERROR, so the
+                              caller must NOT also emit its own alert (review
+                              finding: one load event produced two ERRORs)
+      RETRIGGER_FAILED      — publish failed; nobody owns the tail this tick
     """
     integration_id = str(integration.id)
     if generation >= SHARD_RETRIGGER_CAP:
@@ -491,7 +519,7 @@ async def _retrigger_shard(integration, device_ids, generation, manual_run=False
         await _try_log_activity(
             integration_id, "pull_observations_shard", message, LogLevel.ERROR
         )
-        return False
+        return RETRIGGER_CAP_REACHED
     try:
         await trigger_action(
             integration_id, "pull_observations_shard",
@@ -502,15 +530,19 @@ async def _retrigger_shard(integration, device_ids, generation, manual_run=False
                 manual_run=manual_run,
             )
         )
-        return True
+        return RETRIGGER_HANDED_OFF
     except Exception as e:
         logger.warning(
             f"Could not re-trigger shard for integration {integration_id}: {describe_exception(e)}"
         )
-        return False
+        return RETRIGGER_FAILED
 
 
-@activity_logger()
+# on_start=False: the dispatcher's own started event already marks the tick, and
+# a started event per shard doubled the publish volume on the aiohttp/pubsub
+# path GUNDI-5620 identified as the dominant error source (review finding). The
+# completion event is kept — it carries this shard's observations_extracted.
+@activity_logger(on_start=False)
 async def action_pull_observations_shard(integration, action_config: PullObservationsShardConfig):
     """Internal action: process one shard of the head pass. Machine-triggered
     by pull_observations (and by itself, for a deadline-deferred tail)."""
@@ -559,6 +591,7 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
     deferred_devices = []
     retriggered = False
     budget_starved = False
+    cap_reached = False
     serviced_devices = 0
     # Only reflects devices actually processed this run — a device deferred by
     # the rails before its gap status is checked doesn't trigger backfill this
@@ -572,10 +605,14 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             # does NOT re-trigger — that would defeat the pause the breaker
             # exists to buy. Its devices wait for the next scheduled tick.
             if reason == "deadline":
-                retriggered = await _retrigger_shard(
+                outcome = await _retrigger_shard(
                     integration, deferred_devices, action_config.generation,
                     manual_run=action_config.manual_run,
                 )
+                retriggered = outcome == RETRIGGER_HANDED_OFF
+                # A cap-reached deferral already alerted at ERROR; suppress the
+                # zero-progress alert so one load event yields one signal.
+                cap_reached = outcome == RETRIGGER_CAP_REACHED
             disposition = (
                 "to an immediately re-triggered shard" if retriggered
                 else "to the next scheduled run"
@@ -651,7 +688,7 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             retriggered = await _retrigger_shard(
                 integration, deferred_devices, action_config.generation,
                 manual_run=action_config.manual_run,
-            )
+            ) == RETRIGGER_HANDED_OFF
             # Portal WARNING like every other deferral cause (review finding:
             # this branch was logger.info only, so a starved tail whose
             # re-trigger also failed parked with zero portal visibility —
@@ -698,32 +735,52 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             level=LogLevel.WARNING
         )
 
-    if (device_states and serviced_devices == 0 and observations_extracted == 0
-            and not retriggered and not budget_starved):
+    zero_progress = (
+        device_states and serviced_devices == 0 and observations_extracted == 0
+        and not retriggered and not budget_starved and not cap_reached
+    )
+    if zero_progress:
         # Zero progress: nothing serviced, nothing delivered, and no deferred
-        # tail re-dispatched — systemic degradation, must alert rather than
-        # publish action_complete. A successfully re-triggered deferral is
-        # progress (the work moved to a fresh budget). Slot starvation NEVER
-        # raises, even when the re-trigger hand-off also failed: it is a clean
-        # budget back-off, not degradation (mirrors backfill's budget_starved;
-        # review finding — the old condition flipped a starvation + pubsub
-        # blip into a false systemic ERROR). Starvation visibility comes from
-        # the _log_deferral WARNING on the starved branch and the re-trigger
-        # cap's ERROR instead.
-        raise LotekException(
-            message=(
-                f"No devices could be serviced for integration {integration.id}: "
-                f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
-                f"{len(action_config.devices)}. See the per-device errors in this action's activity log."
-            )
+        # tail re-dispatched — systemic degradation that must alert rather than
+        # pass as a clean completion. A successfully re-triggered deferral is
+        # progress (the work moved to a fresh budget); slot starvation and a
+        # cap-reached deferral are clean back-offs that alert on their own
+        # branches.
+        #
+        # Reported as an ERROR activity event, NOT raised (review finding):
+        # raising routes through the runner's generic _handle_error, which
+        # publishes `config_data` containing every integration configuration —
+        # the auth action's plaintext Lotek password included — and a fleet-wide
+        # outage would leak it once per shard, up to SHARD_SIZE-many times per
+        # tick. An ERROR activity event carries the same health signal (the
+        # unhealthy-connection metric counts ERROR activity events) without the
+        # credential exposure.
+        message = (
+            f"No devices could be serviced for integration {integration.id}: "
+            f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+            f"{len(action_config.devices)}. See the per-device errors in this action's activity log."
+        )
+        logger.error(message)
+        await _try_log_activity(
+            integration_id, "pull_observations_shard", message, LogLevel.ERROR
         )
 
-    if any_open_gap:
+    if any_open_gap and not zero_progress:
         try:
+            # Atomic per-window claim first: concurrent shards all reach this
+            # point within seconds of each other, and the lease below is only
+            # created a pubsub hop later (when the backfill handler runs), so a
+            # plain lease read let every shard publish its own command (review
+            # finding). Exactly one shard wins the claim per window.
+            claimed = await state_manager.set_if_absent(
+                integration_id, "backfill_observations",
+                ttl_seconds=app_settings.MAX_ACTION_EXECUTION_TIME,
+                source_id=BACKFILL_TRIGGER_CLAIM_SOURCE,
+            )
             lease = await state_manager.get_state(
                 integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE
             )
-            if not lease:
+            if claimed and not lease:
                 # backfill_observations is an InternalActionConfiguration with no
                 # persisted portal config, so this MUST carry a non-empty config
                 # override — a bare trigger_action(..., "backfill_observations")
@@ -731,7 +788,14 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
                 # as "no config at all" and 404s before the handler ever runs.
                 await trigger_action(
                     integration_id, "backfill_observations",
-                    config=BackfillObservationsConfig(triggered_by="pull_observations_shard")
+                    config=BackfillObservationsConfig(
+                        triggered_by="pull_observations_shard",
+                        # Carry the manual marker: without it a Trigger on a
+                        # paused integration pulled head data but its backfill
+                        # skipped on the pause, silently importing no history
+                        # (review finding).
+                        manual_run=action_config.manual_run,
+                    )
                 )
         except Exception as e:
             # The shard succeeded; a failed trigger must not fail the run.
@@ -739,18 +803,30 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
                 f"Could not trigger backfill for integration {integration.id}: {describe_exception(e)}"
             )
 
-    return {
+    result = {
         'observations_extracted': observations_extracted,
         'devices_failed': failed_devices,
         'devices_deferred': deferred_devices,
     }
+    if zero_progress:
+        # Only present on the bad path (like `skipped`/`reason` elsewhere), so
+        # the systemic-degradation signal is machine-readable in the completion
+        # event without changing the shape of every healthy result.
+        result['zero_progress'] = True
+    return result
 
 
-async def _read_device_state(integration_id, device_id, action_id="pull_observations"):
+async def _read_device_state(integration_id, device_id, action_id="pull_observations", quiet=False):
     """Read one device's saved state. Returns a DeviceState, or None when the
     key is absent or unparseable. Unparseable state is surfaced at WARNING —
     it means a cursor is about to be discarded and the lookback re-imported
-    (review finding: this was announced only at DEBUG)."""
+    (review finding: this was announced only at DEBUG).
+
+    `quiet` suppresses the portal publish for readers that are not the writer:
+    the dispatcher reads every device's cursor just to order the fleet, and the
+    shard that actually discards the cursor publishes the same warning moments
+    later — publishing on both doubled the volume per affected device (review
+    finding). The local log line is kept either way."""
     saved = await state_manager.get_state(integration_id, "pull_observations", device_id)
     if not saved:
         return None
@@ -763,7 +839,8 @@ async def _read_device_state(integration_id, device_id, action_id="pull_observat
             f"{integration_id} Error: {describe_exception(e)}"
         )
         logger.warning(message)
-        await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
+        if not quiet:
+            await _try_log_activity(integration_id, action_id, message, LogLevel.WARNING)
         return None
 
 
@@ -1104,10 +1181,13 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         )
         return {"skipped": True, "reason": "configuration_missing"}
 
-    if not pull_config.run_on_schedule:
+    if not pull_config.run_on_schedule and not action_config.manual_run:
         # The operator's pause toggle must also stop the cascade: internal
         # actions bypass the runner's skippable_pull pause check, and backfill
         # is only ever machine-triggered — a paused integration skips cleanly
+        # (review finding). manual_run exempts a backfill descending from an
+        # operator-triggered head pass: without it a Trigger on a paused
+        # integration pulled the head window but silently imported no history
         # (review finding).
         logger.info(f"Integration {integration_id} is paused (run_on_schedule=false); skipping backfill.")
         return {"skipped": True, "reason": "integration_paused"}
@@ -1329,7 +1409,10 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         try:
             await trigger_action(
                 integration_id, "backfill_observations",
-                config=BackfillObservationsConfig(triggered_by="backfill_observations")
+                config=BackfillObservationsConfig(
+                    triggered_by="backfill_observations",
+                    manual_run=action_config.manual_run,
+                )
             )
         except Exception as e:
             # The next head pass will re-trigger; losing one cascade step is fine.

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -80,6 +80,10 @@ SHARD_RETRIGGER_CAP = 3
 # saturated across ticks and must be visible in the portal.
 DISPATCHER_SKIP_WARN_AFTER = 2
 DISPATCHER_SKIP_STREAK_SOURCE = "slot_skip_streak"
+# How many device cursors the dispatcher reads concurrently when ordering the
+# fleet. Independent of SHARD_SIZE (this bounds Redis fan-out, not action
+# budget) — named so tuning one does not silently look like it covers the other.
+STATE_READ_CONCURRENCY = 25
 # Outcomes of a deferred-tail re-trigger attempt (see _retrigger_shard).
 RETRIGGER_HANDED_OFF = "handed_off"
 RETRIGGER_CAP_REACHED = "cap_reached"
@@ -296,7 +300,16 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     devices, order them least-fresh first, and fan the fleet out as
     pull_observations_shard sub-actions of SHARD_SIZE ids each. Every shard
     invocation gets its own MAX_ACTION_EXECUTION_TIME budget, so a 600-device
-    account no longer has to fit one 540s window."""
+    account no longer has to fit one 540s window.
+
+    RESULT CONTRACT CHANGE (Copilot review): this action no longer does the
+    fetching, so it no longer reports `observations_extracted`, `devices_failed`
+    or `devices_deferred` — those now belong to each pull_observations_shard
+    result (and its completion event). This action returns `devices_found` and
+    `shards_triggered`, plus `devices_undispatched` when a publish failed, and
+    `skipped`/`reason` when the tick was skipped. Anything aggregating per-tick
+    throughput must sum the shard results instead of reading this one.
+    """
     # Log only the id: the full Integration object embeds auth config data in
     # plaintext (same leak family as the action-runner _handle_error ticket).
     logger.info(f"Executing pull_observations action for integration {integration.id}...")
@@ -391,12 +404,12 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
     # Bounded-concurrency reads (Copilot review): sequential awaits made this
     # sort a per-device Redis round trip — a latency multiplier on exactly the
-    # large fleets sharding exists to serve. Chunks of 25 keep the dispatcher
-    # fast without a thundering herd on Redis.
+    # large fleets sharding exists to serve. STATE_READ_CONCURRENCY keeps the
+    # dispatcher fast without a thundering herd on Redis.
     staleness = []
     all_ids = [device.nDeviceID for device in device_list]
-    for i in range(0, len(all_ids), 25):
-        staleness.extend(await asyncio.gather(*(read_high_water(d) for d in all_ids[i:i + 25])))
+    for batch in generate_batches(all_ids, STATE_READ_CONCURRENCY):
+        staleness.extend(await asyncio.gather(*(read_high_water(d) for d in batch)))
     staleness.sort(key=lambda entry: entry[1])
     device_ids = [device_id for device_id, _ in staleness]
 
@@ -1378,6 +1391,14 @@ async def action_backfill_observations(integration, action_config: BackfillObser
             any(state.has_gap for _, state in gapped)
             and not breaker_hot
             and windows_advanced_total > 0
+            # Budget starvation suppresses the cascade for the same reason a hot
+            # breaker does (Copilot review): a run that advanced a window and
+            # then starved would re-trigger straight back into a saturated
+            # account budget, competing with the head-pass shards that are
+            # holding it. Unlike the shard cascade this one has no generation
+            # cap, so the throttle has to come from here; the next scheduled
+            # head pass re-triggers it once the budget frees up.
+            and not budget_starved
         )
         result = {
             'observations_extracted': observations_extracted,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -66,6 +66,20 @@ FETCH_CONCURRENCY = 5
 # budget. Sized so a shard finishes comfortably inside one budget even on a
 # slow tick (25 devices / FETCH_CONCURRENCY = 5 chunks of round trips).
 SHARD_SIZE = 25
+# Re-trigger governor (review finding, PR #20 discussion): a deferred tail may
+# hop to a fresh shard at most this many times before falling back to the next
+# scheduled tick. Without the cap, sustained slot starvation turned the
+# "pubsub round trip is the backoff" re-trigger into an unbounded busy-loop of
+# zero-progress invocations — bounded waste is acceptable, an ungoverned loop
+# is not. Exceeding the cap is surfaced at ERROR: it means the account could
+# not drain within ~cap budgets and someone should know.
+SHARD_RETRIGGER_CAP = 3
+# Consecutive whole-tick dispatcher skips on slot starvation before the skip
+# is promoted from local log to a portal WARNING. The first skip stays quiet
+# (publish-volume discipline); a streak means the account budget has been
+# saturated across ticks and must be visible in the portal.
+DISPATCHER_SKIP_WARN_AFTER = 2
+DISPATCHER_SKIP_STREAK_SOURCE = "slot_skip_streak"
 # Head fetches re-cover this much of the cursor's trailing edge: rows whose
 # server-assigned UploadTimeStamp falls inside a window we already queried can
 # become queryable only after our request completed (write latency / clock
@@ -276,16 +290,29 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     try:
         async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
+                # Token outside the slot — see _fetch_window.
+                await client.get_token(integration, auth)
                 async with lotek_slot(auth.username):
                     device_list = await client.get_devices(integration, auth)
     except NoConnectionSlot:
         # Account budget saturated (shards/backfills from a previous tick are
         # still draining). Scheduled tick — skip cleanly and let the next one
-        # retry, mirroring the movebank pull's no_connection_slot skip.
-        logger.info(
+        # retry, mirroring the movebank pull's no_connection_slot skip. A
+        # single skip stays out of the portal, but a STREAK of skipped ticks
+        # means the account has been saturated for tens of minutes and must
+        # not stay invisible (review finding: this was logger.info only).
+        message = (
             f"Skipping pull for integration {integration_id}: Lotek connection budget "
             f"exhausted; the next scheduled tick will retry."
         )
+        logger.info(message)
+        streak = await _bump_dispatcher_skip_streak(integration_id)
+        if streak >= DISPATCHER_SKIP_WARN_AFTER:
+            await _try_log_activity(
+                integration_id, "pull_observations",
+                f"{message} ({streak} consecutive ticks skipped on connection-budget exhaustion.)",
+                LogLevel.WARNING,
+            )
         return {"skipped": True, "reason": "no_connection_slot"}
     except httpx.TransportError as e:
         # Transport failures reaching Lotek are the same class the per-device
@@ -322,6 +349,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         raise  # bare: preserve the original traceback
 
     logger.info(f"Extracted {len(device_list)} devices from Lotek for inbound: {integration.id}")
+    await _reset_dispatcher_skip_streak(integration_id)
     if not device_list:
         return {"devices_found": 0, "shards_triggered": 0}
 
@@ -347,14 +375,72 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     return {"devices_found": len(device_list), "shards_triggered": len(shards)}
 
 
-async def _retrigger_shard(integration_id, device_ids):
+async def _bump_dispatcher_skip_streak(integration_id):
+    """Best-effort consecutive-skip counter for the dispatcher's slot-starved
+    tick skips. A Redis blip must not turn a clean skip into a failure."""
+    try:
+        saved = await state_manager.get_state(
+            integration_id, "pull_observations", DISPATCHER_SKIP_STREAK_SOURCE
+        )
+        streak = int((saved or {}).get("streak", 0)) + 1
+        await state_manager.set_state(
+            integration_id, "pull_observations", {"streak": streak}, DISPATCHER_SKIP_STREAK_SOURCE
+        )
+        return streak
+    except Exception as e:
+        logger.warning(
+            f"Could not track skip streak for integration {integration_id}: {describe_exception(e)}"
+        )
+        return 1
+
+
+async def _reset_dispatcher_skip_streak(integration_id):
+    try:
+        await state_manager.delete_state(
+            integration_id, "pull_observations", DISPATCHER_SKIP_STREAK_SOURCE
+        )
+    except Exception as e:
+        logger.warning(
+            f"Could not reset skip streak for integration {integration_id}: {describe_exception(e)}"
+        )
+
+
+async def _retrigger_shard(integration, device_ids, generation):
     """Re-dispatch deferred devices as a fresh shard with its own budget,
-    instead of parking them until the next scheduled tick. Best-effort: the
-    next tick re-lists and re-shards everything anyway."""
+    instead of parking them until the next scheduled tick.
+
+    Governed by SHARD_RETRIGGER_CAP: `generation` is the CURRENT shard's hop
+    count, and the cap bounds how deep a defer-retrigger chain can grow before
+    the tail falls back to the next scheduled tick — an ungoverned chain under
+    sustained slot starvation was an unbounded busy-loop of zero-progress
+    invocations, invisible because each hop reported success (review finding).
+    Returns True only when the tail was actually handed off. Best-effort
+    otherwise: the next tick re-lists and re-shards everything anyway.
+    """
+    integration_id = str(integration.id)
+    if generation >= SHARD_RETRIGGER_CAP:
+        # ERROR, not WARNING: the account failed to drain within ~cap action
+        # budgets — either the connection budget is far too small for the
+        # fleet or something is systemically slow. The data self-heals on the
+        # next tick; the signal must not.
+        message = (
+            f"Shard re-trigger cap ({SHARD_RETRIGGER_CAP}) reached for integration "
+            f"{integration_id}: deferring {len(device_ids)} device(s) to the next "
+            f"scheduled tick: {_summarize_ids(device_ids)}."
+        )
+        logger.error(message)
+        await _try_log_activity(
+            integration_id, "pull_observations_shard", message, LogLevel.ERROR
+        )
+        return False
     try:
         await trigger_action(
             integration_id, "pull_observations_shard",
-            config=PullObservationsShardConfig(devices=device_ids, triggered_by="pull_observations_shard")
+            config=PullObservationsShardConfig(
+                devices=device_ids,
+                triggered_by="pull_observations_shard",
+                generation=generation + 1,
+            )
         )
         return True
     except Exception as e:
@@ -408,6 +494,7 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
     failed_devices = []
     deferred_devices = []
     retriggered = False
+    budget_starved = False
     serviced_devices = 0
     # Only reflects devices actually processed this run — a device deferred by
     # the rails before its gap status is checked doesn't trigger backfill this
@@ -422,7 +509,9 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             # does NOT re-trigger — that would defeat the pause the breaker
             # exists to buy. Its devices wait for the next scheduled tick.
             if reason == "deadline":
-                retriggered = await _retrigger_shard(integration_id, deferred_devices)
+                retriggered = await _retrigger_shard(
+                    integration, deferred_devices, action_config.generation
+                )
             break
         chunk = device_states[chunk_start:chunk_start + FETCH_CONCURRENCY]
         results = await asyncio.gather(
@@ -486,11 +575,14 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             deferred_devices = slot_starved + [
                 device_id for device_id, _, _ in device_states[chunk_start + FETCH_CONCURRENCY:]
             ]
+            budget_starved = True
             logger.info(
                 f"Deferring {len(deferred_devices)} device(s) for integration {integration_id}: "
                 f"Lotek connection budget exhausted."
             )
-            retriggered = await _retrigger_shard(integration_id, deferred_devices)
+            retriggered = await _retrigger_shard(
+                integration, deferred_devices, action_config.generation
+            )
             break
 
     if failed_devices:
@@ -525,11 +617,17 @@ async def action_pull_observations_shard(integration, action_config: PullObserva
             level=LogLevel.WARNING
         )
 
-    if device_states and serviced_devices == 0 and observations_extracted == 0 and not retriggered:
+    if (device_states and serviced_devices == 0 and observations_extracted == 0
+            and not retriggered and not budget_starved):
         # Zero progress: nothing serviced, nothing delivered, and no deferred
         # tail re-dispatched — systemic degradation, must alert rather than
         # publish action_complete. A successfully re-triggered deferral is
-        # progress (the work moved to a fresh budget), so it stays a warning.
+        # progress (the work moved to a fresh budget). Slot starvation NEVER
+        # raises, even when the re-trigger hand-off also failed: it is a clean
+        # budget back-off, not degradation (mirrors backfill's budget_starved;
+        # review finding — the old condition flipped a starvation + pubsub
+        # blip into a false systemic ERROR). Starvation visibility comes from
+        # the deferral WARNING and the re-trigger cap's ERROR instead.
         raise LotekException(
             message=(
                 f"No devices could be serviced for integration {integration.id}: "
@@ -647,6 +745,13 @@ async def _fetch_window(device_id, integration, auth, config, lower_date, upper_
     try:
         async for attempt in stamina.retry_context(**_fetch_retry_kwargs(guards.run_started_at), wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
             with attempt:
+                # Pre-resolve the token OUTSIDE the slot: get_positions calls
+                # get_token internally, and on a cache miss that is a full
+                # login (plus possible queueing on the per-integration token
+                # lock) — holding a slot through it both starves peers and
+                # risks outliving the slot TTL (review finding). Pre-warmed,
+                # the in-slot get_token is a single cached Redis read.
+                await client.get_token(integration, auth)
                 # The slot is held for exactly one request and re-acquired on
                 # retry, so a stamina backoff never parks a slot idle.
                 async with lotek_slot(auth.username):
@@ -939,6 +1044,8 @@ async def action_backfill_observations(integration, action_config: BackfillObser
         try:
             async for attempt in stamina.retry_context(on=RETRYABLE_ERRORS, attempts=RETRY_ATTEMPTS, wait_initial=RETRY_WAIT_INITIAL, wait_jitter=RETRY_WAIT_JITTER, wait_max=RETRY_WAIT_MAX):
                 with attempt:
+                    # Token outside the slot — see _fetch_window.
+                    await client.get_token(integration, auth)
                     async with lotek_slot(auth.username):
                         device_list = await client.get_devices(integration, auth)
         except NoConnectionSlot:

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -64,6 +64,22 @@ def _stub_state_delete(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _stub_state_increment_counter(monkeypatch):
+    # The dispatcher bumps its slot-skip streak with increment_counter on
+    # every no_connection_slot skip. Most handler tests mock get_state/
+    # set_state but not increment_counter, so without this it reaches a real
+    # Redis (slow stamina retries, and a leaked real key/client behind the
+    # closed test event loop — review finding I2). Tests exercising the
+    # streak itself patch increment_counter with mocker.patch, which — being
+    # applied inside the test body, after this fixture runs — takes
+    # precedence for the duration of that test.
+    from app.services.state import IntegrationStateManager
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(IntegrationStateManager, "increment_counter", AsyncMock(return_value=1))
+
+
+@pytest.fixture(autouse=True)
 def _grant_backfill_trigger_claim(monkeypatch):
     # set_if_absent is the atomic "one backfill trigger per window" claim. It
     # is not part of the class-level get_state/set_state mocking most tests do,
@@ -83,13 +99,22 @@ def _grant_connection_slots(monkeypatch):
     # every slot by default so handler tests don't need a Redis server; tests
     # exercising budget exhaustion patch app.actions.handlers.lotek_slot to
     # raise NoConnectionSlot themselves.
+    #
+    # Every call's (username, kwargs) is recorded in order so tests can assert
+    # on how a given handler actually invokes lotek_slot (e.g. that the
+    # per-device/backfill paths still pass max_wait_seconds) — a signature
+    # check alone proves nothing about the call sites (review finding I1).
     from contextlib import asynccontextmanager
+
+    calls = []
 
     @asynccontextmanager
     async def granted_slot(username, **kwargs):
+        calls.append({"username": username, **kwargs})
         yield
 
     monkeypatch.setattr("app.actions.handlers.lotek_slot", granted_slot)
+    return calls
 
 
 @pytest.fixture(autouse=True)

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -51,6 +51,21 @@ def _reset_shared_http_client():
 
 
 @pytest.fixture(autouse=True)
+def _grant_connection_slots(monkeypatch):
+    # lotek_slot talks to real Redis (per-account connection budget). Grant
+    # every slot by default so handler tests don't need a Redis server; tests
+    # exercising budget exhaustion patch app.actions.handlers.lotek_slot to
+    # raise NoConnectionSlot themselves.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def granted_slot(username, **kwargs):
+        yield
+
+    monkeypatch.setattr("app.actions.handlers.lotek_slot", granted_slot)
+
+
+@pytest.fixture(autouse=True)
 def _zero_retry_waits(monkeypatch):
     # Retry-path tests otherwise sleep through real stamina backoff (minutes
     # over the suite, enough to blow a CI step timeout — review finding).

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -51,6 +51,33 @@ def _reset_shared_http_client():
 
 
 @pytest.fixture(autouse=True)
+def _stub_state_delete(monkeypatch):
+    # The dispatcher clears its slot-skip streak with delete_state on every
+    # non-starved outcome. Most handler tests mock get_state/set_state but not
+    # delete_state, so without this the call reaches a real Redis and burns
+    # ~19s of stamina retries per test. Tests that assert on deletion patch it
+    # themselves.
+    from app.services.state import IntegrationStateManager
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(IntegrationStateManager, "delete_state", AsyncMock(return_value=None))
+
+
+@pytest.fixture(autouse=True)
+def _grant_backfill_trigger_claim(monkeypatch):
+    # set_if_absent is the atomic "one backfill trigger per window" claim. It
+    # is not part of the class-level get_state/set_state mocking most tests do,
+    # so without this it reaches a real Redis (slow stamina retries). Granted
+    # by default; the duplicate-suppression test overrides it.
+    from app.services.state import IntegrationStateManager
+
+    async def granted(self, integration_id, action_id, *, ttl_seconds, source_id="no-source"):
+        return True
+
+    monkeypatch.setattr(IntegrationStateManager, "set_if_absent", granted)
+
+
+@pytest.fixture(autouse=True)
 def _grant_connection_slots(monkeypatch):
     # lotek_slot talks to real Redis (per-account connection budget). Grant
     # every slot by default so handler tests don't need a Redis server; tests

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -9,7 +9,7 @@ from app.actions.handlers import (
     BACKFILL_MAX_WINDOWS_PER_DEVICE,
     action_backfill_observations,
 )
-from app.actions.client import LotekDevice, LotekException
+from app.actions.client import LotekDevice
 from app.actions.configurations import BackfillObservationsConfig, PullObservationsConfig
 
 
@@ -248,8 +248,12 @@ async def test_backfill_malformed_data_failure_logs_error_not_warning(
         mocker, mock_redis, _devices("1"), {"1": _gap_state()}
     )
     get_positions.return_value = None  # blows up in filter_and_transform_positions
-    with pytest.raises(LotekException):  # single device, zero progress
-        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    # Single device, so this is also a zero-progress run — reported on the
+    # result now instead of raised (spec D7).
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["zero_progress"] is True
     device_logs = [c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")]
     assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
 
@@ -338,8 +342,10 @@ async def test_backfill_does_not_retrigger_when_all_gaps_closed(
 async def test_backfill_does_not_retrigger_on_zero_progress(
     mocker, lotek_integration, mock_redis
 ):
-    # Zero progress raises — the raise is the cascade's natural chain-breaker,
-    # otherwise a wholly-failing backfill would re-trigger itself forever.
+    # Zero progress breaks the cascade: the raise used to be its natural
+    # chain-breaker, and `not zero_progress` on the gaps_remaining gate now
+    # carries that explicitly (spec D7). A wholly-failing backfill must not
+    # re-trigger itself forever.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     get_positions, _, _, _, _ = _setup_backfill_mocks(
@@ -347,23 +353,36 @@ async def test_backfill_does_not_retrigger_on_zero_progress(
     )
     get_positions.side_effect = httpx.ReadTimeout("")
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
-    with pytest.raises(LotekException):
-        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["zero_progress"] is True
     trigger.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_backfill_zero_progress_raises(
+async def test_backfill_zero_progress_reports_and_still_releases_the_lease(
     mocker, lotek_integration, mock_redis
 ):
+    # Was test_backfill_zero_progress_raises: the ERROR activity event replaced
+    # the raise (spec D7), so the lease release now happens on a normal return
+    # through the finally rather than while an exception unwinds.
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
-    get_positions, _, _, release, _ = _setup_backfill_mocks(
+    get_positions, _, _, release, log = _setup_backfill_mocks(
         mocker, mock_redis, _devices("1"), {"1": _gap_state()}
     )
     get_positions.side_effect = httpx.ReadTimeout("")
-    with pytest.raises(LotekException, match="No devices could be backfilled"):
-        await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["zero_progress"] is True
+    zero_progress_errors = [
+        c for c in log.await_args_list
+        if c.kwargs.get("level") == LogLevel.ERROR
+        and "No devices could be backfilled" in c.kwargs.get("title", "")
+    ]
+    assert zero_progress_errors, "the health signal must still reach the activity feed"
     release.assert_awaited_once()
 
 
@@ -435,3 +454,58 @@ async def test_backfill_skips_quietly_when_config_is_missing(
     get_positions.assert_not_awaited()
     error_logs = [c for c in log.await_args_list if c.kwargs.get("level") == LogLevel.ERROR]
     assert not error_logs
+
+
+# --- spec D7: zero progress reports instead of raising -----------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_progress_backfill_reports_instead_of_raising(
+    mocker, lotek_integration, mock_redis
+):
+    """Raising routed through the runner's generic _handle_error, which
+    publishes config_data containing the integration's plaintext auth
+    (GUNDI-5628). Backfill adopts the head pass's ERROR-event + result-flag
+    contract instead (spec D7), and must still suppress the self-retrigger."""
+    _setup_backfill_mocks(mocker, mock_redis, _devices("1"), {"1": _gap_state()})
+    mocker.patch(
+        "app.actions.handlers._backfill_device",
+        new=AsyncMock(side_effect=ValueError("boom")),
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    try_log = mocker.patch("app.actions.handlers._try_log_activity", new=AsyncMock())
+
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig(triggered_by="test")
+    )
+
+    assert result["zero_progress"] is True
+    # ERROR activity event carries the health signal...
+    assert try_log.await_args.args[3] is LogLevel.ERROR
+    # ...and the cascade stays broken, exactly as the raise used to guarantee.
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_zero_progress_backfill_breaks_the_cascade_after_a_window_advanced(
+    mocker, lotek_integration, mock_redis
+):
+    # The removed raise broke the cascade implicitly by unwinding before the
+    # re-trigger. A run that advanced an empty window and then failed satisfies
+    # every other gaps_remaining conjunct, so `not zero_progress` has to be
+    # explicit or a wholly-failing backfill would re-trigger itself forever.
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": _gap_state(days_back_start=14)}
+    )
+    # Window 1 delivers nothing but advances the gap; window 2's fetch fails.
+    get_positions.side_effect = [[]] + [httpx.ReadTimeout("")] * 4
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+
+    assert result["observations_extracted"] == 0
+    assert result["devices_failed"] == ["1"]
+    assert result["zero_progress"] is True
+    trigger.assert_not_awaited()

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -577,3 +577,27 @@ async def test_deadline_stop_still_publishes_the_zero_progress_error(
     assert _zero_progress_errors(log), (
         "a deadline stop must NOT suppress the zero-progress ERROR"
     )
+
+
+@pytest.mark.asyncio
+async def test_backfill_device_listing_requests_a_bounded_wait_on_the_slot(
+    mocker, lotek_integration, mock_redis, _grant_connection_slots
+):
+    """Same headline wiring as the shard's per-device fetch (review finding
+    I1), but for the backfill's own device-listing lotek_slot acquire. A
+    gap-less device means no per-device fetch happens at all, so the only
+    lotek_slot call in this run is the device-listing one — isolating it."""
+    from app.actions.handlers import DEADLINE_FRACTION
+    from app import settings as app_settings
+
+    now = datetime.now(timezone.utc)
+    get_positions, _, _, _, _ = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1"), {"1": {"high_water": now.isoformat()}}
+    )
+
+    await action_backfill_observations(lotek_integration, BackfillObservationsConfig())
+
+    get_positions.assert_not_awaited()  # no gap, so no per-device fetch
+    assert len(_grant_connection_slots) == 1
+    recorded = _grant_connection_slots[0]
+    assert 0 < recorded["max_wait_seconds"] <= DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME

--- a/app/actions/tests/test_backfill.py
+++ b/app/actions/tests/test_backfill.py
@@ -509,3 +509,71 @@ async def test_zero_progress_backfill_breaks_the_cascade_after_a_window_advanced
     assert result["devices_failed"] == ["1"]
     assert result["zero_progress"] is True
     trigger.assert_not_awaited()
+
+
+def _zero_progress_errors(log):
+    return [
+        c for c in log.await_args_list
+        if c.kwargs.get("level") == LogLevel.ERROR
+        and "No devices could be backfilled" in c.kwargs.get("title", "")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_breaker_stop_still_publishes_the_zero_progress_error(
+    mocker, lotek_integration, mock_redis
+):
+    # Pins backfill's suppression policy (spec criterion 8: alerting unchanged).
+    # ONLY connection-budget starvation excuses a no-progress backfill run. A
+    # hot circuit breaker must NOT: a Lotek-wide outage is exactly when a
+    # breaker stop and zero progress co-occur, and the cdip health metric counts
+    # ERROR activity events — suppressing here would make the outage look
+    # healthy. The shard's expression deliberately differs; unifying the two
+    # (an earlier draft hoisted a shared `deferred_cleanly` onto the traversal)
+    # would silently break this, so assert it rather than trust the expression.
+    get_positions, _, _, _, log = _setup_backfill_mocks(
+        mocker, mock_redis,
+        _devices("1", "2", "3", "4", "5", "6"),
+        {d: _gap_state() for d in ("1", "2", "3", "4", "5", "6")},
+    )
+    # Every fetch times out: chunk 1 (FETCH_CONCURRENCY=5) records 5 consecutive
+    # transport failures, so should_stop() before chunk 2 returns
+    # "circuit breaker" and defers device 6.
+    get_positions.side_effect = httpx.ReadTimeout("")
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    assert result["devices_failed"] == ["1", "2", "3", "4", "5"]
+    assert result["devices_deferred"] == ["6"]  # the breaker really did stop it
+    breaker_deferrals = [
+        c for c in log.await_args_list
+        if c.kwargs.get("level") == LogLevel.WARNING
+        and "circuit breaker" in c.kwargs.get("title", "")
+    ]
+    assert breaker_deferrals, "the breaker stop must be the reason the tail deferred"
+    assert result["zero_progress"] is True
+    assert _zero_progress_errors(log), (
+        "a breaker stop must NOT suppress the zero-progress ERROR"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deadline_stop_still_publishes_the_zero_progress_error(
+    mocker, lotek_integration, mock_redis
+):
+    # Same policy, other stop reason: a deadline cut is not a clean back-off for
+    # backfill (unlike the shard, it hands nothing off to a fresh budget), so it
+    # must keep alerting too.
+    get_positions, _, _, _, log = _setup_backfill_mocks(
+        mocker, mock_redis, _devices("1", "2"), {"1": _gap_state(), "2": _gap_state()}
+    )
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+    result = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig()
+    )
+    get_positions.assert_not_awaited()  # stopped before the first chunk
+    assert result["devices_deferred"] == ["1", "2"]
+    assert result["zero_progress"] is True
+    assert _zero_progress_errors(log), (
+        "a deadline stop must NOT suppress the zero-progress ERROR"
+    )

--- a/app/actions/tests/test_backfill_trigger_e2e.py
+++ b/app/actions/tests/test_backfill_trigger_e2e.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock
 
 from gundi_core.schemas.v2 import IntegrationActionConfiguration
 from app.actions.client import LotekDevice
-from app.actions.handlers import action_pull_observations
+from app.actions.configurations import PullObservationsShardConfig
+from app.actions.handlers import (
+    BACKFILL_TRIGGER_CLAIM_SOURCE,
+    action_pull_observations,
+    action_pull_observations_shard,
+)
+from app.services.state import IntegrationStateManager
+from .test_handlers import _setup_pull_mocks
 
 
 @pytest.mark.asyncio
@@ -66,3 +73,39 @@ async def test_pull_observations_trigger_actually_runs_backfill_end_to_end(mocke
         f"backfill_observations never ran — the trigger's config resolution "
         f"short-circuited it. pull_observations result: {result}"
     )
+
+
+@pytest.mark.asyncio
+async def test_claim_is_released_when_the_trigger_publish_fails(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    """The claim (TTL 540s) is taken before the publish. If the publish fails,
+    a stale claim suppresses backfill for every other shard this tick AND the
+    next — pre-sharding a lost trigger self-healed on the next run. Roll back.
+
+    Setup mirrors test_sharding.py::test_only_one_shard_triggers_backfill_per_window
+    (a proven way to reach the any_open_gap-and-not-zero_progress branch: an
+    unsaved device on its first run opens a gap from the lookback floor, and a
+    quiet (positions=[]) fetch still counts as serviced, so zero_progress stays
+    False). The only difference here is that trigger_action raises."""
+    _setup_pull_mocks(mocker, mock_redis, [], saved_state=None)
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    mocker.patch(
+        "app.actions.handlers.trigger_action", side_effect=RuntimeError("pubsub down")
+    )
+    # set_if_absent is granted by an autouse fixture (conftest's
+    # _grant_backfill_trigger_claim) and get_state returns {} (falsy, i.e. no
+    # lease yet) via _setup_pull_mocks above, so the claim is won and the
+    # publish is attempted. delete_state is also autouse-stubbed
+    # (_stub_state_delete); re-patch it here so this test can assert on it.
+    delete_state = mocker.patch.object(
+        IntegrationStateManager, "delete_state", new=AsyncMock(return_value=None)
+    )
+
+    await action_pull_observations_shard(
+        lotek_integration, PullObservationsShardConfig(devices=["1"])
+    )
+
+    delete_state.assert_awaited_once()
+    assert delete_state.await_args.args[1] == "backfill_observations"
+    assert delete_state.await_args.kwargs["source_id"] == BACKFILL_TRIGGER_CLAIM_SOURCE

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -640,9 +640,13 @@ async def test_action_pull_observations_does_not_retry_rejected_login_at_get_dev
         raise LotekUnauthorizedException(message="Lotek login failed", status_code=400)
 
     mocker.patch("app.actions.client.get_devices", new=get_devices)
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
 
+    # The dispatcher owns the get_devices retry loop; calling it directly is
+    # what exercises the no-retry-on-refused-login guarantee (review finding:
+    # the run_head_pass conversion made this assertion vacuous).
     with pytest.raises(LotekUnauthorizedException):
-        await run_head_pass(lotek_integration, pull_config)
+        await action_pull_observations(lotek_integration, pull_config)
 
     assert len(attempts) == 1, f"refused login was retried {len(attempts)} times"
 

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -438,8 +438,11 @@ async def test_action_pull_observations_fails_when_every_device_fails(
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
 
-    with pytest.raises(LotekException):
-        await run_head_pass(lotek_integration, pull_config)
+    # Reported via the zero_progress result flag + an ERROR activity event,
+    # not raised (a raise leaks the integration config through the runner's
+    # generic error handler — review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
 
 
 @pytest.mark.asyncio
@@ -488,8 +491,11 @@ async def test_action_pull_observations_logs_exception_type_when_message_is_empt
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
 
     # the only device fails and delivers nothing, so the run is reported as failed
-    with pytest.raises(LotekException):
-        await run_head_pass(lotek_integration, pull_config)
+    # Reported via the zero_progress result flag + an ERROR activity event,
+    # not raised (a raise leaks the integration config through the runner's
+    # generic error handler — review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
 
     # Transport failures are local-log only (publish-volume fix); the
     # exception type must still be named in the local warning.
@@ -742,8 +748,11 @@ async def test_action_pull_observations_emits_summary_before_all_failed_raise(
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
 
-    with pytest.raises(LotekException):
-        await run_head_pass(lotek_integration, pull_config)
+    # Reported via the zero_progress result flag + an ERROR activity event,
+    # not raised (a raise leaks the integration config through the runner's
+    # generic error handler — review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
 
     warnings = [c.kwargs["title"] for c in mock_log_action_activity.call_args_list
                 if c.kwargs.get("level") == LogLevel.WARNING and "failing" in c.kwargs["title"]]
@@ -1036,9 +1045,9 @@ async def test_failed_head_fetch_does_not_advance_high_water(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
     )
     get_positions.side_effect = httpx.ReadTimeout("")
-    with pytest.raises(LotekException):
-        # single device, nothing serviced → the run-level failure raise
-        await run_head_pass(lotek_integration, pull_config)
+    # single device, nothing serviced → reported via zero_progress, not raised
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
     set_state.assert_not_awaited()
 
 
@@ -1075,8 +1084,11 @@ async def test_all_failed_run_raises_zero_progress(
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
     get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
     get_positions.side_effect = httpx.ReadTimeout("")
-    with pytest.raises(LotekException, match="No devices could be serviced"):
-        await run_head_pass(lotek_integration, pull_config)
+    # Zero progress is reported as an ERROR activity event and a result flag,
+    # not raised: raising routes through the runner's generic error handler,
+    # which publishes every integration config (auth included) (review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
 
 
 @pytest.mark.asyncio
@@ -1110,8 +1122,11 @@ async def test_zero_progress_run_raises_even_when_devices_were_only_deferred(
         new=AsyncMock(side_effect=Exception("pubsub down")),
     )
     mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
-    with pytest.raises(LotekException, match="No devices could be serviced"):
-        await run_head_pass(lotek_integration, pull_config)
+    # Zero progress is reported as an ERROR activity event and a result flag,
+    # not raised: raising routes through the runner's generic error handler,
+    # which publishes every integration config (auth included) (review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
 
 
 @pytest.mark.asyncio
@@ -1438,8 +1453,11 @@ async def test_lotek_5xx_failures_feed_the_circuit_breaker(
         mocker, mock_redis, _devices("1", "2", "3", "4", "5", "6", "7", "8")
     )
     get_positions.side_effect = LotekException(message="down", status_code=503)
-    with pytest.raises(LotekException, match="No devices could be serviced"):
-        await run_head_pass(lotek_integration, pull_config)
+    # Zero progress is reported as an ERROR activity event and a result flag,
+    # not raised: raising routes through the runner's generic error handler,
+    # which publishes every integration config (auth included) (review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
     # the first chunk's 5 consecutive 503s trip the breaker at the chunk
     # boundary; devices 6-8 (chunk 2) are deferred and never dispatched
     deferral_logs = [
@@ -1464,8 +1482,11 @@ async def test_lotek_4xx_failure_stays_error_and_does_not_feed_breaker(
         mocker, mock_redis, _devices("1", "2", "3", "4")
     )
     get_positions.side_effect = LotekException(message="bad request", status_code=404)
-    with pytest.raises(LotekException, match="No devices could be serviced"):
-        await run_head_pass(lotek_integration, pull_config)
+    # Zero progress is reported as an ERROR activity event and a result flag,
+    # not raised: raising routes through the runner's generic error handler,
+    # which publishes every integration config (auth included) (review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
     assert get_positions.await_count == 4, "4xx failures must not trip the breaker"
     device_logs = [c for c in log.await_args_list if "Device:" in c.kwargs.get("title", "")]
     assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
@@ -1533,8 +1554,11 @@ async def test_no_stale_drop_warning_when_the_fetch_fails(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
     )
     get_positions.side_effect = httpx.ReadTimeout("")
-    with pytest.raises(LotekException, match="No devices could be serviced"):
-        await run_head_pass(lotek_integration, pull_config)
+    # Zero progress is reported as an ERROR activity event and a result flag,
+    # not raised: raising routes through the runner's generic error handler,
+    # which publishes every integration config (auth included) (review finding).
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["zero_progress"] is True
     set_state.assert_not_awaited()
     assert not any(
         "stale range" in c.kwargs.get("title", "").lower() for c in log.await_args_list

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -814,6 +814,7 @@ async def test_get_devices_failure_logs_exception_type_when_message_is_empty(
     mocker.patch("app.services.activity_logger.publish_event", new=AsyncMock())
     mocker.patch("app.actions.handlers.RETRY_WAIT_INITIAL", 0)
     mocker.patch("app.actions.handlers.RETRY_WAIT_JITTER", 0)
+    mocker.patch("app.actions.client.get_token", new=AsyncMock(return_value="token"))
     mocker.patch(
         "app.actions.client.get_devices",
         new=AsyncMock(side_effect=httpx.ReadTimeout("")),

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -4,14 +4,30 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 from gundi_core.schemas.v2 import LogLevel
+from unittest.mock import patch as _patch
+
 from app.actions.handlers import (
     FETCH_CONCURRENCY,
     RETRY_ATTEMPTS,
     action_auth,
     action_pull_observations,
+    action_pull_observations_shard,
     filter_and_transform_positions,
 )
+from app.actions.configurations import PullObservationsShardConfig
 from app.actions.client import LotekDevice, LotekException, LotekUnauthorizedException
+
+
+async def run_head_pass(integration, pull_config):
+    """Drive the head pass the way production does post-sharding (GUNDI-5620):
+    the device list (tests patch client.get_devices) becomes one shard, and the
+    shard action reads the pull config from the integration — patched here to
+    the test's pull_config fixture so per-test mutations apply."""
+    import app.actions.client as client
+    devices = await client.get_devices(integration, None)
+    config = PullObservationsShardConfig(devices=[d.nDeviceID for d in devices])
+    with _patch("app.actions.handlers.get_pull_config", return_value=pull_config):
+        return await action_pull_observations_shard(integration, config)
 
 
 @pytest.mark.asyncio
@@ -99,7 +115,7 @@ async def test_invalid_position_filtered_and_logs_warning_when_no_valid_observat
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result == {'observations_extracted': 0, 'devices_failed': [], 'devices_deferred': []}
     # Publish-volume fix: quiet devices are local-log only — one portal WARNING
     # per dormant device was the largest pubsub-congestion contributor.
@@ -122,7 +138,7 @@ async def test_lookback_days_config_sets_first_run_gap_depth(mocker, lotek_integ
     mock_set_state = mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
     mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
     pull_config.default_lookback_days = 30
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     assert len(mock_get_positions.call_args_list) == 1
     saved = mock_set_state.call_args.args[2]
     gap_age_days = (datetime.now(timezone.utc) - saved["gap_start"]).days
@@ -137,7 +153,7 @@ async def test_action_pull_observations_success(mocker, lotek_integration, pull_
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[]))
     mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(return_value={}))
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(return_value=None))
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result == {'observations_extracted': 0, 'devices_failed': [], 'devices_deferred': []}
 
 def _devices(*device_ids):
@@ -172,7 +188,7 @@ async def test_action_pull_observations_continues_after_one_device_fails(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     # Device 2 exhausts its retries and is given up on, but devices 1 and 3 are
     # still serviced. Devices fetch concurrently within a chunk, so only the
@@ -207,7 +223,7 @@ async def test_action_pull_observations_continues_after_lotek_error_status(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert queried == ["1", "2", "3"]
     assert result == {"observations_extracted": 2, "devices_failed": ["2"], "devices_deferred": []}
@@ -239,7 +255,7 @@ async def test_action_pull_observations_continues_after_malformed_device_data(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert queried[-1] == "3"
     assert result == {"observations_extracted": 2, "devices_failed": ["2"], "devices_deferred": []}
@@ -278,7 +294,7 @@ async def test_action_pull_observations_aborts_when_login_is_rejected(
     mocker.patch("app.services.state.IntegrationStateManager.delete_state", new=AsyncMock(return_value=None))
 
     with pytest.raises(LotekUnauthorizedException):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
     # The rejection memo in get_token means concurrent waiters re-raise the
     # cached refusal instead of each attempting a real login (lockout risk).
@@ -312,7 +328,7 @@ async def test_action_pull_observations_continues_when_one_device_send_fails(
 
     mocker.patch("app.services.gundi.send_observations_to_gundi", new=send_observations_to_gundi)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert len(sent_for) == 2, "second device was never attempted"
     assert result["devices_failed"] == ["1"]
@@ -341,7 +357,7 @@ async def test_action_pull_observations_counts_data_delivered_before_downstream_
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(return_value=[lotek_position]))
     mocker.patch("app.services.gundi.send_observations_to_gundi", new=AsyncMock())
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert result == {"observations_extracted": 1, "devices_failed": ["1"], "devices_deferred": []}
 
@@ -368,7 +384,7 @@ async def test_action_pull_observations_summary_names_failed_devices(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
 
     warnings = [c.kwargs["title"] for c in mock_log_action_activity.call_args_list
                 if c.kwargs.get("level") == LogLevel.WARNING and "failing" in c.kwargs["title"]]
@@ -401,7 +417,7 @@ async def test_action_pull_observations_continues_when_one_device_checkpoint_fai
 
     mocker.patch("app.services.state.IntegrationStateManager.set_state", new=set_state)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert "2" in checkpointed, "second device was never processed"
     assert result["devices_failed"] == ["1"]
@@ -423,7 +439,7 @@ async def test_action_pull_observations_fails_when_every_device_fails(
     mocker.patch("app.actions.client.get_positions", new=AsyncMock(side_effect=httpx.ReadTimeout("")))
 
     with pytest.raises(LotekException):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
 
 @pytest.mark.asyncio
@@ -448,7 +464,7 @@ async def test_action_pull_observations_does_not_advance_state_for_failed_device
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
 
     advanced_devices = [call.args[-1] for call in mock_set_state.call_args_list]
     assert "1" in advanced_devices
@@ -473,7 +489,7 @@ async def test_action_pull_observations_logs_exception_type_when_message_is_empt
 
     # the only device fails and delivers nothing, so the run is reported as failed
     with pytest.raises(LotekException):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
     # Transport failures are local-log only (publish-volume fix); the
     # exception type must still be named in the local warning.
@@ -509,7 +525,7 @@ async def test_action_pull_observations_retries_transient_timeout(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert len(attempts) == 2, "the transient timeout should have been retried"
     assert result == {"observations_extracted": 1, "devices_failed": [], "devices_deferred": []}
@@ -542,7 +558,7 @@ async def test_action_pull_observations_aborts_on_auth_failure(
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
     with pytest.raises(LotekUnauthorizedException):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
     first_chunk = {str(i) for i in range(1, FETCH_CONCURRENCY + 1)}
     assert set(queried) == first_chunk, (
@@ -599,7 +615,7 @@ async def test_action_pull_observations_isolates_persistent_401_on_one_device(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert "3" in queried, "devices after the 401 device were never queried"
     assert result["devices_failed"] == ["2"]
@@ -626,7 +642,7 @@ async def test_action_pull_observations_does_not_retry_rejected_login_at_get_dev
     mocker.patch("app.actions.client.get_devices", new=get_devices)
 
     with pytest.raises(LotekUnauthorizedException):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
     assert len(attempts) == 1, f"refused login was retried {len(attempts)} times"
 
@@ -649,7 +665,7 @@ async def test_action_pull_observations_quiet_device_unaffected_by_logging_failu
     mocker.patch("app.actions.handlers.log_action_activity",
                  new=AsyncMock(side_effect=RuntimeError("pubsub down")))
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert result["devices_failed"] == []
     assert [c.args[-1] for c in mock_set_state.call_args_list] == ["1"], "cursor was not advanced"
@@ -678,7 +694,7 @@ async def test_action_pull_observations_isolates_transform_failure_to_the_device
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert result["devices_failed"] == ["1"]
     assert mock_send.call_count == 1, "the device behind the malformed one was not delivered"
@@ -699,7 +715,7 @@ async def test_malformed_data_failure_logs_error_not_warning(
         return None if device_id == "1" else []  # device 1: malformed; device 2: fine
 
     get_positions.side_effect = get_positions_side_effect
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == ["1"]
     device_logs = [c for c in log.await_args_list if "Device: 1" in c.kwargs.get("title", "")]
     assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
@@ -723,7 +739,7 @@ async def test_action_pull_observations_emits_summary_before_all_failed_raise(
     mock_log_action_activity = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
 
     with pytest.raises(LotekException):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
     warnings = [c.kwargs["title"] for c in mock_log_action_activity.call_args_list
                 if c.kwargs.get("level") == LogLevel.WARNING and "failing" in c.kwargs["title"]]
@@ -781,7 +797,7 @@ async def test_action_pull_observations_retries_token_expiry_and_recovers(
 
     mocker.patch("app.actions.client.get_positions", new=get_positions)
 
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
 
     assert len(attempts) == 2, "token expiry was not retried"
     assert result == {"observations_extracted": 1, "devices_failed": [], "devices_deferred": []}
@@ -845,7 +861,7 @@ async def test_head_pass_fetches_single_max_age_window_on_first_run(
     # First run: ONE request per device covering [now - max_data_age_hours, now]
     # — not a chunked walk over the whole lookback.
     get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     assert get_positions.await_count == 1
     start, end = get_positions.call_args.args[3], get_positions.call_args.args[4]
     assert abs((end - start) - timedelta(hours=pull_config.max_data_age_hours)) < timedelta(minutes=1)
@@ -856,7 +872,7 @@ async def test_first_run_opens_gap_from_lookback_to_freshness_floor(
     mocker, lotek_integration, pull_config, mock_redis
 ):
     _, _, set_state, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     saved = set_state.call_args.args[2]
     gap_span = saved["gap_end"] - saved["gap_start"]
     expected = timedelta(days=pull_config.default_lookback_days) - timedelta(
@@ -898,7 +914,7 @@ async def test_steady_state_advances_high_water_and_keeps_gap_closed(
     get_positions, _, set_state, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": recent}
     )
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     start = get_positions.call_args.args[3]
     from app.actions.handlers import HEAD_LATE_UPLOAD_OVERLAP
     assert abs(
@@ -929,7 +945,7 @@ async def test_stale_span_is_dropped_with_warning_and_not_added_to_gap(
     get_positions, _, set_state, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": stale}
     )
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     start = get_positions.call_args.args[3]
     assert abs(
         (datetime.now(timezone.utc) - start) - timedelta(hours=pull_config.max_data_age_hours)
@@ -959,7 +975,7 @@ async def test_legacy_updated_at_state_migrates_to_high_water(
     get_positions, _, set_state, _ = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"updated_at": recent}
     )
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     start = get_positions.call_args.args[3]
     from app.actions.handlers import HEAD_LATE_UPLOAD_OVERLAP
     assert abs(
@@ -989,7 +1005,7 @@ async def test_transient_fetch_failure_logs_warning_not_error(
         return []
 
     get_positions.side_effect = get_positions_side_effect
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == ["1"]
     # Transport failures are local-log only; the end-of-run summary is the
     # single portal publish and it is a WARNING, not an ERROR.
@@ -1017,7 +1033,7 @@ async def test_failed_head_fetch_does_not_advance_high_water(
     get_positions.side_effect = httpx.ReadTimeout("")
     with pytest.raises(LotekException):
         # single device, nothing serviced → the run-level failure raise
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
     set_state.assert_not_awaited()
 
 
@@ -1032,7 +1048,7 @@ async def test_delivery_failure_stays_error_and_does_not_advance_high_water(
         "app.actions.handlers.gundi_tools.send_observations_to_gundi",
         new=AsyncMock(side_effect=[Exception("boom"), None]),
     )
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == ["1"]
     error_logs = [
         c for c in log.await_args_list
@@ -1055,19 +1071,42 @@ async def test_all_failed_run_raises_zero_progress(
     get_positions, _, _, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
     get_positions.side_effect = httpx.ReadTimeout("")
     with pytest.raises(LotekException, match="No devices could be serviced"):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
+
+
+@pytest.mark.asyncio
+async def test_deferred_all_run_retriggers_tail_instead_of_raising(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Sharded head pass (GUNDI-5620): a deadline-deferred tail is handed a
+    # fresh budget immediately via a re-triggered shard. A successful hand-off
+    # IS progress, so the zero-progress alert must not fire.
+    _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+    result = await run_head_pass(lotek_integration, pull_config)
+    assert result["devices_deferred"] == ["1", "2"]
+    shard_calls = [
+        c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"
+    ]
+    assert len(shard_calls) == 1
+    assert shard_calls[0].kwargs["config"].devices == ["1", "2"]
 
 
 @pytest.mark.asyncio
 async def test_zero_progress_run_raises_even_when_devices_were_only_deferred(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # A run that services nothing is systemic degradation — it must alert
-    # (ERROR/raise), not warn forever. Deferring every device counts.
+    # A run that services nothing AND cannot hand its tail off (re-trigger
+    # publish fails) is systemic degradation — it must alert (ERROR/raise).
     _setup_pull_mocks(mocker, mock_redis, _devices("1", "2"))
+    mocker.patch(
+        "app.actions.handlers.trigger_action",
+        new=AsyncMock(side_effect=Exception("pubsub down")),
+    )
     mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
     with pytest.raises(LotekException, match="No devices could be serviced"):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
 
 
 @pytest.mark.asyncio
@@ -1089,7 +1128,7 @@ async def test_deadline_defers_remaining_devices_with_warning(
         "app.actions.handlers._deadline_exceeded",
         side_effect=itertools.chain([False] * 6, itertools.repeat(True)),
     )
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_deferred"] == ["6", "7", "8"]
     assert result["devices_failed"] == []
     deferral_logs = [
@@ -1146,7 +1185,7 @@ async def test_breaker_trips_after_three_consecutive_transport_failures(
         raise httpx.ReadTimeout("")
 
     get_positions.side_effect = get_positions_side_effect
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == ["2", "3", "4", "5"]
     assert result["devices_deferred"] == ["6", "7", "8"]
     breaker_logs = [
@@ -1176,7 +1215,7 @@ async def test_breaker_counter_resets_on_success(
         return []
 
     get_positions.side_effect = get_positions_side_effect
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_deferred"] == []
     assert result["devices_failed"] == ["1", "3", "5"]
 
@@ -1188,7 +1227,7 @@ async def test_head_pass_triggers_backfill_when_gap_open_and_lease_free(
     # First run on default config opens a gap → backfill must be triggered.
     _setup_pull_mocks(mocker, mock_redis, _devices("1"))
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     trigger.assert_awaited_once()
     args, kwargs = trigger.await_args
     assert args[:2] == (str(lotek_integration.id), "backfill_observations")
@@ -1209,7 +1248,7 @@ async def test_head_pass_does_not_trigger_backfill_when_lease_held(
         "app.services.state.IntegrationStateManager.get_state",
         new=AsyncMock(side_effect=lambda i, a, s="no-source": "1" if s == "lease" else {}),
     )
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     trigger.assert_not_awaited()
 
 
@@ -1220,7 +1259,7 @@ async def test_head_pass_does_not_trigger_backfill_without_gaps(
     recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
     _setup_pull_mocks(mocker, mock_redis, _devices("1"), saved_state={"high_water": recent})
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     trigger.assert_not_awaited()
 
 
@@ -1232,7 +1271,7 @@ async def test_trigger_failure_does_not_fail_the_head_pass(
     mocker.patch(
         "app.actions.handlers.trigger_action", new=AsyncMock(side_effect=Exception("pubsub down"))
     )
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == []
 
 
@@ -1264,7 +1303,7 @@ async def test_stale_drop_publish_failure_does_not_stall_the_device(
             raise Exception("pubsub down")
 
     log.side_effect = flaky_publish
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == []
     saved = set_state.call_args.args[2]
     assert abs(datetime.now(timezone.utc) - saved["high_water"]) < timedelta(minutes=1)
@@ -1279,7 +1318,7 @@ async def test_unparseable_state_reset_is_surfaced_at_warning(
     get_positions, _, _, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"high_water": "not-a-date"}
     )
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     reset_warnings = [
         c for c in log.await_args_list
         if c.kwargs["level"] == LogLevel.WARNING and "unparseable" in c.kwargs["title"].lower()
@@ -1313,7 +1352,7 @@ async def test_head_pass_save_does_not_clobber_concurrently_closed_gap(
     # 1st read = the head pass loading its snapshot (gap open);
     # 2nd read = the merge-save re-read (backfill closed the gap meanwhile).
     get_state.side_effect = [open_gap_state, gap_closed_state]
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     saved = set_state.call_args.args[2]
     assert saved.get("gap_start") is None and saved.get("gap_end") is None, (
         "the head pass resurrected a gap a concurrent backfill had closed"
@@ -1342,7 +1381,7 @@ async def test_stale_first_run_save_does_not_resurrect_a_gap_closed_meanwhile(
     # 1st read = this run loading state (absent → is_new, gap birthed in memory);
     # 2nd read = the merge-save re-read (the faster run + backfill already ran).
     get_state.side_effect = [{}, gap_closed_doc]
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     saved = set_state.call_args.args[2]
     assert saved.get("gap_start") is None and saved.get("gap_end") is None, (
         "a stale is_new save resurrected a gap a backfill had already closed"
@@ -1370,7 +1409,7 @@ async def test_stale_first_run_save_does_not_rewind_an_advanced_gap(
     }
     _, get_state, set_state, _ = _setup_pull_mocks(mocker, mock_redis, _devices("1"))
     get_state.side_effect = [{}, gap_advanced_doc]
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     saved = set_state.call_args.args[2]
     assert saved["gap_start"] == advanced_start, (
         "a stale is_new save rewound gap_start to its full-lookback snapshot"
@@ -1395,7 +1434,7 @@ async def test_lotek_5xx_failures_feed_the_circuit_breaker(
     )
     get_positions.side_effect = LotekException(message="down", status_code=503)
     with pytest.raises(LotekException, match="No devices could be serviced"):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
     # the first chunk's 5 consecutive 503s trip the breaker at the chunk
     # boundary; devices 6-8 (chunk 2) are deferred and never dispatched
     deferral_logs = [
@@ -1421,7 +1460,7 @@ async def test_lotek_4xx_failure_stays_error_and_does_not_feed_breaker(
     )
     get_positions.side_effect = LotekException(message="bad request", status_code=404)
     with pytest.raises(LotekException, match="No devices could be serviced"):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
     assert get_positions.await_count == 4, "4xx failures must not trip the breaker"
     device_logs = [c for c in log.await_args_list if "Device:" in c.kwargs.get("title", "")]
     assert device_logs and all(c.kwargs["level"] == LogLevel.ERROR for c in device_logs)
@@ -1445,7 +1484,7 @@ async def test_head_pass_services_least_fresh_devices_first(
         mocker, mock_redis, _devices("fresh", "stale", "middle")
     )
     get_state.side_effect = lambda i, a, d: states.get(d, {})
-    await action_pull_observations(lotek_integration, pull_config)
+    await run_head_pass(lotek_integration, pull_config)
     order = [c.args[0] for c in get_positions.await_args_list]
     assert order == ["stale", "middle", "fresh"]
 
@@ -1462,7 +1501,7 @@ async def test_stale_legacy_cursor_migrates_into_gap_not_permanent_drop(
     get_positions, _, set_state, log = _setup_pull_mocks(
         mocker, mock_redis, _devices("1"), saved_state={"updated_at": behind.isoformat()}
     )
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     saved = set_state.call_args.args[2]
     assert abs(saved["gap_start"] - behind) < timedelta(seconds=1), (
         "the owed range's start must be the legacy cursor"
@@ -1490,7 +1529,7 @@ async def test_no_stale_drop_warning_when_the_fetch_fails(
     )
     get_positions.side_effect = httpx.ReadTimeout("")
     with pytest.raises(LotekException, match="No devices could be serviced"):
-        await action_pull_observations(lotek_integration, pull_config)
+        await run_head_pass(lotek_integration, pull_config)
     set_state.assert_not_awaited()
     assert not any(
         "stale range" in c.kwargs.get("title", "").lower() for c in log.await_args_list
@@ -1525,6 +1564,6 @@ async def test_fetch_error_publish_failure_stays_contained_to_the_device(
             raise Exception("pubsub down")
 
     log.side_effect = flaky_publish
-    result = await action_pull_observations(lotek_integration, pull_config)
+    result = await run_head_pass(lotek_integration, pull_config)
     assert result["devices_failed"] == ["1"]
     assert get_positions.await_count == 3, "device 2 was never serviced"

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -224,3 +224,141 @@ async def test_shard_config_requires_at_least_one_device():
     import pydantic
     with pytest.raises(pydantic.ValidationError):
         PullObservationsShardConfig(devices=[])
+
+
+# --- Re-trigger governor + starvation alarm fixes (PR #20 review blockers) ---
+
+
+@pytest.mark.asyncio
+async def test_retrigger_increments_generation(mocker, lotek_integration, pull_config, mock_redis):
+    import itertools
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    mocker.patch(
+        "app.actions.handlers._deadline_exceeded",
+        side_effect=itertools.chain([False] * 6, itertools.repeat(True)),
+    )
+
+    config = PullObservationsShardConfig(devices=[str(i) for i in range(1, 9)], generation=1)
+    await action_pull_observations_shard(lotek_integration, config)
+
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert shard_calls[0].kwargs["config"].generation == 2
+
+
+@pytest.mark.asyncio
+async def test_retrigger_cap_falls_back_to_next_tick_with_error(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # At the cap the tail is NOT re-triggered (next scheduled tick picks it
+    # up) and the exhaustion is surfaced at ERROR — an ungoverned chain under
+    # sustained starvation was an invisible busy-loop (review blocker).
+    from app.actions.handlers import SHARD_RETRIGGER_CAP
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+
+    @asynccontextmanager
+    async def starved_slot(username, **kwargs):
+        raise NoConnectionSlot("no slot")
+        yield
+
+    mocker.patch("app.actions.handlers.lotek_slot", starved_slot)
+
+    config = PullObservationsShardConfig(devices=["1", "2"], generation=SHARD_RETRIGGER_CAP)
+    result = await action_pull_observations_shard(lotek_integration, config)  # must not raise
+
+    assert result["devices_deferred"] == ["1", "2"]
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert shard_calls == []
+    cap_errors = [
+        c for c in log.await_args_list
+        if c.kwargs.get("level") == LogLevel.ERROR and "re-trigger cap" in c.kwargs.get("title", "")
+    ]
+    assert len(cap_errors) == 1
+
+
+@pytest.mark.asyncio
+async def test_slot_starvation_never_raises_even_when_retrigger_fails(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Starvation + a failed re-trigger publish is a clean back-off plus a
+    # pubsub blip — NOT systemic degradation. The old condition raised the
+    # zero-progress LotekException here (review blocker, both directions).
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    mocker.patch(
+        "app.actions.handlers.trigger_action",
+        new=AsyncMock(side_effect=Exception("pubsub down")),
+    )
+
+    @asynccontextmanager
+    async def starved_slot(username, **kwargs):
+        raise NoConnectionSlot("no slot")
+        yield
+
+    mocker.patch("app.actions.handlers.lotek_slot", starved_slot)
+
+    result = await action_pull_observations_shard(
+        lotek_integration, _shard_config("1", "2")
+    )  # must not raise
+
+    assert sorted(result["devices_deferred"], key=int) == ["1", "2"]
+    assert result["devices_failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_skip_streak_warns_after_consecutive_skips(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # One skipped tick stays out of the portal; a streak must not stay
+    # invisible (review blocker: the skip was logger.info only).
+    from app.actions.handlers import DISPATCHER_SKIP_WARN_AFTER
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    streak_state = {}
+
+    async def get_state(integration_id, action_id, source_id="no-source"):
+        return streak_state.get(source_id)
+
+    async def set_state(integration_id, action_id, state, source_id="no-source", **kwargs):
+        streak_state[source_id] = state
+
+    async def delete_state(integration_id, action_id, source_id="no-source"):
+        streak_state.pop(source_id, None)
+
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(side_effect=get_state))
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(side_effect=set_state))
+    mocker.patch("app.services.state.IntegrationStateManager.delete_state", new=AsyncMock(side_effect=delete_state))
+
+    @asynccontextmanager
+    async def starved_slot(username, **kwargs):
+        raise NoConnectionSlot("no slot")
+        yield
+
+    mocker.patch("app.actions.handlers.lotek_slot", starved_slot)
+
+    warnings = lambda: [
+        c for c in log.await_args_list
+        if c.kwargs.get("level") == LogLevel.WARNING and "consecutive ticks" in c.kwargs.get("title", "")
+    ]
+    for tick in range(1, DISPATCHER_SKIP_WARN_AFTER + 1):
+        result = await action_pull_observations(lotek_integration, pull_config)
+        assert result == {"skipped": True, "reason": "no_connection_slot"}
+        assert len(warnings()) == (1 if tick >= DISPATCHER_SKIP_WARN_AFTER else 0)
+
+    # A successful tick resets the streak.
+    mocker.patch("app.actions.handlers.lotek_slot", None)  # restore not needed; grant below
+
+    @asynccontextmanager
+    async def granted_slot(username, **kwargs):
+        yield
+
+    mocker.patch("app.actions.handlers.lotek_slot", granted_slot)
+    await action_pull_observations(lotek_integration, pull_config)
+    from app.actions.handlers import DISPATCHER_SKIP_STREAK_SOURCE
+    assert DISPATCHER_SKIP_STREAK_SOURCE not in streak_state

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -150,12 +150,13 @@ async def test_shard_does_not_retrigger_on_hot_breaker(
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
 
     # Every device fails, the breaker trips, and nothing is re-triggered: the
-    # zero-progress alarm fires (systemic degradation must alert).
-    from app.actions.client import LotekException
-    with pytest.raises(LotekException, match="No devices could be serviced"):
-        await action_pull_observations_shard(
-            lotek_integration, _shard_config(*(str(i) for i in range(1, 9)))
-        )
+    # zero-progress alarm fires (systemic degradation must alert) — as an ERROR
+    # activity event plus a result flag, never a raise (a raise would leak the
+    # integration's config through the runner's generic error handler).
+    result = await action_pull_observations_shard(
+        lotek_integration, _shard_config(*(str(i) for i in range(1, 9)))
+    )
+    assert result["zero_progress"] is True
 
     shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
     assert shard_calls == []
@@ -389,16 +390,16 @@ async def test_dispatch_failures_do_not_abort_remaining_shards(
 
 
 @pytest.mark.asyncio
-async def test_all_dispatches_failing_raises(mocker, lotek_integration, pull_config, mock_redis):
+async def test_all_dispatches_failing_reports_without_raising(mocker, lotek_integration, pull_config, mock_redis):
     _setup_pull_mocks(mocker, mock_redis, _devices("1"))
     mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
     mocker.patch(
         "app.actions.handlers.trigger_action",
         new=AsyncMock(side_effect=Exception("commands topic down")),
     )
-    from app.actions.client import LotekException
-    with pytest.raises(LotekException, match="Could not dispatch any"):
-        await action_pull_observations(lotek_integration, pull_config)
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result["shards_triggered"] == 0
+    assert result["devices_undispatched"] == ["1"]
 
 
 @pytest.mark.asyncio
@@ -420,3 +421,99 @@ async def test_manual_run_shards_bypass_the_pause(mocker, lotek_integration, pul
     mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
     result = await action_pull_observations_shard(lotek_integration, shard_config)
     assert result.get("reason") != "integration_paused"
+
+
+@pytest.mark.asyncio
+async def test_only_one_shard_triggers_backfill_per_window(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # 25 shards of a gapped fleet used to each publish a backfill command (the
+    # lease only exists a pubsub hop later). The atomic claim lets exactly one
+    # win; the losers publish nothing (review finding).
+    from app.services.state import IntegrationStateManager
+    _setup_pull_mocks(mocker, mock_redis, [], saved_state=None)
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    claims = {"count": 0}
+
+    async def claim_once(self, integration_id, action_id, *, ttl_seconds, source_id="no-source"):
+        claims["count"] += 1
+        return claims["count"] == 1  # first caller wins, rest lose
+
+    mocker.patch.object(IntegrationStateManager, "set_if_absent", claim_once)
+
+    for _ in range(3):  # three concurrent-ish shards of the same gapped fleet
+        await action_pull_observations_shard(lotek_integration, _shard_config("1"))
+
+    backfill_calls = [c for c in trigger.await_args_list if c.args[1] == "backfill_observations"]
+    assert len(backfill_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_manual_run_propagates_to_the_backfill_trigger(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A manual Trigger on a paused integration must import history too: without
+    # the marker the backfill skipped on the pause and the run silently covered
+    # only the head window (review finding).
+    _setup_pull_mocks(mocker, mock_redis, [], saved_state=None)
+    pull_config.run_on_schedule = False
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    config = PullObservationsShardConfig(devices=["1"], manual_run=True)
+    await action_pull_observations_shard(lotek_integration, config)
+
+    backfill_calls = [c for c in trigger.await_args_list if c.args[1] == "backfill_observations"]
+    assert len(backfill_calls) == 1
+    assert backfill_calls[0].kwargs["config"].manual_run is True
+
+
+@pytest.mark.asyncio
+async def test_retrigger_cap_does_not_also_emit_zero_progress(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # One load event, one signal: a cap-reached deadline cut already alerts at
+    # ERROR, so the zero-progress alert must not fire on top of it.
+    import itertools
+    from app.actions.handlers import SHARD_RETRIGGER_CAP
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    mocker.patch("app.actions.handlers._deadline_exceeded", return_value=True)
+
+    config = PullObservationsShardConfig(devices=["1", "2"], generation=SHARD_RETRIGGER_CAP)
+    result = await action_pull_observations_shard(lotek_integration, config)
+
+    assert "zero_progress" not in result
+    errors = [c.kwargs["title"] for c in log.await_args_list if c.kwargs.get("level") == LogLevel.ERROR]
+    assert len(errors) == 1
+    assert "re-trigger cap" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_backfill_honors_manual_run_on_a_paused_integration(
+    mocker, lotek_integration, pull_config, mock_redis, auth_config
+):
+    from app.actions.configurations import BackfillObservationsConfig
+    from app.actions.handlers import action_backfill_observations
+    _setup_pull_mocks(mocker, mock_redis, [])
+    pull_config.run_on_schedule = False
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    mocker.patch("app.actions.handlers.get_auth_config", return_value=auth_config)
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.acquire_lease",
+        new=AsyncMock(return_value=None),  # stop right after the pause check
+    )
+
+    paused = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig(manual_run=False)
+    )
+    assert paused == {"skipped": True, "reason": "integration_paused"}
+
+    manual = await action_backfill_observations(
+        lotek_integration, BackfillObservationsConfig(manual_run=True)
+    )
+    assert manual["reason"] != "integration_paused"

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -362,3 +362,61 @@ async def test_dispatcher_skip_streak_warns_after_consecutive_skips(
     await action_pull_observations(lotek_integration, pull_config)
     from app.actions.handlers import DISPATCHER_SKIP_STREAK_SOURCE
     assert DISPATCHER_SKIP_STREAK_SOURCE not in streak_state
+
+
+@pytest.mark.asyncio
+async def test_dispatch_failures_do_not_abort_remaining_shards(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # One pubsub blip must not abort the fan-out (and must never escape into
+    # the runner's config-embedding generic error handler).
+    device_ids = [str(i) for i in range(1, SHARD_SIZE * 3 + 1)]  # 3 shards
+    _setup_pull_mocks(mocker, mock_redis, _devices(*device_ids))
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    calls = []
+
+    async def flaky_trigger(integration_id, action_id, config=None):
+        calls.append(config)
+        if len(calls) == 2:
+            raise Exception("pubsub blip")
+
+    mocker.patch("app.actions.handlers.trigger_action", new=flaky_trigger)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result["shards_triggered"] == 2  # shard 2 failed, 1 and 3 dispatched
+    assert len(calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_all_dispatches_failing_raises(mocker, lotek_integration, pull_config, mock_redis):
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    mocker.patch(
+        "app.actions.handlers.trigger_action",
+        new=AsyncMock(side_effect=Exception("commands topic down")),
+    )
+    from app.actions.client import LotekException
+    with pytest.raises(LotekException, match="Could not dispatch any"):
+        await action_pull_observations(lotek_integration, pull_config)
+
+
+@pytest.mark.asyncio
+async def test_manual_run_shards_bypass_the_pause(mocker, lotek_integration, pull_config, mock_redis):
+    # Portal Trigger on a paused integration: the runner bypasses the pause
+    # for the manual dispatcher run, and the shards it publishes must carry
+    # manual_run so they don't skip (review finding: they used to, showing a
+    # successful run that pulled nothing).
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    pull_config.run_on_schedule = False  # paused; reaching the dispatcher means manual
+
+    await action_pull_observations(lotek_integration, pull_config)
+
+    shard_config = trigger.await_args_list[0].kwargs["config"]
+    assert shard_config.manual_run is True
+
+    # And the shard itself honors the marker instead of skipping.
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    result = await action_pull_observations_shard(lotek_integration, shard_config)
+    assert result.get("reason") != "integration_paused"

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -556,3 +556,21 @@ async def test_backfill_honors_manual_run_on_a_paused_integration(
         lotek_integration, BackfillObservationsConfig(manual_run=True)
     )
     assert manual["reason"] != "integration_paused"
+
+
+def test_partitioning_constants_may_oversubscribe_the_budget():
+    """Guards the spec-D1 contract: SHARD_SIZE and FETCH_CONCURRENCY are
+    work-partitioning parameters, NOT concurrency limits, so they are ALLOWED
+    to exceed the account budget — the budget applies backpressure (Task 3).
+
+    This test exists so nobody 'fixes' the arithmetic by shrinking the
+    partitioning constants: that would reintroduce the coupling spec D1
+    removed. If you need to bound concurrency, change LOTEK_MAX_CONNECTIONS.
+    """
+    from app.actions.handlers import FETCH_CONCURRENCY, SHARD_SIZE
+    from app.services.lotek_connections import lotek_slot
+    import inspect
+
+    assert FETCH_CONCURRENCY > 0 and SHARD_SIZE > 0
+    # The budget must be a WAITING primitive for oversubscription to be safe.
+    assert "max_wait_seconds" in inspect.signature(lotek_slot).parameters

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -392,17 +392,14 @@ async def test_dispatcher_skip_streak_warns_after_consecutive_skips(
 
     streak_state = {}
 
-    async def get_state(integration_id, action_id, source_id="no-source"):
-        return streak_state.get(source_id)
-
-    async def set_state(integration_id, action_id, state, source_id="no-source", **kwargs):
-        streak_state[source_id] = state
+    async def increment_counter(integration_id, action_id, source_id="no-source", ttl_seconds=3600):
+        streak_state[source_id] = streak_state.get(source_id, 0) + 1
+        return streak_state[source_id]
 
     async def delete_state(integration_id, action_id, source_id="no-source"):
         streak_state.pop(source_id, None)
 
-    mocker.patch("app.services.state.IntegrationStateManager.get_state", new=AsyncMock(side_effect=get_state))
-    mocker.patch("app.services.state.IntegrationStateManager.set_state", new=AsyncMock(side_effect=set_state))
+    mocker.patch("app.services.state.IntegrationStateManager.increment_counter", new=AsyncMock(side_effect=increment_counter))
     mocker.patch("app.services.state.IntegrationStateManager.delete_state", new=AsyncMock(side_effect=delete_state))
 
     @asynccontextmanager

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
@@ -5,13 +6,19 @@ from unittest.mock import AsyncMock
 
 from gundi_core.schemas.v2 import LogLevel
 from app.actions.configurations import PullObservationsShardConfig
+from app.actions.device_state import DeviceState
 from app.actions.handlers import (
     SHARD_SIZE,
+    STATE_READ_CONCURRENCY,
     action_pull_observations,
     action_pull_observations_shard,
 )
 from app.services.lotek_connections import NoConnectionSlot
 from .test_handlers import _devices, _setup_pull_mocks
+
+
+def _plain_state():
+    return DeviceState(high_water=datetime.now(tz=timezone.utc))
 
 
 # --- Parent dispatcher -------------------------------------------------------
@@ -100,6 +107,37 @@ async def test_pull_observations_dispatches_nothing_for_empty_device_list(
 
 def _shard_config(*device_ids):
     return PullObservationsShardConfig(devices=list(device_ids))
+
+
+@pytest.mark.asyncio
+async def test_shard_loads_device_states_concurrently(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    """The following .sort() forces every state eager, so these reads are a
+    serial startup tax with no network I/O to hide behind — paid again on every
+    re-trigger hop. The dispatcher's identical pattern was batched in PR #20."""
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+
+    in_flight = 0
+    peak = 0
+
+    async def slow_load(*args, **kwargs):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return (_plain_state(), False)
+
+    mocker.patch("app.actions.handlers._load_device_state", side_effect=slow_load)
+    mocker.patch("app.actions.handlers._head_pass_device", return_value=(0, False, False))
+
+    await action_pull_observations_shard(
+        lotek_integration, _shard_config(*(f"dev{i}" for i in range(10)))
+    )
+
+    assert peak > 1, "state reads must overlap, not run one-at-a-time"
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -1,0 +1,226 @@
+import pytest
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+from gundi_core.schemas.v2 import LogLevel
+from app.actions.configurations import PullObservationsShardConfig
+from app.actions.handlers import (
+    SHARD_SIZE,
+    action_pull_observations,
+    action_pull_observations_shard,
+)
+from app.services.lotek_connections import NoConnectionSlot
+from .test_handlers import _devices, _setup_pull_mocks
+
+
+# --- Parent dispatcher -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_dispatches_shards(mocker, lotek_integration, pull_config, mock_redis):
+    # GUNDI-5620: the scheduled action only lists devices and fans them out as
+    # pull_observations_shard sub-actions of SHARD_SIZE ids each — the whole
+    # fleet never has to fit one action budget.
+    device_ids = [str(i) for i in range(1, SHARD_SIZE * 2 + 6)]  # 2 full shards + 5
+    _setup_pull_mocks(mocker, mock_redis, _devices(*device_ids))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result == {"devices_found": len(device_ids), "shards_triggered": 3}
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert len(shard_calls) == 3
+    dispatched = [d for c in shard_calls for d in c.kwargs["config"].devices]
+    assert sorted(dispatched) == sorted(device_ids)  # every device exactly once
+    assert all(len(c.kwargs["config"].devices) <= SHARD_SIZE for c in shard_calls)
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_orders_shards_least_fresh_first(mocker, lotek_integration, pull_config, mock_redis):
+    # Devices most behind lead the first shard; devices with no saved state at
+    # all are most behind by definition.
+    _setup_pull_mocks(mocker, mock_redis, _devices("fresh", "stale", "new"))
+    states = {
+        "fresh": {"version": 2, "high_water": "2026-08-18T10:00:00+00:00"},
+        "stale": {"version": 2, "high_water": "2026-08-10T10:00:00+00:00"},
+        "new": None,
+    }
+
+    async def get_state(integration_id, action_id, source_id="no-source"):
+        return states.get(source_id)
+
+    mocker.patch(
+        "app.services.state.IntegrationStateManager.get_state",
+        new=AsyncMock(side_effect=get_state),
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    await action_pull_observations(lotek_integration, pull_config)
+
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert shard_calls[0].kwargs["config"].devices == ["new", "stale", "fresh"]
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_skips_cleanly_when_connection_budget_exhausted(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A saturated account budget on the device listing is a clean skip (the
+    # next tick retries), not an action failure.
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    @asynccontextmanager
+    async def starved_slot(username, **kwargs):
+        raise NoConnectionSlot("no slot")
+        yield
+
+    mocker.patch("app.actions.handlers.lotek_slot", starved_slot)
+
+    result = await action_pull_observations(lotek_integration, pull_config)
+
+    assert result == {"skipped": True, "reason": "no_connection_slot"}
+    trigger.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_dispatches_nothing_for_empty_device_list(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    _setup_pull_mocks(mocker, mock_redis, [])
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    result = await action_pull_observations(lotek_integration, pull_config)
+    assert result == {"devices_found": 0, "shards_triggered": 0}
+    trigger.assert_not_awaited()
+
+
+# --- Shard action ------------------------------------------------------------
+
+
+def _shard_config(*device_ids):
+    return PullObservationsShardConfig(devices=list(device_ids))
+
+
+@pytest.mark.asyncio
+async def test_shard_defers_and_retriggers_on_slot_starvation(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # Mid-shard budget exhaustion defers the starved device plus the untouched
+    # tail into a re-triggered shard (the pubsub round trip is the backoff) —
+    # no device failures, no ERROR-level noise, no zero-progress raise.
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    log = mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+
+    @asynccontextmanager
+    async def starved_slot(username, **kwargs):
+        raise NoConnectionSlot("no slot")
+        yield
+
+    mocker.patch("app.actions.handlers.lotek_slot", starved_slot)
+
+    result = await action_pull_observations_shard(
+        lotek_integration, _shard_config(*(str(i) for i in range(1, 9)))
+    )
+
+    assert result["devices_failed"] == []
+    assert sorted(result["devices_deferred"], key=int) == [str(i) for i in range(1, 9)]
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert len(shard_calls) == 1
+    assert sorted(shard_calls[0].kwargs["config"].devices, key=int) == [str(i) for i in range(1, 9)]
+    assert LogLevel.ERROR not in [c.kwargs.get("level") for c in log.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_shard_does_not_retrigger_on_hot_breaker(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    # A hot circuit breaker means Lotek-wide degradation: re-triggering
+    # immediately would defeat the pause the breaker exists to buy. The tail
+    # waits for the next scheduled tick.
+    import httpx
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    mocker.patch(
+        "app.actions.client.get_positions",
+        new=AsyncMock(side_effect=httpx.ReadTimeout("Lotek timed out")),
+    )
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+
+    # Every device fails, the breaker trips, and nothing is re-triggered: the
+    # zero-progress alarm fires (systemic degradation must alert).
+    from app.actions.client import LotekException
+    with pytest.raises(LotekException, match="No devices could be serviced"):
+        await action_pull_observations_shard(
+            lotek_integration, _shard_config(*(str(i) for i in range(1, 9)))
+        )
+
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert shard_calls == []
+
+
+@pytest.mark.asyncio
+async def test_shard_retriggers_tail_on_deadline(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    import itertools
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    mocker.patch(
+        "app.actions.handlers._deadline_exceeded",
+        side_effect=itertools.chain([False] * 6, itertools.repeat(True)),
+    )
+
+    result = await action_pull_observations_shard(
+        lotek_integration, _shard_config(*(str(i) for i in range(1, 9)))
+    )
+
+    assert result["devices_deferred"] == ["6", "7", "8"]
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert len(shard_calls) == 1
+    assert shard_calls[0].kwargs["config"].devices == ["6", "7", "8"]
+    assert shard_calls[0].kwargs["config"].triggered_by == "pull_observations_shard"
+
+
+@pytest.mark.asyncio
+async def test_shard_skips_when_integration_is_paused(mocker, lotek_integration, pull_config, mock_redis):
+    # Internal actions bypass the runner's skippable_pull pause check; the
+    # shard must honor the operator's pause toggle itself.
+    _setup_pull_mocks(mocker, mock_redis, [])
+    pull_config.run_on_schedule = False
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    get_positions = mocker.patch("app.actions.client.get_positions", new=AsyncMock())
+
+    result = await action_pull_observations_shard(lotek_integration, _shard_config("1"))
+
+    assert result == {"skipped": True, "reason": "integration_paused"}
+    get_positions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shard_skips_quietly_when_pull_config_is_missing(mocker, lotek_integration, mock_redis):
+    # Machine-triggered: raising would route the full integration config
+    # (auth included) through the generic error handler. Skip quietly; the
+    # scheduled parent surfaces the missing config.
+    from app.services.errors import ConfigurationNotFound
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch(
+        "app.actions.handlers.get_pull_config",
+        side_effect=ConfigurationNotFound("pull config missing"),
+    )
+
+    result = await action_pull_observations_shard(lotek_integration, _shard_config("1"))
+
+    assert result == {"skipped": True, "reason": "configuration_missing"}
+
+
+@pytest.mark.asyncio
+async def test_shard_config_requires_at_least_one_device():
+    # An empty devices list would publish an empty config_overrides, which the
+    # runner reads as "no config at all" (404 before the handler runs).
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        PullObservationsShardConfig(devices=[])

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -169,6 +169,36 @@ async def test_starved_device_does_not_abort_the_whole_shard(
 
 
 @pytest.mark.asyncio
+async def test_quiet_success_beside_a_failed_device_is_not_zero_progress(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    """A device serviced with nothing new to send is still progress, even when
+    a peer failed. serviced_devices must therefore discount only the devices
+    the CALLER marked failed — the ones the traversal already logged never
+    yielded a result, so subtracting them too would double-count and fire the
+    zero-progress ERROR that the cdip health metric counts on a healthy run.
+    """
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+    mocker.patch("app.actions.handlers.log_action_activity", new=AsyncMock())
+    mocker.patch("app.actions.traversal.log_action_activity", new=AsyncMock())
+
+    async def fake_head_pass(device_id, *args, **kwargs):
+        if device_id == "boom":
+            raise ValueError("delivery rejected")
+        return (0, False, False)  # serviced, but nothing new to send
+
+    mocker.patch("app.actions.handlers._head_pass_device", side_effect=fake_head_pass)
+
+    result = await action_pull_observations_shard(
+        lotek_integration, _shard_config("boom", "quiet")
+    )
+
+    assert result["devices_failed"] == ["boom"]
+    assert "zero_progress" not in result
+
+
+@pytest.mark.asyncio
 async def test_shard_does_not_retrigger_on_hot_breaker(
     mocker, lotek_integration, pull_config, mock_redis
 ):

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -503,6 +503,13 @@ async def test_only_one_shard_triggers_backfill_per_window(
     _setup_pull_mocks(mocker, mock_redis, [], saved_state=None)
     mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    # delete_state is autouse-stubbed to a no-op elsewhere in this test package
+    # (conftest's _stub_state_delete), which would hide a regression on this
+    # exact path (a losing shard erroneously releasing the winner's claim) —
+    # re-patch it here, escaping the autouse stub, so it is observable.
+    delete_state = mocker.patch.object(
+        IntegrationStateManager, "delete_state", new=AsyncMock()
+    )
 
     claims = {"count": 0}
 
@@ -517,6 +524,12 @@ async def test_only_one_shard_triggers_backfill_per_window(
 
     backfill_calls = [c for c in trigger.await_args_list if c.args[1] == "backfill_observations"]
     assert len(backfill_calls) == 1
+    # The two shards that lost the claim (claimed=False) must NOT release it —
+    # doing so would delete the winner's claim and hand a second shard a
+    # licence to publish the same window (the most dangerous regression on
+    # this code path, per the review). The winner published successfully, so
+    # it doesn't release either: delete_state must be untouched altogether.
+    delete_state.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -103,12 +103,14 @@ def _shard_config(*device_ids):
 
 
 @pytest.mark.asyncio
-async def test_shard_defers_and_retriggers_on_slot_starvation(
+async def test_shard_defers_starved_devices_without_retriggering(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # Mid-shard budget exhaustion defers the starved device plus the untouched
-    # tail into a re-triggered shard (the pubsub round trip is the backoff) —
-    # no device failures, no ERROR-level noise, no zero-progress raise.
+    # A fully saturated budget defers every starved device (spec D3: narrow
+    # deferral, not the whole tail — here they happen to be the same set
+    # because every device starves) and does NOT immediately re-trigger a
+    # shard for them; they wait for the next scheduled tick. No device
+    # failures, no ERROR-level noise, no zero-progress raise.
     _setup_pull_mocks(mocker, mock_redis, [])
     mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
     trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
@@ -128,9 +130,42 @@ async def test_shard_defers_and_retriggers_on_slot_starvation(
     assert result["devices_failed"] == []
     assert sorted(result["devices_deferred"], key=int) == [str(i) for i in range(1, 9)]
     shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
-    assert len(shard_calls) == 1
-    assert sorted(shard_calls[0].kwargs["config"].devices, key=int) == [str(i) for i in range(1, 9)]
+    assert shard_calls == []
     assert LogLevel.ERROR not in [c.kwargs.get("level") for c in log.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_starved_device_does_not_abort_the_whole_shard(
+    mocker, lotek_integration, pull_config, mock_redis
+):
+    """One device losing the slot race must defer THAT device, not the shard's
+    entire remaining tail (spec D3). Its in-chunk peers keep their results and
+    the loop carries on to later chunks."""
+    _setup_pull_mocks(mocker, mock_redis, [])
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+
+    devices = [f"dev{i}" for i in range(10)]
+    calls = []
+
+    async def fake_head_pass(device_id, *args, **kwargs):
+        calls.append(device_id)
+        if device_id == "dev0":
+            raise NoConnectionSlot("saturated")
+        return (5, False, False)
+
+    mocker.patch("app.actions.handlers._head_pass_device", side_effect=fake_head_pass)
+    mocker.patch("app.actions.handlers._retrigger_shard", return_value="handed_off")
+
+    result = await action_pull_observations_shard(
+        lotek_integration, _shard_config(*devices)
+    )
+
+    # Every device was attempted, not just the first chunk.
+    assert len(calls) == 10
+    # Only the starved one is deferred.
+    assert result["devices_deferred"] == ["dev0"]
+    # The other nine still delivered.
+    assert result["observations_extracted"] == 45
 
 
 @pytest.mark.asyncio
@@ -249,12 +284,15 @@ async def test_retrigger_increments_generation(mocker, lotek_integration, pull_c
 
 
 @pytest.mark.asyncio
-async def test_retrigger_cap_falls_back_to_next_tick_with_error(
+async def test_slot_starvation_at_retrigger_cap_still_defers_without_error(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # At the cap the tail is NOT re-triggered (next scheduled tick picks it
-    # up) and the exhaustion is surfaced at ERROR — an ungoverned chain under
-    # sustained starvation was an invisible busy-loop (review blocker).
+    # Slot starvation no longer attempts a re-trigger at all (spec D3: it
+    # defers only the starved devices to the next scheduled tick), so the
+    # generation being at the re-trigger cap must not matter to it — no
+    # cap-reached ERROR, just the ordinary WARNING deferral. The cap's ERROR
+    # path is still exercised via the deadline cut (see
+    # test_retrigger_cap_does_not_also_emit_zero_progress).
     from app.actions.handlers import SHARD_RETRIGGER_CAP
     _setup_pull_mocks(mocker, mock_redis, [])
     mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
@@ -274,23 +312,22 @@ async def test_retrigger_cap_falls_back_to_next_tick_with_error(
     assert result["devices_deferred"] == ["1", "2"]
     shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
     assert shard_calls == []
-    cap_errors = [
-        c for c in log.await_args_list
-        if c.kwargs.get("level") == LogLevel.ERROR and "re-trigger cap" in c.kwargs.get("title", "")
-    ]
-    assert len(cap_errors) == 1
+    assert LogLevel.ERROR not in [c.kwargs.get("level") for c in log.await_args_list]
 
 
 @pytest.mark.asyncio
-async def test_slot_starvation_never_raises_even_when_retrigger_fails(
+async def test_slot_starvation_never_raises_and_does_not_retrigger(
     mocker, lotek_integration, pull_config, mock_redis
 ):
-    # Starvation + a failed re-trigger publish is a clean back-off plus a
-    # pubsub blip — NOT systemic degradation. The old condition raised the
-    # zero-progress LotekException here (review blocker, both directions).
+    # Starvation is a clean back-off to the next scheduled tick — NOT systemic
+    # degradation, and (spec D3) not even an attempt to re-trigger, so a dead
+    # pubsub can't turn a starved shard into a raise either (review blocker,
+    # both directions; the old condition raised the zero-progress
+    # LotekException here when the re-trigger publish it used to attempt
+    # also failed).
     _setup_pull_mocks(mocker, mock_redis, [])
     mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
-    mocker.patch(
+    trigger = mocker.patch(
         "app.actions.handlers.trigger_action",
         new=AsyncMock(side_effect=Exception("pubsub down")),
     )
@@ -308,6 +345,8 @@ async def test_slot_starvation_never_raises_even_when_retrigger_fails(
 
     assert sorted(result["devices_deferred"], key=int) == ["1", "2"]
     assert result["devices_failed"] == []
+    shard_calls = [c for c in trigger.await_args_list if c.args[1] == "pull_observations_shard"]
+    assert shard_calls == []
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_sharding.py
+++ b/app/actions/tests/test_sharding.py
@@ -636,6 +636,29 @@ async def test_backfill_honors_manual_run_on_a_paused_integration(
     assert manual["reason"] != "integration_paused"
 
 
+@pytest.mark.asyncio
+async def test_shard_fetch_requests_a_bounded_wait_on_the_slot(
+    mocker, lotek_integration, pull_config, mock_redis, _grant_connection_slots
+):
+    """The headline behaviour change (spec D2): the per-device fetch's
+    lotek_slot acquire in _fetch_window must pass max_wait_seconds, not just
+    have a parameter for it. A signature check alone (as the old guard here
+    did) cannot catch that wiring being deleted from the call site — this
+    drives an actual device through the shard so the recorded call is
+    inspected end to end."""
+    from app.actions.handlers import DEADLINE_FRACTION
+    from app import settings as app_settings
+
+    _setup_pull_mocks(mocker, mock_redis, _devices("1"))
+    mocker.patch("app.actions.handlers.get_pull_config", return_value=pull_config)
+
+    await action_pull_observations_shard(lotek_integration, _shard_config("1"))
+
+    assert len(_grant_connection_slots) == 1
+    recorded = _grant_connection_slots[0]
+    assert 0 < recorded["max_wait_seconds"] <= DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME
+
+
 def test_partitioning_constants_may_oversubscribe_the_budget():
     """Guards the spec-D1 contract: SHARD_SIZE and FETCH_CONCURRENCY are
     work-partitioning parameters, NOT concurrency limits, so they are ALLOWED

--- a/app/actions/tests/test_transport_failures.py
+++ b/app/actions/tests/test_transport_failures.py
@@ -51,7 +51,7 @@ async def test_pull_get_devices_transport_failure_is_warning_and_clean_return(
 
     assert result["skipped"] is True
     assert result["reason"] == "lotek_unreachable"
-    assert result["observations_extracted"] == 0
+    assert result["shards_triggered"] == 0
     levels = _levels(mock_log)
     assert "WARNING" in levels
     assert "ERROR" not in levels

--- a/app/actions/tests/test_traversal.py
+++ b/app/actions/tests/test_traversal.py
@@ -1,0 +1,141 @@
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from gundi_core.events import LogLevel
+
+from app.actions.traversal import DeviceTraversal
+from app.actions.client import LotekUnauthorizedException
+from app.services.lotek_connections import NoConnectionSlot
+
+
+class FakeGuards:
+    """RunGuards stand-in: stops when told, records transport failures."""
+    def __init__(self, stop_after=None):
+        self.stop_after = stop_after
+        self.calls = 0
+        self.recorded = []
+    def should_stop(self):
+        self.calls += 1
+        if self.stop_after is not None and self.calls > self.stop_after:
+            return "deadline"
+        return None
+    def record(self, transport_failure):
+        self.recorded.append(transport_failure)
+
+
+@pytest.fixture
+def integration(mocker):
+    return mocker.Mock(id="11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.asyncio
+async def test_yields_every_successful_result(integration):
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=2)
+    seen = []
+    async for item, value in t.run([1, 2, 3], key=str, process=lambda i: _ok(i)):
+        seen.append((item, value))
+    assert seen == [(1, "r1"), (2, "r2"), (3, "r3")]
+    assert t.failed_devices == []
+    assert t.serviced_devices == 3
+
+
+async def _ok(i):
+    return f"r{i}"
+
+
+@pytest.mark.asyncio
+async def test_per_device_failure_is_isolated_and_logged(integration, mocker):
+    log = mocker.patch("app.actions.traversal.log_action_activity", new=AsyncMock())
+
+    async def process(i):
+        if i == 2:
+            raise ValueError("boom")
+        return f"r{i}"
+
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=3)
+    seen = [item async for item, _ in t.run([1, 2, 3], key=str, process=process)]
+
+    assert seen == [1, 3]              # device 2 did not stop its peers
+    assert t.failed_devices == ["2"]
+    assert log.await_count == 1
+    assert log.await_args.kwargs["level"] is LogLevel.ERROR
+
+
+@pytest.mark.asyncio
+async def test_serviced_devices_discounts_only_caller_marked_failures(integration, mocker):
+    # A device the traversal failed never yielded, so it must not be
+    # subtracted a second time: serviced_devices counts yielded results minus
+    # the ones the caller marked failed. Getting this wrong makes a run that
+    # serviced devices quietly look like zero progress, which alerts.
+    mocker.patch("app.actions.traversal.log_action_activity", new=AsyncMock())
+
+    async def process(i):
+        if i == 1:
+            raise ValueError("boom")
+        return f"r{i}"
+
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=3)
+    async for item, _ in t.run([1, 2, 3], key=str, process=process):
+        if item == 2:
+            t.mark_failed("2")
+
+    assert t.failed_devices == ["1", "2"]
+    assert t.serviced_devices == 1        # device 3 only
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_propagates(integration):
+    async def process(i):
+        raise LotekUnauthorizedException("refused")
+
+    t = DeviceTraversal(integration, "act", FakeGuards())
+    with pytest.raises(LotekUnauthorizedException):
+        async for _ in t.run([1], key=str, process=process):
+            pytest.fail("must not yield")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates(integration):
+    async def process(i):
+        raise asyncio.CancelledError()
+
+    t = DeviceTraversal(integration, "act", FakeGuards())
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in t.run([1], key=str, process=process):
+            pytest.fail("must not yield")
+
+
+@pytest.mark.asyncio
+async def test_slot_starvation_records_narrowly(integration):
+    async def process(i):
+        if i == 1:
+            raise NoConnectionSlot("saturated")
+        return f"r{i}"
+
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=3)
+    seen = [item async for item, _ in t.run([1, 2, 3], key=str, process=process)]
+
+    assert seen == [2, 3]                 # peers unaffected (spec D3)
+    assert t.deferred_devices == ["1"]
+    assert t.budget_starved is True
+    assert t.failed_devices == []         # starvation is not a device failure
+
+
+@pytest.mark.asyncio
+async def test_guard_stop_defers_the_unreached_tail(integration):
+    t = DeviceTraversal(integration, "act", FakeGuards(stop_after=1), concurrency=2)
+    seen = [item async for item, _ in t.run([1, 2, 3, 4], key=str, process=_ok)]
+
+    assert seen == [1, 2]                 # first chunk only
+    assert t.stop_reason == "deadline"
+    assert t.deferred_devices == ["3", "4"]
+
+
+@pytest.mark.asyncio
+async def test_clean_completion_records_no_stop_and_no_starvation(integration):
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=2)
+    _ = [item async for item, _ in t.run([1], key=str, process=_ok)]
+    assert t.stop_reason is None
+    assert t.budget_starved is False
+    assert t.deferred_devices == []

--- a/app/actions/tests/test_traversal.py
+++ b/app/actions/tests/test_traversal.py
@@ -139,3 +139,29 @@ async def test_clean_completion_records_no_stop_and_no_starvation(integration):
     assert t.stop_reason is None
     assert t.budget_starved is False
     assert t.deferred_devices == []
+
+
+@pytest.mark.asyncio
+async def test_slot_starvation_and_guard_stop_stay_in_separate_lists(integration):
+    # A chunk that starves on slots can itself burn enough wall-clock time
+    # (queueing for a peer to release) that the deadline guard trips on the
+    # very next chunk. Both used to land in one shared deferred_devices list,
+    # so a caller retriggering/logging "deadline" devices picked up the
+    # starved one too, and the budget-starved log picked up the untouched
+    # tail — each device reported under the wrong reason, and reported twice
+    # overall (review finding). They must stay in disjoint, reason-specific
+    # lists, with `deferred_devices` only their union.
+    async def process(i):
+        if i == 1:
+            raise NoConnectionSlot("saturated")
+        return f"r{i}"
+
+    t = DeviceTraversal(integration, "act", FakeGuards(stop_after=1), concurrency=2)
+    seen = [item async for item, _ in t.run([1, 2, 3, 4], key=str, process=process)]
+
+    assert seen == [2]                               # device 1 starved, chunk 1 processed
+    assert t.slot_starved_devices == ["1"]
+    assert t.guard_stopped_devices == ["3", "4"]      # unreached tail only
+    assert sorted(t.deferred_devices) == ["1", "3", "4"]  # union
+    assert t.budget_starved is True
+    assert t.stop_reason == "deadline"

--- a/app/actions/traversal.py
+++ b/app/actions/traversal.py
@@ -1,0 +1,107 @@
+import asyncio
+import logging
+from typing import Optional
+
+from gundi_core.events import LogLevel
+
+from app.actions.client import LotekUnauthorizedException
+from app.actions.core import describe_exception
+from app.services.activity_logger import log_action_activity
+from app.services.lotek_connections import NoConnectionSlot
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceTraversal:
+    """Shared chunked-device-loop mechanics for the head pass and the backfill.
+
+    Owns: chunking, gather-with-return_exceptions, fatal re-raise, per-device
+    failure logging, slot-starvation collection, guard-stop detection, and the
+    deferred-tail computation.
+
+    Deliberately does NOT own: whether to re-trigger, what the deferral message
+    says, or what zero progress means. Those differ between the head pass and
+    the backfill and stay in the handlers (spec D6). Keeping policy out is what
+    makes one traversal serve both without a flag soup.
+    """
+
+    def __init__(self, integration, action_id, guards, *, concurrency=1):
+        self.integration = integration
+        self.integration_id = str(integration.id)
+        self.action_id = action_id
+        self.guards = guards
+        # Work partitioning, not a concurrency limit — the account-wide ceiling
+        # lives in the Redis slot (spec D1). Callers pass their chunk width; the
+        # default of 1 just means "one device per chunk".
+        self.concurrency = concurrency
+        self.failed_devices = []
+        self.deferred_devices = []
+        self.stop_reason: Optional[str] = None
+        self.budget_starved = False
+        self._yielded = 0
+        self._marked_failed = 0
+
+    @property
+    def serviced_devices(self):
+        # Only the caller knows whether a yielded result counts as success, so
+        # it calls mark_failed() for the ones that don't. Discount ONLY those:
+        # a device whose exception the traversal logged never yielded, so
+        # subtracting all of failed_devices would count it twice and could make
+        # a run that serviced devices quietly (nothing new to send) look like
+        # zero progress — which alerts.
+        return self._yielded - self._marked_failed
+
+    def mark_failed(self, device_id):
+        """Caller-side failure: the device produced a result, but the result
+        says it failed (e.g. delivery rejected)."""
+        self.failed_devices.append(device_id)
+        self._marked_failed += 1
+
+    async def run(self, work, key, process):
+        work = list(work)
+        for chunk_start in range(0, len(work), self.concurrency):
+            if reason := self.guards.should_stop():
+                self.stop_reason = reason
+                self.deferred_devices.extend(key(item) for item in work[chunk_start:])
+                return
+            chunk = work[chunk_start:chunk_start + self.concurrency]
+            results = await asyncio.gather(
+                *(process(item) for item in chunk),
+                # Collect every task's outcome rather than aborting the chunk on
+                # the first exception: per-device failures must stay per-device.
+                return_exceptions=True,
+            )
+            # Credentials refused is integration-wide and fatal; re-raise it over
+            # any per-device outcomes in the same chunk. Cancellation must also
+            # propagate: with return_exceptions=True a task's CancelledError
+            # comes back as a result, and treating it as a device failure would
+            # swallow shutdown/timeout cancellation and keep the run going.
+            for res in results:
+                if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
+                    raise res
+            for item, res in zip(chunk, results):
+                device_id = key(item)
+                if isinstance(res, NoConnectionSlot):
+                    # Account budget saturated for longer than this run can wait:
+                    # not a device failure and not evidence about Lotek. Defer
+                    # THIS device only; peers and later chunks continue (D3).
+                    self.deferred_devices.append(device_id)
+                    self.budget_starved = True
+                    continue
+                if isinstance(res, BaseException):
+                    message = (
+                        f"Failed to process device {device_id} for integration "
+                        f"{self.integration.id}: {describe_exception(res)}"
+                    )
+                    logger.error(message, exc_info=res)
+                    await log_action_activity(
+                        integration_id=self.integration_id,
+                        action_id=self.action_id,
+                        title=message,
+                        level=LogLevel.ERROR,
+                    )
+                    self.failed_devices.append(device_id)
+                    self.guards.record(transport_failure=False)
+                    continue
+                self._yielded += 1
+                yield item, res

--- a/app/actions/traversal.py
+++ b/app/actions/traversal.py
@@ -35,11 +35,29 @@ class DeviceTraversal:
         # default of 1 just means "one device per chunk".
         self.concurrency = concurrency
         self.failed_devices = []
-        self.deferred_devices = []
+        # Two reason-specific lists, not one combined `deferred_devices`:
+        # guard_stopped_devices is the unreached tail cut short by
+        # should_stop() (deadline/breaker/cap); slot_starved_devices is
+        # per-device NoConnectionSlot within an attempted chunk. Callers used
+        # to share one list for both, so a chunk that starved on slots right
+        # before a deadline cut got its starved devices re-triggered/logged as
+        # the deadline tail, and the untouched tail got mislabeled as slot
+        # starvation — devices reported under the wrong reason, and reported
+        # twice when both conditions applied to the same run (review finding).
+        self.guard_stopped_devices = []
+        self.slot_starved_devices = []
         self.stop_reason: Optional[str] = None
         self.budget_starved = False
         self._yielded = 0
         self._marked_failed = 0
+
+    @property
+    def deferred_devices(self):
+        """Union of every deferred device, for the overall reported count and
+        result only. Stop-reason and budget-starved handling must use
+        guard_stopped_devices / slot_starved_devices directly instead of this
+        union — see the constructor comment."""
+        return self.guard_stopped_devices + self.slot_starved_devices
 
     @property
     def serviced_devices(self):
@@ -62,7 +80,7 @@ class DeviceTraversal:
         for chunk_start in range(0, len(work), self.concurrency):
             if reason := self.guards.should_stop():
                 self.stop_reason = reason
-                self.deferred_devices.extend(key(item) for item in work[chunk_start:])
+                self.guard_stopped_devices.extend(key(item) for item in work[chunk_start:])
                 return
             chunk = work[chunk_start:chunk_start + self.concurrency]
             results = await asyncio.gather(
@@ -85,7 +103,7 @@ class DeviceTraversal:
                     # Account budget saturated for longer than this run can wait:
                     # not a device failure and not evidence about Lotek. Defer
                     # THIS device only; peers and later chunks continue (D3).
-                    self.deferred_devices.append(device_id)
+                    self.slot_starved_devices.append(device_id)
                     self.budget_starved = True
                     continue
                 if isinstance(res, BaseException):

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ import app.settings as settings
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.actions.client import close_client as close_lotek_client
+from app.services.lotek_connections import close_connection_client
 from app.services.action_runner import execute_action, _portal
 from app.services.self_registration import register_integration_in_gundi
 from app.services.webhooks import close_diagnostic_client
@@ -32,6 +33,7 @@ async def lifespan(app: FastAPI):
     await _portal.close()
     await close_diagnostic_client()
     await close_lotek_client()
+    await close_connection_client()
 
 
 app = FastAPI(

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -1,5 +1,7 @@
+import asyncio
 import hashlib
 import logging
+import random
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -19,6 +21,12 @@ logger = logging.getLogger(__name__)
 # this budget and escaped as RedisError into the generic per-device handler —
 # a fabricated Lotek failure caused by our own Redis (review finding).
 SLOT_REDIS_RETRY = dict(attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
+
+# Backpressure poll schedule for a saturated account budget. Jittered so that
+# N shards refused in the same millisecond do not retry in lockstep.
+SLOT_WAIT_POLL_INITIAL = 0.25
+SLOT_WAIT_POLL_MAX = 2.0
+SLOT_WAIT_JITTER = 0.25
 
 
 class NoConnectionSlot(Exception):
@@ -86,12 +94,17 @@ async def close_connection_client() -> None:
 
 
 @asynccontextmanager
-async def lotek_slot(username: str, *, ttl_seconds: int = 300):
+async def lotek_slot(username: str, *, ttl_seconds: int = 300, max_wait_seconds: float = 0.0):
     """Acquire one Lotek connection slot for `username`, shared across every
-    shard/backfill invocation on the same Redis. Raises NoConnectionSlot if at
-    capacity. (Movebank-connector pattern: once the head pass fans out into
-    concurrently-running shard sub-actions, an out-of-process cap is the only
-    thing bounding simultaneous requests against one Lotek account.)
+    shard/backfill invocation on the same Redis.
+
+    With `max_wait_seconds > 0` a saturated budget makes the caller QUEUE
+    (jittered poll) rather than fail: fan-out deliberately oversubscribes the
+    ceiling, so refusing on first contention aborted whole shards and turned
+    ordinary large-fleet ticks into zero-progress churn (spec D2). The wait is
+    capped by the caller's remaining action budget, so queueing can never cause
+    a timeout that failing fast would have avoided. NoConnectionSlot now means
+    "saturated for longer than I can afford to wait".
 
     Slots are members of a per-username sorted set scored by expiry time, so a
     crashed holder's slot self-expires (purged on the next acquire) rather than
@@ -107,19 +120,36 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300):
     """
     client = _client()
     key = connection_key(username)
+    # One token for the whole acquire, including every wait poll: the Lua's
+    # ZSCORE fast-path re-grants an already-held slot, so re-using the token is
+    # what makes a lost reply safe (Task 1).
     token = str(uuid.uuid4())
-    # Retried like every IntegrationStateManager Redis op (review finding: an
-    # unretried transient Redis error here escaped as a fake per-device
-    # failure downstream — a blip in OUR Redis said nothing about Lotek).
-    async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
-        with attempt:
-            now = time.time()
-            acquired = await client.eval(
-                _ACQUIRE_LUA, 1, key, now, now + ttl_seconds,
-                settings.LOTEK_MAX_CONNECTIONS, token, ttl_seconds * 2,
+    deadline = time.monotonic() + max(0.0, max_wait_seconds)
+    backoff = SLOT_WAIT_POLL_INITIAL
+    acquired = 0
+    while True:
+        async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
+            with attempt:
+                now = time.time()
+                acquired = await client.eval(
+                    _ACQUIRE_LUA, 1, key, now, now + ttl_seconds,
+                    settings.LOTEK_MAX_CONNECTIONS, token, ttl_seconds * 2,
+                )
+        if acquired:
+            break
+        # Saturated. Wait for a peer to release rather than aborting the
+        # caller's whole tail (spec D2/D3) — but never past the budget the
+        # caller can afford to spend.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise NoConnectionSlot(
+                f"No Lotek connection slot available within "
+                f"{max_wait_seconds:.1f}s (limit {settings.LOTEK_MAX_CONNECTIONS})."
             )
-    if not acquired:
-        raise NoConnectionSlot(f"No Lotek connection slot available (limit {settings.LOTEK_MAX_CONNECTIONS}).")
+        pause = min(backoff + random.uniform(0, SLOT_WAIT_JITTER), remaining)
+        if pause > 0:
+            await asyncio.sleep(pause)
+        backoff = min(backoff * 2 or SLOT_WAIT_POLL_INITIAL, SLOT_WAIT_POLL_MAX)
     try:
         yield
     finally:

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -50,15 +50,17 @@ class NoConnectionSlot(Exception):
 # the longest-lived member, so it can never expire a key with live holders.
 _ACQUIRE_LUA = """
 redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
-redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
 if redis.call('ZSCORE', KEYS[1], ARGV[4]) then
     redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
     return 1
 end
 if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
     redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
     return 1
 end
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
 return 0
 """
 

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -16,22 +16,32 @@ class NoConnectionSlot(Exception):
     """Raised when the Lotek connection budget for a username is exhausted."""
 
 
-# Atomic acquire: purge expired slots, then add a new slot only if under the
-# ceiling. KEYS[1]=zset key. ARGV: now, expiry, ceiling, token.
-# Returns 1 if acquired, 0 if at capacity.
-# The key itself is given a TTL on every acquire (Copilot review): members
-# carry logical expiry in their score, but they are only purged by a LATER
-# acquire — so an account that stops being used would leave its zset behind
-# forever. The TTL is refreshed on each acquire and comfortably outlives the
-# longest-lived member, so it can never expire a key with live holders.
+# Atomic acquire: purge expired slots, re-grant to an existing holder, then add
+# a new slot only if under the ceiling. KEYS[1]=zset key.
+# ARGV: now, expiry, ceiling, token, key_ttl.
+# Returns 1 if acquired (or already held), 0 if at capacity.
+#
+# The ZSCORE fast-path makes the script idempotent for a given token. Without
+# it, a lost reply on the acquire that filled the last slot made the stamina
+# retry refuse the very caller that owns the slot, stranding it for the full
+# TTL (review finding). Re-granting also refreshes the expiry so a retried
+# holder does not inherit an about-to-expire slot.
+#
+# The key itself gets a TTL on every path: members carry logical expiry in
+# their score but are only purged by a LATER acquire, so an account that stops
+# being used would leave its zset behind forever. The TTL comfortably outlives
+# the longest-lived member, so it can never expire a key with live holders.
 _ACQUIRE_LUA = """
 redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
-if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
+if redis.call('ZSCORE', KEYS[1], ARGV[4]) then
     redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
-    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
     return 1
 end
-redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    return 1
+end
 return 0
 """
 

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -5,6 +5,7 @@ import uuid
 from contextlib import asynccontextmanager
 
 import redis.asyncio as redis
+import stamina
 
 from app import settings
 
@@ -68,10 +69,17 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300):
     client = _client()
     key = connection_key(username)
     token = str(uuid.uuid4())
-    now = time.time()
-    acquired = await client.eval(
-        _ACQUIRE_LUA, 1, key, now, now + ttl_seconds, settings.LOTEK_MAX_CONNECTIONS, token
-    )
+    # Retried like every IntegrationStateManager Redis op (review finding: an
+    # unretried transient Redis error here escaped as a fake per-device
+    # failure downstream — a blip in OUR Redis said nothing about Lotek).
+    async for attempt in stamina.retry_context(
+        on=redis.RedisError, attempts=3, wait_initial=0.1, wait_max=2.0
+    ):
+        with attempt:
+            now = time.time()
+            acquired = await client.eval(
+                _ACQUIRE_LUA, 1, key, now, now + ttl_seconds, settings.LOTEK_MAX_CONNECTIONS, token
+            )
     if not acquired:
         raise NoConnectionSlot(f"No Lotek connection slot available (limit {settings.LOTEK_MAX_CONNECTIONS}).")
     try:

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -1,0 +1,80 @@
+import hashlib
+import logging
+import time
+import uuid
+from contextlib import asynccontextmanager
+
+import redis.asyncio as redis
+
+from app import settings
+
+logger = logging.getLogger(__name__)
+
+
+class NoConnectionSlot(Exception):
+    """Raised when the Lotek connection budget for a username is exhausted."""
+
+
+# Atomic acquire: purge expired slots, then add a new slot only if under the
+# ceiling. KEYS[1]=zset key. ARGV: now, expiry, ceiling, token.
+# Returns 1 if acquired, 0 if at capacity.
+_ACQUIRE_LUA = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    return 1
+end
+return 0
+"""
+
+
+def connection_key(username: str) -> str:
+    digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:16]
+    return f"lotek:connections:{digest}"
+
+
+_shared_client = None
+
+
+def _client() -> redis.Redis:
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = redis.Redis(
+            host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+        )
+    return _shared_client
+
+
+@asynccontextmanager
+async def lotek_slot(username: str, *, ttl_seconds: int = 120):
+    """Acquire one Lotek connection slot for `username`, shared across every
+    shard/backfill invocation on the same Redis. Raises NoConnectionSlot if at
+    capacity. (Movebank-connector pattern: once the head pass fans out into
+    concurrently-running shard sub-actions, an out-of-process cap is the only
+    thing bounding simultaneous requests against one Lotek account.)
+
+    Slots are members of a per-username sorted set scored by expiry time, so a
+    crashed holder's slot self-expires (purged on the next acquire) rather than
+    leaking the budget permanently. The TTL only needs to outlive one request
+    (connect 10s + read 30s worst case, times one stamina retry).
+    """
+    client = _client()
+    key = connection_key(username)
+    token = str(uuid.uuid4())
+    now = time.time()
+    acquired = await client.eval(
+        _ACQUIRE_LUA, 1, key, now, now + ttl_seconds, settings.LOTEK_MAX_CONNECTIONS, token
+    )
+    if not acquired:
+        raise NoConnectionSlot(f"No Lotek connection slot available (limit {settings.LOTEK_MAX_CONNECTIONS}).")
+    try:
+        yield
+    finally:
+        # Best-effort release: a failed zrem must not turn an otherwise-successful
+        # Lotek call into an action failure (spurious retry). The slot is
+        # time-bounded and purged on the next acquire, so a missed release
+        # self-heals via TTL.
+        try:
+            await client.zrem(key, token)
+        except Exception as exc:
+            logger.warning(f"Failed to release Lotek connection slot (will expire via TTL): {exc}")

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -142,6 +142,18 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300, max_wait_seconds:
         # caller can afford to spend.
         remaining = deadline - time.monotonic()
         if remaining <= 0:
+            # Give-up path: if the Lua actually granted this token on a poll
+            # whose reply we never saw (lost reply on the final attempt), no
+            # one else will ever release it. Best-effort zrem so a lost-reply
+            # slot isn't stranded for the full TTL; failure here must not mask
+            # the NoConnectionSlot we're about to raise.
+            try:
+                await client.zrem(key, token)
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to release Lotek connection slot on give-up "
+                    f"(will expire via TTL): {exc}"
+                )
             raise NoConnectionSlot(
                 f"No Lotek connection slot available within "
                 f"{max_wait_seconds:.1f}s (limit {settings.LOTEK_MAX_CONNECTIONS})."

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -129,14 +129,59 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300, max_wait_seconds:
     deadline = time.monotonic() + max(0.0, max_wait_seconds)
     backoff = SLOT_WAIT_POLL_INITIAL
     acquired = 0
+
+    async def _acquire_once():
+        now = time.time()
+        return await client.eval(
+            _ACQUIRE_LUA, 1, key, now, now + ttl_seconds,
+            settings.LOTEK_MAX_CONNECTIONS, token, ttl_seconds * 2,
+        )
+
+    async def _give_up(reason):
+        # Shared give-up path: if the Lua actually granted this token on an
+        # attempt whose reply we never saw (lost reply on the last try), no
+        # one else will ever release it. Best-effort zrem so a lost-reply
+        # slot isn't stranded for the full TTL; failure here must not mask
+        # the NoConnectionSlot we're about to raise.
+        try:
+            await client.zrem(key, token)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to release Lotek connection slot on {reason} "
+                f"(will expire via TTL): {exc}"
+            )
+        raise NoConnectionSlot(
+            f"No Lotek connection slot available within "
+            f"{max_wait_seconds:.1f}s (limit {settings.LOTEK_MAX_CONNECTIONS})."
+        )
+
     while True:
-        async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
-            with attempt:
-                now = time.time()
-                acquired = await client.eval(
-                    _ACQUIRE_LUA, 1, key, now, now + ttl_seconds,
-                    settings.LOTEK_MAX_CONNECTIONS, token, ttl_seconds * 2,
-                )
+        # Bound the retry/backoff itself by the caller's remaining wait
+        # budget: letting stamina's own attempts=5/wait_max=30 run unbounded
+        # on a Redis brownout could burn well past `deadline` before this
+        # loop ever rechecks it, entering the protected section late (review
+        # finding). A caller with no wait budget left (including a
+        # max_wait_seconds=0 caller on its very first pass) still gets one
+        # immediate, unretried attempt rather than none at all.
+        remaining_before_attempt = deadline - time.monotonic()
+        if remaining_before_attempt <= 0:
+            try:
+                acquired = await _acquire_once()
+            except redis.RedisError:
+                # No budget left to retry a Redis brownout.
+                await _give_up("retry give-up")
+        else:
+            try:
+                async def _bounded_retry():
+                    async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
+                        with attempt:
+                            return await _acquire_once()
+                acquired = await asyncio.wait_for(_bounded_retry(), timeout=remaining_before_attempt)
+            except (redis.RedisError, asyncio.TimeoutError):
+                # Either the retry budget itself ran past what the caller can
+                # afford to wait, or the last attempt before the deadline
+                # failed outright.
+                await _give_up("retry give-up")
         if acquired:
             break
         # Saturated. Wait for a peer to release rather than aborting the
@@ -144,22 +189,7 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300, max_wait_seconds:
         # caller can afford to spend.
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            # Give-up path: if the Lua actually granted this token on a poll
-            # whose reply we never saw (lost reply on the final attempt), no
-            # one else will ever release it. Best-effort zrem so a lost-reply
-            # slot isn't stranded for the full TTL; failure here must not mask
-            # the NoConnectionSlot we're about to raise.
-            try:
-                await client.zrem(key, token)
-            except Exception as exc:
-                logger.warning(
-                    f"Failed to release Lotek connection slot on give-up "
-                    f"(will expire via TTL): {exc}"
-                )
-            raise NoConnectionSlot(
-                f"No Lotek connection slot available within "
-                f"{max_wait_seconds:.1f}s (limit {settings.LOTEK_MAX_CONNECTIONS})."
-            )
+            await _give_up("give-up")
         pause = min(backoff + random.uniform(0, SLOT_WAIT_JITTER), remaining)
         if pause > 0:
             await asyncio.sleep(pause)

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -19,12 +19,19 @@ class NoConnectionSlot(Exception):
 # Atomic acquire: purge expired slots, then add a new slot only if under the
 # ceiling. KEYS[1]=zset key. ARGV: now, expiry, ceiling, token.
 # Returns 1 if acquired, 0 if at capacity.
+# The key itself is given a TTL on every acquire (Copilot review): members
+# carry logical expiry in their score, but they are only purged by a LATER
+# acquire — so an account that stops being used would leave its zset behind
+# forever. The TTL is refreshed on each acquire and comfortably outlives the
+# longest-lived member, so it can never expire a key with live holders.
 _ACQUIRE_LUA = """
 redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
 if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
     redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
     return 1
 end
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
 return 0
 """
 
@@ -78,7 +85,8 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300):
         with attempt:
             now = time.time()
             acquired = await client.eval(
-                _ACQUIRE_LUA, 1, key, now, now + ttl_seconds, settings.LOTEK_MAX_CONNECTIONS, token
+                _ACQUIRE_LUA, 1, key, now, now + ttl_seconds,
+                settings.LOTEK_MAX_CONNECTIONS, token, ttl_seconds * 2,
             )
     if not acquired:
         raise NoConnectionSlot(f"No Lotek connection slot available (limit {settings.LOTEK_MAX_CONNECTIONS}).")

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -46,7 +46,7 @@ def _client() -> redis.Redis:
 
 
 @asynccontextmanager
-async def lotek_slot(username: str, *, ttl_seconds: int = 120):
+async def lotek_slot(username: str, *, ttl_seconds: int = 300):
     """Acquire one Lotek connection slot for `username`, shared across every
     shard/backfill invocation on the same Redis. Raises NoConnectionSlot if at
     capacity. (Movebank-connector pattern: once the head pass fans out into
@@ -55,8 +55,15 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 120):
 
     Slots are members of a per-username sorted set scored by expiry time, so a
     crashed holder's slot self-expires (purged on the next acquire) rather than
-    leaking the budget permanently. The TTL only needs to outlive one request
-    (connect 10s + read 30s worst case, times one stamina retry).
+    leaking the budget permanently. TTL sizing: the slot is released between
+    stamina attempts (re-acquired per attempt), so retries never extend a
+    hold. What CAN extend one is a 401-triggered re-login inside the request
+    (token invalidated mid-flight — callers pre-warm the token before
+    acquiring, so this is the rare path, but it stacks a login's
+    connect+read on top of the request's own, plus queueing on the
+    per-integration token lock). 300s covers that worst case; a hold that
+    somehow outlives the TTL only soft-fails (one extra admission until the
+    next purge).
     """
     client = _client()
     key = connection_key(username)

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -53,6 +53,19 @@ def _client() -> redis.Redis:
     return _shared_client
 
 
+async def close_connection_client() -> None:
+    """Close the shared Redis client on shutdown, like every other module-level
+    client the FastAPI lifespan closes. Without this the connections are only
+    reclaimed by __del__ after the event loop is gone, which logs a
+    "RuntimeError: Event loop is closed" traceback per pooled connection on
+    every restart (observed on the local stage stack).
+    """
+    global _shared_client
+    if _shared_client is not None:
+        await _shared_client.aclose()
+        _shared_client = None
+
+
 @asynccontextmanager
 async def lotek_slot(username: str, *, ttl_seconds: int = 300):
     """Acquire one Lotek connection slot for `username`, shared across every

--- a/app/services/lotek_connections.py
+++ b/app/services/lotek_connections.py
@@ -12,6 +12,15 @@ from app import settings
 logger = logging.getLogger(__name__)
 
 
+# The uniform Redis retry policy used by every IntegrationStateManager and
+# config-manager op (app/services/state.py). Kept identical on purpose: the
+# slot acquire previously used attempts=3/wait_initial=0.1/wait_max=2.0, so a
+# multi-second Redis brownout that every get_state around it survived exhausted
+# this budget and escaped as RedisError into the generic per-device handler —
+# a fabricated Lotek failure caused by our own Redis (review finding).
+SLOT_REDIS_RETRY = dict(attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
+
+
 class NoConnectionSlot(Exception):
     """Raised when the Lotek connection budget for a username is exhausted."""
 
@@ -102,9 +111,7 @@ async def lotek_slot(username: str, *, ttl_seconds: int = 300):
     # Retried like every IntegrationStateManager Redis op (review finding: an
     # unretried transient Redis error here escaped as a fake per-device
     # failure downstream — a blip in OUR Redis said nothing about Lotek).
-    async for attempt in stamina.retry_context(
-        on=redis.RedisError, attempts=3, wait_initial=0.1, wait_max=2.0
-    ):
+    async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
         with attempt:
             now = time.time()
             acquired = await client.eval(

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -147,11 +147,17 @@ class IntegrationStateManager:
         added to close — and an untimed key leaks for anything abandoned
         mid-streak.
 
-        INCR and EXPIRE are retried as two separate attempt loops (not one
-        block): retrying INCR+EXPIRE together as a unit means a RedisError on
-        the EXPIRE call re-runs the INCR too, silently over-counting the
-        streak. Isolating EXPIRE in its own retry loop means a retry there can
-        only repeat the (idempotent) EXPIRE, never the increment.
+        INCR and EXPIRE are handled very differently. EXPIRE is idempotent, so
+        it keeps its own retry loop, isolated from INCR so a retry there can
+        never repeat the increment. INCR itself is NOT wrapped in a stamina
+        retry at all: a blind retry of a non-idempotent write risks
+        double-counting the streak when the server actually applied the
+        increment but the reply was lost, and if every retry attempt fails
+        that way the loop would raise without ever reaching EXPIRE, leaving an
+        inflated, never-expiring key behind (review finding). A single,
+        unretried INCR instead risks only an occasional missed increment on a
+        genuine Redis blip — an acceptable miss for a best-effort streak
+        counter whose callers already treat any failure as a safe default.
 
         Self-heals a legacy value: this key was previously written by
         set_state as a JSON blob (e.g. {"streak": 2}), with no TTL, so any
@@ -164,17 +170,18 @@ class IntegrationStateManager:
         on the saturated accounts it exists to diagnose (review finding). Only
         that specific message is treated as a legacy value; any other
         ResponseError (a genuine server-side problem) is re-raised untouched.
+        This one-time delete-and-retry is deterministic (keyed off the error
+        message, not a blind retry-on-any-failure), so it does not reintroduce
+        the double-count risk INCR's own retry was removed to avoid.
         """
         key = f"integration_state.{integration_id}.{action_id}.{source_id}"
-        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
-            with attempt:
-                try:
-                    value = await self.db_client.incr(key)
-                except ResponseError as e:
-                    if "not an integer" not in str(e).lower():
-                        raise
-                    await self.db_client.delete(key)
-                    value = await self.db_client.incr(key)
+        try:
+            value = await self.db_client.incr(key)
+        except ResponseError as e:
+            if "not an integer" not in str(e).lower():
+                raise
+            await self.db_client.delete(key)
+            value = await self.db_client.incr(key)
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.expire(key, ttl_seconds)

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -135,6 +135,24 @@ class IntegrationStateManager:
                 deleted = await self.db_client.eval(_RELEASE_LEASE_SCRIPT, 1, key, json.dumps(token))
         return bool(deleted)
 
+    async def increment_counter(
+        self, integration_id: str, action_id: str, source_id: str = "no-source",
+        ttl_seconds: int = 3600,
+    ) -> int:
+        """Atomically increment a small counter and refresh its TTL.
+
+        Used for streak counters. A client-side get / int+1 / set loses
+        increments when two runs overlap — the same race merge_state_fields was
+        added to close — and an untimed key leaks for anything abandoned
+        mid-streak.
+        """
+        key = f"integration_state.{integration_id}.{action_id}.{source_id}"
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                value = await self.db_client.incr(key)
+                await self.db_client.expire(key, ttl_seconds)
+        return int(value)
+
     async def delete_state(self, integration_id: str, action_id: str, source_id: str = "no-source"):
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -5,6 +5,7 @@ from typing import Optional
 import stamina
 import httpx
 import redis.asyncio as redis
+from redis.exceptions import ResponseError
 from app import settings
 
 
@@ -151,11 +152,29 @@ class IntegrationStateManager:
         the EXPIRE call re-runs the INCR too, silently over-counting the
         streak. Isolating EXPIRE in its own retry loop means a retry there can
         only repeat the (idempotent) EXPIRE, never the increment.
+
+        Self-heals a legacy value: this key was previously written by
+        set_state as a JSON blob (e.g. {"streak": 2}), with no TTL, so any
+        pre-existing key from before this counter was atomic is permanent and
+        INCR against it always raises "value is not an integer or out of
+        range". Rather than fail forever, the first INCR to hit one drops the
+        stale value and increments once more — otherwise the streak could
+        never advance for any integration carrying a legacy key, making the
+        DISPATCHER_SKIP_WARN_AFTER diagnostic permanently unreachable exactly
+        on the saturated accounts it exists to diagnose (review finding). Only
+        that specific message is treated as a legacy value; any other
+        ResponseError (a genuine server-side problem) is re-raised untouched.
         """
         key = f"integration_state.{integration_id}.{action_id}.{source_id}"
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
-                value = await self.db_client.incr(key)
+                try:
+                    value = await self.db_client.incr(key)
+                except ResponseError as e:
+                    if "not an integer" not in str(e).lower():
+                        raise
+                    await self.db_client.delete(key)
+                    value = await self.db_client.incr(key)
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 await self.db_client.expire(key, ttl_seconds)

--- a/app/services/state.py
+++ b/app/services/state.py
@@ -145,11 +145,19 @@ class IntegrationStateManager:
         increments when two runs overlap — the same race merge_state_fields was
         added to close — and an untimed key leaks for anything abandoned
         mid-streak.
+
+        INCR and EXPIRE are retried as two separate attempt loops (not one
+        block): retrying INCR+EXPIRE together as a unit means a RedisError on
+        the EXPIRE call re-runs the INCR too, silently over-counting the
+        streak. Isolating EXPIRE in its own retry loop means a retry there can
+        only repeat the (idempotent) EXPIRE, never the increment.
         """
         key = f"integration_state.{integration_id}.{action_id}.{source_id}"
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 value = await self.db_client.incr(key)
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
                 await self.db_client.expire(key, ttl_seconds)
         return int(value)
 

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from unittest.mock import AsyncMock
 
@@ -234,6 +236,46 @@ async def test_slot_without_wait_budget_still_fails_fast(fake_redis):
         async with lotek_slot("user@example.com"):
             pytest.fail("body must not run")
     assert fake_redis.eval.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_slot_retry_is_bounded_by_the_wait_deadline_not_the_retry_budget(fake_redis, monkeypatch):
+    """A Redis brownout must not let stamina's own retry/backoff (attempts=5,
+    wait_max=30) run to completion regardless of the caller's wait budget: a
+    slow-but-eventually-successful retry could grant the slot well after the
+    caller's deadline had already passed, entering the protected section late
+    (review finding). The retry/backoff itself must be bounded by the
+    monotonic deadline, giving up close to the caller's actual budget instead
+    of stamina's own worst case."""
+    from redis.exceptions import RedisError
+    fake_redis.eval = AsyncMock(side_effect=RedisError("brownout"))
+
+    start = time.monotonic()
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com", max_wait_seconds=0.05):
+            pytest.fail("body must not run")
+    elapsed = time.monotonic() - start
+
+    # stamina's own policy alone (wait_initial=1.0s before a 2nd attempt)
+    # would blow this 0.05s budget by 20x+ if unbounded.
+    assert elapsed < 1.0
+    fake_redis.zrem.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slot_retry_still_gets_one_immediate_attempt_with_zero_budget(fake_redis):
+    """A caller with no wait budget at all (the common default) must still
+    get one immediate, unretried attempt on a Redis error — not zero — the
+    same "always at least one try" guarantee the happy path already had."""
+    from redis.exceptions import RedisError
+    fake_redis.eval = AsyncMock(side_effect=RedisError("brownout"))
+
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com"):
+            pytest.fail("body must not run")
+
+    assert fake_redis.eval.await_count == 1
+    fake_redis.zrem.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -116,6 +116,51 @@ async def test_reacquire_with_same_token_is_idempotent(fake_redis):
 
 
 @pytest.mark.asyncio
+async def test_slot_waits_then_acquires_when_capacity_frees(fake_redis, monkeypatch):
+    """Oversubscription must queue, not refuse: with shards x FETCH_CONCURRENCY
+    well above the ceiling, a caller that waits a moment gets a slot instead of
+    deferring its whole tail (spec D2)."""
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_INITIAL", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_MAX", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_JITTER", 0)
+    # Refused twice (account saturated), then a peer releases.
+    fake_redis.eval = AsyncMock(side_effect=[0, 0, 1])
+
+    async with lotek_slot("user@example.com", max_wait_seconds=5.0):
+        pass
+
+    assert fake_redis.eval.await_count == 3
+    fake_redis.zrem.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slot_gives_up_when_wait_budget_exhausted(fake_redis, monkeypatch):
+    """Waiting must never eat the caller's action deadline: once the budget is
+    spent the slot raises, and the caller defers as before."""
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_INITIAL", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_MAX", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_JITTER", 0)
+    fake_redis.eval = AsyncMock(return_value=0)
+
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com", max_wait_seconds=0.05):
+            pytest.fail("body must not run when the account stays saturated")
+
+    assert fake_redis.eval.await_count >= 1
+    fake_redis.zrem.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slot_without_wait_budget_still_fails_fast(fake_redis):
+    """Default stays fail-fast for callers with no deadline to reason about."""
+    fake_redis.eval = AsyncMock(return_value=0)
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com"):
+            pytest.fail("body must not run")
+    assert fake_redis.eval.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_close_connection_client_closes_and_resets(monkeypatch):
     # The FastAPI lifespan closes every other module-level client; without this
     # the pooled connections are reclaimed by __del__ after the loop is gone,

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -119,6 +119,40 @@ async def test_reacquire_with_same_token_is_idempotent(fake_redis):
     assert "ZADD" in _ACQUIRE_LUA[zscore_at:zcard_at]
 
 
+def test_expire_runs_after_every_zadd_and_before_every_return():
+    """A key this script's own ZADD just created, or that a concurrent
+    holder's ZADD created and this call merely found at capacity, must get a
+    TTL before the script returns 0 or 1 — otherwise the very first acquire
+    on a brand-new account key leaves a persistent zset with no TTL at all,
+    only fixed up whenever some later acquire happens to run EXPIRE (review
+    finding: EXPIRE used to run once, before either branch, so it covered the
+    at-capacity return-0 path but missed the TTL-less key its own ZADD had
+    just created on the create path).
+
+    The `fake_redis` AsyncMock can't model key creation, so this pins the
+    guarantee at the script-text level, in the style of
+    test_reacquire_with_same_token_is_idempotent: scanning top to bottom,
+    every `return` must be preceded by an EXPIRE since the most recent ZADD
+    (or since the start of the script, for the return that has no ZADD at
+    all on its path).
+    """
+    from app.services.lotek_connections import _ACQUIRE_LUA
+
+    lines = [ln.strip() for ln in _ACQUIRE_LUA.strip().splitlines()]
+    expired_since_last_zadd = True  # true at the top, before any ZADD
+    for line in lines:
+        if line.startswith("redis.call('ZADD'"):
+            expired_since_last_zadd = False
+        if line.startswith("redis.call('EXPIRE'"):
+            expired_since_last_zadd = True
+        if line.startswith("return"):
+            assert expired_since_last_zadd, (
+                f"{line!r} is reachable without an EXPIRE since the last "
+                f"ZADD (or since the start of the script) — the key can be "
+                f"left with no TTL."
+            )
+
+
 @pytest.mark.asyncio
 async def test_slot_waits_then_acquires_when_capacity_frees(fake_redis, monkeypatch):
     """Oversubscription must queue, not refuse: with shards x FETCH_CONCURRENCY

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -32,12 +32,16 @@ async def test_acquire_under_capacity_grants_and_releases(fake_redis):
 
 
 @pytest.mark.asyncio
-async def test_acquire_at_capacity_raises_and_does_not_release(fake_redis):
+async def test_acquire_at_capacity_raises_and_best_effort_releases(fake_redis):
+    # Give-up (including the fail-fast default with no wait budget) cannot
+    # tell "server said 0" apart from "granted but the reply was lost", so it
+    # always attempts a cleanup zrem before raising — a no-op if the token
+    # was never actually added.
     fake_redis.eval = AsyncMock(return_value=0)
     with pytest.raises(NoConnectionSlot):
         async with lotek_slot("user@example.com"):
             pytest.fail("body must not run when at capacity")
-    fake_redis.zrem.assert_not_awaited()
+    fake_redis.zrem.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -147,7 +151,45 @@ async def test_slot_gives_up_when_wait_budget_exhausted(fake_redis, monkeypatch)
             pytest.fail("body must not run when the account stays saturated")
 
     assert fake_redis.eval.await_count >= 1
-    fake_redis.zrem.assert_not_awaited()
+    # Best-effort cleanup on give-up: we cannot tell "server said 0" apart
+    # from "server granted it but the reply was lost" from the client side,
+    # so the give-up path always attempts to remove the token. It is a no-op
+    # if the token was never actually added.
+    fake_redis.zrem.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slot_give_up_releases_a_token_the_server_actually_granted(fake_redis, monkeypatch):
+    """If the final poll's reply is lost after the server already granted the
+    slot (e.g. a network blip on the way back), the give-up path must not
+    strand that slot for the full TTL: it removes the token before raising."""
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_INITIAL", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_MAX", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_JITTER", 0)
+    fake_redis.eval = AsyncMock(return_value=0)
+
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com", max_wait_seconds=0.05):
+            pytest.fail("body must not run when the account stays saturated")
+
+    # The token removed is the same one used in every acquire attempt.
+    token = fake_redis.eval.await_args.args[-2]
+    fake_redis.zrem.assert_awaited_once_with(connection_key("user@example.com"), token)
+
+
+@pytest.mark.asyncio
+async def test_slot_give_up_zrem_failure_does_not_mask_no_connection_slot(fake_redis, monkeypatch):
+    """A failed best-effort cleanup on give-up must not turn into some other
+    exception that hides the real NoConnectionSlot from the caller."""
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_INITIAL", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_MAX", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_JITTER", 0)
+    fake_redis.eval = AsyncMock(return_value=0)
+    fake_redis.zrem = AsyncMock(side_effect=ConnectionError("redis blip"))
+
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com", max_wait_seconds=0.05):
+            pytest.fail("body must not run when the account stays saturated")
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -1,0 +1,77 @@
+import pytest
+from unittest.mock import AsyncMock
+
+import app.services.lotek_connections as lc
+from app.services.lotek_connections import NoConnectionSlot, connection_key, lotek_slot
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Deterministic stand-in for the module's shared Redis client: `eval`
+    grants or refuses per test wiring, `zrem` records releases."""
+    client = AsyncMock()
+    client.eval = AsyncMock(return_value=1)
+    client.zrem = AsyncMock(return_value=1)
+    monkeypatch.setattr(lc, "_shared_client", client)
+    yield client
+    monkeypatch.setattr(lc, "_shared_client", None)
+
+
+@pytest.mark.asyncio
+async def test_acquire_under_capacity_grants_and_releases(fake_redis):
+    async with lotek_slot("user@example.com"):
+        pass
+    # One atomic Lua acquire against the per-username key...
+    assert fake_redis.eval.await_count == 1
+    args = fake_redis.eval.await_args.args
+    assert args[2] == connection_key("user@example.com")
+    # ...and the exact member added is the one removed on release.
+    token = args[-1]
+    fake_redis.zrem.assert_awaited_once_with(connection_key("user@example.com"), token)
+
+
+@pytest.mark.asyncio
+async def test_acquire_at_capacity_raises_and_does_not_release(fake_redis):
+    fake_redis.eval = AsyncMock(return_value=0)
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com"):
+            pytest.fail("body must not run when at capacity")
+    fake_redis.zrem.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_release_happens_even_when_body_raises(fake_redis):
+    with pytest.raises(RuntimeError):
+        async with lotek_slot("user@example.com"):
+            raise RuntimeError("request blew up")
+    fake_redis.zrem.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_release_is_swallowed(fake_redis):
+    # A zrem blip must not turn a successful Lotek call into an action
+    # failure; the slot self-expires via its TTL score.
+    fake_redis.zrem = AsyncMock(side_effect=ConnectionError("redis blip"))
+    async with lotek_slot("user@example.com"):
+        pass  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_expiry_score_and_ceiling_are_passed_to_the_lua_script(fake_redis):
+    import time
+    before = time.time()
+    async with lotek_slot("user@example.com", ttl_seconds=300):
+        pass
+    args = fake_redis.eval.await_args.args
+    # ARGV: now, expiry, ceiling, token (after script + numkeys + key)
+    now_arg, expiry_arg, ceiling_arg = args[3], args[4], args[5]
+    assert before <= now_arg <= time.time()
+    assert expiry_arg == pytest.approx(now_arg + 300)
+    from app import settings
+    assert ceiling_arg == settings.LOTEK_MAX_CONNECTIONS
+
+
+def test_connection_key_is_stable_and_username_scoped():
+    assert connection_key("a") == connection_key("a")
+    assert connection_key("a") != connection_key("b")
+    assert connection_key("a").startswith("lotek:connections:")

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -82,6 +82,27 @@ def test_connection_key_is_stable_and_username_scoped():
 
 
 @pytest.mark.asyncio
+async def test_reacquire_with_same_token_is_idempotent(fake_redis):
+    """A lost reply on the acquire that took the last slot must not refuse the
+    caller that already owns that slot. The Lua checks ZSCORE for the token
+    before the ZCARD ceiling test, so a retry with the same token re-grants.
+
+    Simulated at the script level: the real guarantee lives in the Lua, so this
+    test pins that the script text contains the membership fast-path ahead of
+    the capacity check.
+    """
+    from app.services.lotek_connections import _ACQUIRE_LUA
+
+    zscore_at = _ACQUIRE_LUA.find("ZSCORE")
+    zcard_at = _ACQUIRE_LUA.find("ZCARD")
+    assert zscore_at != -1, "acquire must check token membership before capacity"
+    assert zscore_at < zcard_at, "membership fast-path must precede the ceiling test"
+    # The fast-path must re-arm the member's expiry rather than returning a
+    # stale score, so a waiting retry cannot inherit an about-to-expire slot.
+    assert "ZADD" in _ACQUIRE_LUA[zscore_at:zcard_at]
+
+
+@pytest.mark.asyncio
 async def test_close_connection_client_closes_and_resets(monkeypatch):
     # The FastAPI lifespan closes every other module-level client; without this
     # the pooled connections are reclaimed by __del__ after the loop is gone,

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -25,8 +25,9 @@ async def test_acquire_under_capacity_grants_and_releases(fake_redis):
     assert fake_redis.eval.await_count == 1
     args = fake_redis.eval.await_args.args
     assert args[2] == connection_key("user@example.com")
-    # ...and the exact member added is the one removed on release.
-    token = args[-1]
+    # ...and the exact member added is the one removed on release. (ARGV order:
+    # now, expiry, ceiling, token, key_ttl — the token is second from the end.)
+    token = args[-2]
     fake_redis.zrem.assert_awaited_once_with(connection_key("user@example.com"), token)
 
 
@@ -63,12 +64,15 @@ async def test_expiry_score_and_ceiling_are_passed_to_the_lua_script(fake_redis)
     async with lotek_slot("user@example.com", ttl_seconds=300):
         pass
     args = fake_redis.eval.await_args.args
-    # ARGV: now, expiry, ceiling, token (after script + numkeys + key)
+    # ARGV: now, expiry, ceiling, token, key_ttl (after script + numkeys + key)
     now_arg, expiry_arg, ceiling_arg = args[3], args[4], args[5]
     assert before <= now_arg <= time.time()
     assert expiry_arg == pytest.approx(now_arg + 300)
     from app import settings
     assert ceiling_arg == settings.LOTEK_MAX_CONNECTIONS
+    # The key's own TTL must outlive the longest-lived member, so a refresh can
+    # never expire a key that still has live holders.
+    assert args[7] > 300
 
 
 def test_connection_key_is_stable_and_username_scoped():

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -82,6 +82,19 @@ def test_connection_key_is_stable_and_username_scoped():
 
 
 @pytest.mark.asyncio
+async def test_slot_retry_policy_matches_state_manager(fake_redis):
+    """A Redis brownout that every IntegrationStateManager op survives must not
+    escape from the slot acquire as a fake per-device Lotek failure. The policy
+    here has to match state.py's, not undercut it.
+    """
+    from app.services.lotek_connections import SLOT_REDIS_RETRY
+
+    assert SLOT_REDIS_RETRY == {
+        "attempts": 5, "wait_initial": 1.0, "wait_max": 30, "wait_jitter": 3.0,
+    }
+
+
+@pytest.mark.asyncio
 async def test_reacquire_with_same_token_is_idempotent(fake_redis):
     """A lost reply on the acquire that took the last slot must not refuse the
     caller that already owns that slot. The Lua checks ZSCORE for the token

--- a/app/services/tests/test_lotek_connections.py
+++ b/app/services/tests/test_lotek_connections.py
@@ -79,3 +79,18 @@ def test_connection_key_is_stable_and_username_scoped():
     assert connection_key("a") == connection_key("a")
     assert connection_key("a") != connection_key("b")
     assert connection_key("a").startswith("lotek:connections:")
+
+
+@pytest.mark.asyncio
+async def test_close_connection_client_closes_and_resets(monkeypatch):
+    # The FastAPI lifespan closes every other module-level client; without this
+    # the pooled connections are reclaimed by __del__ after the loop is gone,
+    # logging "Event loop is closed" per connection on each restart.
+    from app.services.lotek_connections import close_connection_client
+
+    client = AsyncMock()
+    monkeypatch.setattr(lc, "_shared_client", client)
+    await close_connection_client()
+    client.aclose.assert_awaited_once()
+    assert lc._shared_client is None
+    await close_connection_client()  # idempotent: no client, no error

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -263,9 +263,10 @@ async def test_increment_counter_is_atomic_and_expires(mocker, mock_redis, integ
 
 @pytest.mark.asyncio
 async def test_increment_counter_expire_retry_does_not_reincrement(mocker, integration_v2, monkeypatch):
-    """INCR and EXPIRE must be retried as two separate attempt loops: retrying
-    them as one block means a RedisError on EXPIRE re-runs INCR too, silently
-    over-counting the streak (review finding M3)."""
+    """EXPIRE keeps its own retry loop, isolated from INCR (which is not
+    retried at all — see test_increment_counter_incr_is_never_retried):
+    retrying INCR+EXPIRE as one block means a RedisError on EXPIRE re-runs
+    INCR too, silently over-counting the streak (review finding M3)."""
     import stamina
     from redis.exceptions import RedisError
 
@@ -300,6 +301,30 @@ async def test_increment_counter_expire_retry_does_not_reincrement(mocker, integ
     assert state_manager.db_client.incr.await_count == 1
     assert state_manager.db_client.expire.await_count == 2
 
+
+@pytest.mark.asyncio
+async def test_increment_counter_incr_is_never_retried(mocker, integration_v2):
+    """INCR is a non-idempotent write: retrying it risks double-counting a
+    streak on a lost reply (the server applied it, the client never saw the
+    reply), and if every retry attempt fails that way EXPIRE is never reached,
+    leaving an inflated key with no TTL (review finding). A single unretried
+    INCR call accepts an occasional missed increment instead — the caller
+    already treats any failure as a safe default."""
+    from redis.exceptions import RedisError
+
+    state_manager = IntegrationStateManager()
+    state_manager.db_client = mocker.MagicMock()
+    state_manager.db_client.incr = mocker.AsyncMock(side_effect=RedisError("blip"))
+    state_manager.db_client.expire = mocker.AsyncMock(return_value=True)
+    integration_id = str(integration_v2.id)
+
+    with pytest.raises(RedisError):
+        await state_manager.increment_counter(
+            integration_id, "pull_observations", source_id="slot_skip_streak", ttl_seconds=3600
+        )
+
+    assert state_manager.db_client.incr.await_count == 1
+    state_manager.db_client.expire.assert_not_awaited()
 
 @pytest.mark.asyncio
 async def test_increment_counter_self_heals_a_legacy_json_value(mocker, integration_v2):
@@ -341,9 +366,9 @@ async def test_increment_counter_reraises_unrelated_response_error(mocker, integ
     import stamina
     from redis.exceptions import ResponseError
 
-    # ResponseError IS a RedisError, so it exhausts the real retry loop. Zero
-    # the waits or this single test costs ~22s of genuine backoff (same
-    # pattern as test_increment_counter_expire_retry_does_not_reincrement).
+    # INCR is not retried at all (see test_increment_counter_incr_is_never_
+    # retried), so this no longer needs the retry loop zeroed to run fast —
+    # kept anyway in case EXPIRE's own loop is ever reached on this path.
     real_retry_context = stamina.retry_context
 
     def fast_retry_context(*args, **kwargs):

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -299,3 +299,74 @@ async def test_increment_counter_expire_retry_does_not_reincrement(mocker, integ
     # EXPIRE's own retry must not re-run INCR.
     assert state_manager.db_client.incr.await_count == 1
     assert state_manager.db_client.expire.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_increment_counter_self_heals_a_legacy_json_value(mocker, integration_v2):
+    """Before this counter existed, _bump_dispatcher_skip_streak stored the
+    same key as a JSON blob via set_state (e.g. {"streak": 2}), with no TTL —
+    so that key is permanent, and post-deploy INCR against it always raises
+    "value is not an integer or out of range" (review finding: this made
+    DISPATCHER_SKIP_WARN_AFTER permanently unreachable for any integration
+    carrying one). The first INCR to hit a legacy value must self-heal: drop
+    the stale value and increment once more so the call still returns 1."""
+    from redis.exceptions import ResponseError
+
+    state_manager = IntegrationStateManager()
+    state_manager.db_client = mocker.MagicMock()
+    state_manager.db_client.incr = mocker.AsyncMock(
+        side_effect=[ResponseError("value is not an integer or out of range"), 1]
+    )
+    state_manager.db_client.delete = mocker.AsyncMock(return_value=1)
+    state_manager.db_client.expire = mocker.AsyncMock(return_value=True)
+    integration_id = str(integration_v2.id)
+    key = f"integration_state.{integration_id}.pull_observations.slot_skip_streak"
+
+    value = await state_manager.increment_counter(
+        integration_id, "pull_observations", source_id="slot_skip_streak", ttl_seconds=3600
+    )
+
+    assert value == 1
+    state_manager.db_client.delete.assert_awaited_once_with(key)
+    assert state_manager.db_client.incr.await_count == 2
+    state_manager.db_client.expire.assert_awaited_once_with(key, 3600)
+
+
+@pytest.mark.asyncio
+async def test_increment_counter_reraises_unrelated_response_error(mocker, integration_v2, monkeypatch):
+    """Catching ResponseError must not swallow a genuine server-side problem
+    that happens to share the exception class — only the specific
+    not-an-integer message identifies a legacy value; anything else must
+    surface untouched rather than be silently treated as a migration."""
+    import stamina
+    from redis.exceptions import ResponseError
+
+    # ResponseError IS a RedisError, so it exhausts the real retry loop. Zero
+    # the waits or this single test costs ~22s of genuine backoff (same
+    # pattern as test_increment_counter_expire_retry_does_not_reincrement).
+    real_retry_context = stamina.retry_context
+
+    def fast_retry_context(*args, **kwargs):
+        kwargs["wait_initial"] = 0
+        kwargs["wait_max"] = 0
+        kwargs["wait_jitter"] = 0
+        return real_retry_context(*args, **kwargs)
+
+    monkeypatch.setattr(stamina, "retry_context", fast_retry_context)
+
+    state_manager = IntegrationStateManager()
+    state_manager.db_client = mocker.MagicMock()
+    state_manager.db_client.incr = mocker.AsyncMock(
+        side_effect=ResponseError("ERR some unrelated server problem")
+    )
+    state_manager.db_client.delete = mocker.AsyncMock()
+    state_manager.db_client.expire = mocker.AsyncMock(return_value=True)
+    integration_id = str(integration_v2.id)
+
+    with pytest.raises(ResponseError):
+        await state_manager.increment_counter(
+            integration_id, "pull_observations", source_id="slot_skip_streak", ttl_seconds=3600
+        )
+
+    state_manager.db_client.delete.assert_not_awaited()
+    state_manager.db_client.expire.assert_not_awaited()

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -235,3 +235,27 @@ async def test_delete_state_source_state(mocker, mock_redis, integration_v2, moc
     mock_redis.Redis.return_value.delete.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.{source_id}"
     )
+
+
+@pytest.mark.asyncio
+async def test_increment_counter_is_atomic_and_expires(mocker, mock_redis, integration_v2):
+    """Client-side get/int+1/set loses increments under concurrency — the same
+    reason merge_state_fields exists. INCR is atomic; EXPIRE stops abandoned
+    counters leaking keys."""
+    mocker.patch("app.services.state.redis", mock_redis)
+    mock_redis.Redis.return_value.incr.return_value = async_return(3)
+    mock_redis.Redis.return_value.expire.return_value = async_return(True)
+    state_manager = IntegrationStateManager()
+    integration_id = str(integration_v2.id)
+
+    value = await state_manager.increment_counter(
+        integration_id, "pull_observations", source_id="slot_skip_streak", ttl_seconds=3600
+    )
+
+    assert value == 3
+    mock_redis.Redis.return_value.incr.assert_called_once_with(
+        f"integration_state.{integration_id}.pull_observations.slot_skip_streak"
+    )
+    mock_redis.Redis.return_value.expire.assert_called_once_with(
+        f"integration_state.{integration_id}.pull_observations.slot_skip_streak", 3600
+    )

--- a/app/services/tests/test_state_manager.py
+++ b/app/services/tests/test_state_manager.py
@@ -259,3 +259,43 @@ async def test_increment_counter_is_atomic_and_expires(mocker, mock_redis, integ
     mock_redis.Redis.return_value.expire.assert_called_once_with(
         f"integration_state.{integration_id}.pull_observations.slot_skip_streak", 3600
     )
+
+
+@pytest.mark.asyncio
+async def test_increment_counter_expire_retry_does_not_reincrement(mocker, integration_v2, monkeypatch):
+    """INCR and EXPIRE must be retried as two separate attempt loops: retrying
+    them as one block means a RedisError on EXPIRE re-runs INCR too, silently
+    over-counting the streak (review finding M3)."""
+    import stamina
+    from redis.exceptions import RedisError
+
+    # Keep the (real) retry loop from sleeping between attempts; the `redis`
+    # name in app.services.state must stay the real module here (not a mock)
+    # so `on=redis.RedisError` in the retried block still matches a real
+    # RedisError instance.
+    real_retry_context = stamina.retry_context
+
+    def fast_retry_context(*args, **kwargs):
+        kwargs["wait_initial"] = 0
+        kwargs["wait_max"] = 0
+        kwargs["wait_jitter"] = 0
+        return real_retry_context(*args, **kwargs)
+
+    monkeypatch.setattr(stamina, "retry_context", fast_retry_context)
+
+    state_manager = IntegrationStateManager()
+    state_manager.db_client = mocker.MagicMock()
+    state_manager.db_client.incr = mocker.AsyncMock(return_value=5)
+    state_manager.db_client.expire = mocker.AsyncMock(
+        side_effect=[RedisError("blip"), True]
+    )
+    integration_id = str(integration_v2.id)
+
+    value = await state_manager.increment_counter(
+        integration_id, "pull_observations", source_id="slot_skip_streak", ttl_seconds=3600
+    )
+
+    assert value == 5
+    # EXPIRE's own retry must not re-run INCR.
+    assert state_manager.db_client.incr.await_count == 1
+    assert state_manager.db_client.expire.await_count == 2

--- a/app/settings/integration.py
+++ b/app/settings/integration.py
@@ -4,3 +4,10 @@ env = Env()
 env.read_env()
 
 OBSERVATIONS_BATCH_SIZE = env.int("OBSERVATIONS_BATCH_SIZE", default=200)
+
+# Per-account ceiling on simultaneous Lotek API requests, enforced in Redis
+# across all concurrently-running shard/backfill invocations (GUNDI-5620:
+# shards fan out via pubsub, so an in-process semaphore cannot bound them).
+# Sized to a handful of shards' worth of FETCH_CONCURRENCY without recreating
+# the pool exhaustion the shared-client fix removed.
+LOTEK_MAX_CONNECTIONS = env.int("LOTEK_MAX_CONNECTIONS", 20)

--- a/app/settings/integration.py
+++ b/app/settings/integration.py
@@ -5,9 +5,12 @@ env.read_env()
 
 OBSERVATIONS_BATCH_SIZE = env.int("OBSERVATIONS_BATCH_SIZE", default=200)
 
-# Per-account ceiling on simultaneous Lotek API requests, enforced in Redis
-# across all concurrently-running shard/backfill invocations (GUNDI-5620:
-# shards fan out via pubsub, so an in-process semaphore cannot bound them).
-# Sized to a handful of shards' worth of FETCH_CONCURRENCY without recreating
-# the pool exhaustion the shared-client fix removed.
+# THE account-wide ceiling on simultaneous Lotek requests, enforced in Redis
+# across all concurrently-running shard/backfill invocations (shards fan out via
+# pubsub, so an in-process semaphore cannot bound them). This is the ONLY
+# concurrency governor in the connector: SHARD_SIZE and FETCH_CONCURRENCY are
+# work-partitioning parameters that may oversubscribe it, because lotek_slot
+# queues on a saturated budget instead of refusing. Raise this to allow more
+# parallelism against one Lotek account; do not tune the partitioning constants
+# for that purpose.
 LOTEK_MAX_CONNECTIONS = env.int("LOTEK_MAX_CONNECTIONS", 20)

--- a/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
+++ b/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
@@ -594,12 +594,12 @@ class DeviceTraversal:
     stop_reason: Optional[str]  # None | "deadline" | "circuit breaker"
     budget_starved: bool      # at least one device lost the slot race
 
-    @property
-    def deferred_cleanly(self) -> bool:
-        """True when the tail was handed off or backed off deliberately, i.e. the
-        run's lack of progress is explained. Replaces the retriggered /
-        budget_starved / cap_reached boolean trio (review finding: one copy of
-        that trio had already drifted)."""
+    # NOTE: there is deliberately NO `deferred_cleanly` here. Whether a given
+    # stop counts as "cleanly deferred" is POLICY and the two callers disagree:
+    # the shard suppresses its zero-progress alert on a successful hand-off, a
+    # cap-reached deferral, or starvation, but NOT on a breaker stop; the
+    # backfill suppresses on starvation only. Hoisting it here would silently
+    # change both handlers' alerting. Each caller computes its own (spec D6).
 ```
 
 - `serviced_devices` cannot be counted by the traversal (only the caller knows whether a yielded result means success), so `run()` exposes `mark_failed(device_id)` for the caller to call inside the loop; `serviced_devices` is derived as `yielded - len(failed_devices)`.
@@ -708,7 +708,6 @@ async def test_slot_starvation_records_narrowly(integration):
     assert seen == [2, 3]                 # peers unaffected (spec D3)
     assert t.deferred_devices == ["1"]
     assert t.budget_starved is True
-    assert t.deferred_cleanly is True
     assert t.failed_devices == []         # starvation is not a device failure
 
 
@@ -720,15 +719,15 @@ async def test_guard_stop_defers_the_unreached_tail(integration):
     assert seen == [1, 2]                 # first chunk only
     assert t.stop_reason == "deadline"
     assert t.deferred_devices == ["3", "4"]
-    assert t.deferred_cleanly is True
 
 
 @pytest.mark.asyncio
-async def test_clean_completion_is_not_a_clean_deferral(integration):
+async def test_clean_completion_records_no_stop_and_no_starvation(integration):
     t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=2)
     _ = [item async for item, _ in t.run([1], key=str, process=_ok)]
     assert t.stop_reason is None
-    assert t.deferred_cleanly is False    # nothing was deferred at all
+    assert t.budget_starved is False
+    assert t.deferred_devices == []
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -816,13 +815,6 @@ class DeviceTraversal:
         # Only the caller knows whether a yielded result counts as success, so
         # it calls mark_failed() for the ones that don't.
         return self._yielded - len(self.failed_devices)
-
-    @property
-    def deferred_cleanly(self):
-        """True when the run's lack of progress is explained by a deliberate
-        hand-off or back-off. Replaces the retriggered/budget_starved/
-        cap_reached boolean trio, one copy of which had already drifted."""
-        return bool(self.stop_reason) or self.budget_starved
 
     def mark_failed(self, device_id):
         """Caller-side failure: the device produced a result, but the result
@@ -959,9 +951,19 @@ Replace the whole loop body in `action_pull_observations_shard` — from `guards
 Then replace the `zero_progress` computation with the traversal-backed form:
 
 ```python
+    # Suppression policy, preserved EXACTLY as it was before the traversal
+    # existed: a successful hand-off, a cap-reached deferral (which already
+    # alerted at ERROR inside _retrigger_shard), or slot starvation all explain
+    # the lack of progress. A BREAKER stop deliberately does not — a Lotek-wide
+    # outage must still raise the zero-progress ERROR that the cdip health
+    # metric counts.
+    deferred_cleanly = (
+        retrigger_outcome in (RETRIGGER_HANDED_OFF, RETRIGGER_CAP_REACHED)
+        or traversal.budget_starved
+    )
     zero_progress = (
         device_states and traversal.serviced_devices == 0
-        and observations_extracted == 0 and not traversal.deferred_cleanly
+        and observations_extracted == 0 and not deferred_cleanly
     )
 ```
 
@@ -970,7 +972,7 @@ Delete the now-unused `retriggered`, `budget_starved`, `cap_reached`, and `servi
 - [ ] **Step 7: Run the full suite**
 
 Run: `./venv/bin/python -m pytest app -q`
-Expected: PASS. Tests asserting the old cap-reached suppression now exercise `deferred_cleanly`; if one fails on the `cap_reached` path specifically, note that `_retrigger_shard` already emits its own ERROR on cap, and `stop_reason` being set makes `deferred_cleanly` true — same suppression, one fewer boolean.
+Expected: PASS, with **no change to which runs emit the zero-progress ERROR**. The local `deferred_cleanly` expression above is a like-for-like translation of the old `not retriggered and not budget_starved and not cap_reached` trio: `retrigger_outcome == RETRIGGER_HANDED_OFF` replaces `retriggered`, `RETRIGGER_CAP_REACHED` replaces `cap_reached`, and `traversal.budget_starved` replaces `budget_starved`. A breaker stop still alerts, exactly as before. If a test about breaker-stop alerting fails here, the translation is wrong — fix the expression, do not update the test.
 
 - [ ] **Step 8: Commit**
 
@@ -1076,9 +1078,12 @@ In `action_backfill_observations`, replace the loop (from `guards = RunGuards(ru
 Replace the zero-progress `raise` block with:
 
 ```python
+        # Backfill's suppression policy differs from the shard's and is
+        # preserved exactly: ONLY starvation explains a no-progress run here.
+        # Deadline and breaker stops must still alert.
         zero_progress = (
             gapped and traversal.serviced_devices == 0
-            and observations_extracted == 0 and not traversal.deferred_cleanly
+            and observations_extracted == 0 and not traversal.budget_starved
         )
         if zero_progress:
             # Same systemic-degradation contract as the head pass. Reported, NOT

--- a/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
+++ b/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
@@ -613,6 +613,8 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock
 
+from gundi_core.events import LogLevel
+
 from app.actions.traversal import DeviceTraversal
 from app.actions.client import LotekUnauthorizedException
 from app.services.lotek_connections import NoConnectionSlot
@@ -668,7 +670,7 @@ async def test_per_device_failure_is_isolated_and_logged(integration, mocker):
     assert seen == [1, 3]              # device 2 did not stop its peers
     assert t.failed_devices == ["2"]
     assert log.await_count == 1
-    assert log.await_args.kwargs["level"].value == "ERROR"
+    assert log.await_args.kwargs["level"] is LogLevel.ERROR
 
 
 @pytest.mark.asyncio
@@ -1014,7 +1016,8 @@ async def test_zero_progress_backfill_reports_instead_of_raising(
 
     assert result["zero_progress"] is True
     # ERROR activity event carries the health signal...
-    assert try_log.await_args.args[3].value == "ERROR"
+    from gundi_core.events import LogLevel
+    assert try_log.await_args.args[3] is LogLevel.ERROR
     # ...and the cascade stays broken, exactly as the raise used to guarantee.
     trigger.assert_not_awaited()
 ```
@@ -1335,15 +1338,15 @@ Add to `IntegrationStateManager` in `app/services/state.py`, following the retry
         added to close — and an untimed key leaks for anything abandoned
         mid-streak.
         """
-        key = self._get_key(integration_id, action_id, source_id)
+        # state.py has no key-builder helper — every method inlines this exact
+        # f-string. Match the neighbours rather than introducing one here.
+        key = f"integration_state.{integration_id}.{action_id}.{source_id}"
         for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
             with attempt:
                 value = await self.db_client.incr(key)
                 await self.db_client.expire(key, ttl_seconds)
         return int(value)
 ```
-
-If the private key builder is not named `_get_key`, use whatever the neighbouring methods use — match them exactly.
 
 Then replace `_bump_dispatcher_skip_streak` in `app/actions/handlers.py`:
 

--- a/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
+++ b/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
@@ -1142,7 +1142,13 @@ Expected: PASS. Any existing test using `pytest.raises(LotekException)` for back
 - [ ] **Step 5: Verify the consolidation actually shrank the file**
 
 Run: `wc -l app/actions/handlers.py`
-Expected: **≤ 1,240 lines** (from 1,443 — the spec's ≥200-line success criterion). If it is above that, the traversal seam leaked policy; re-read spec D6 and move it back into the handlers rather than adding traversal flags.
+Expected: **~1,350 lines**, and `action_backfill_observations` down from 274 to roughly 226.
+
+The spec's original "≤1,240" gate was based on a bad line-count proxy and has been corrected
+(see the amended Success criteria) — extraction relocates lines rather than deleting them,
+and this plan also adds code. **Do not cut behaviour, inline the traversal, or move policy
+into it to chase a number.** The binding check is Step 6 below: both duplication greps must
+return 0.
 
 - [ ] **Step 6: Commit**
 
@@ -1500,13 +1506,15 @@ Expected: **≥ 263 tests** (PR #20's count) — Tasks 1-10 add roughly 15 and r
 - [ ] **Step 3: Confirm the success criteria from the spec**
 
 ```bash
-wc -l app/actions/handlers.py                    # target: <= 1240 (was 1443)
+wc -l app/actions/handlers.py                    # expect ~1350 (was 1443); NOT a hard gate
 grep -c "^[A-Z_]* = " app/actions/handlers.py    # constants: expect <= 20 (was 22)
 grep -n "raise LotekException" app/actions/handlers.py   # expect: no zero-progress hit
 grep -rn "config_data" app/actions/handlers.py   # expect: no matches
 ```
 
-Expected: all four hold. The last two are the spec's criterion 4 — no `raise`-based leak surface left in the file.
+Expected: the last three hold. The line count is a diagnostic, not a gate — see the spec's
+amended Success criteria. The two `grep`s for `raise LotekException` and `config_data` are
+the spec's criterion 6: no `raise`-based leak surface left in the file.
 
 - [ ] **Step 4: Confirm the duplication is actually gone**
 

--- a/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
+++ b/docs/superpowers/plans/2026-08-20-lotek-consolidation.md
@@ -1,0 +1,1527 @@
+# Lotek Rail Consolidation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse the scaffolding left by PRs #14–#20 — one concurrency governor instead of three overlapping ones, one shared device traversal instead of two ~270-line copies — while fixing the composition bugs that layering produced.
+
+**Architecture:** Per the approved spec `docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md` (source of truth). `lotek_slot` becomes a bounded, deadline-aware wait so the Redis connection budget applies *backpressure* instead of *refusal*, making `LOTEK_MAX_CONNECTIONS` the only concurrency limit and demoting `FETCH_CONCURRENCY` / `SHARD_SIZE` to work-partitioning parameters. A new `DeviceTraversal` helper owns the chunked-loop mechanics shared by the head pass and the backfill; policy (re-trigger, deferral wording, zero-progress) stays in each handler.
+
+**Tech Stack:** Python 3.11, pydantic v1, httpx, stamina, redis.asyncio, pytest + pytest-asyncio + pytest-mock. Suite runs with `./venv/bin/python -m pytest app -q`.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md`
+
+## Global Constraints
+
+- **Branch from PR #20's head, not `main`.** `main` is six PRs behind. Base this work on `feat/GUNDI-5620-sharded-head-pass`; if PR #20 has merged by the time you start, rebase onto `main` and re-run the suite before Task 1.
+- TDD strictly: failing test first, then minimal implementation. For tests that pin a specific production line, flip-verify: change the line, watch the test fail, restore byte-identical.
+- Test suite must stay **< 2 s**. Patch `RETRY_WAIT_INITIAL` / `RETRY_WAIT_JITTER` / `RETRY_WAIT_MAX` and the new `SLOT_WAIT_*` constants to 0 in any test exercising retries or waiting. **Never `sleep`.**
+- **Behaviour-preserving except where the spec says otherwise.** The only intended behaviour changes are: slot waits (D2), starvation defers narrowly (D3), backfill zero-progress stops raising (D7), and the claim rolls back (D8). Observation output must be unchanged.
+- Health/alerting keys on ERROR-count only (cdip `calculate_integration_status`, ≥3 ERROR logs / 60 min → UNHEALTHY). ERROR = "someone can and should act". WARNING = transient per-device failures and deferrals. Do not add new ERROR paths.
+- `Optional[str]`, not `str | None` (pydantic v1 codebase style). All datetimes tz-aware UTC.
+- Code constants, NOT config fields, for anything added here.
+- Commit after every green task. One task = one commit.
+- Do **not** touch `app/services/config_manager.py` or `app/services/action_runner.py` — those gaps are tracked in GUNDI-5628.
+
+---
+
+### Task 1: Make the slot acquire idempotent
+
+Prerequisite for Task 3: waiting multiplies acquire attempts, which widens the lost-reply window this fixes.
+
+**Files:**
+- Modify: `app/services/lotek_connections.py` (the `_ACQUIRE_LUA` script, ~lines 24-36)
+- Test: `app/services/tests/test_lotek_connections.py`
+
+**Interfaces:**
+- Consumes: nothing (first task)
+- Produces: `_ACQUIRE_LUA` gains a `ZSCORE` membership fast-path. ARGV order is **unchanged**: `now, expiry, ceiling, token, key_ttl`. Existing tests index `args[-2]` for the token and must keep passing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `app/services/tests/test_lotek_connections.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_reacquire_with_same_token_is_idempotent(fake_redis):
+    """A lost reply on the acquire that took the last slot must not refuse the
+    caller that already owns that slot. The Lua checks ZSCORE for the token
+    before the ZCARD ceiling test, so a retry with the same token re-grants.
+
+    Simulated at the script level: the real guarantee lives in the Lua, so this
+    test pins that the script text contains the membership fast-path ahead of
+    the capacity check.
+    """
+    from app.services.lotek_connections import _ACQUIRE_LUA
+
+    zscore_at = _ACQUIRE_LUA.find("ZSCORE")
+    zcard_at = _ACQUIRE_LUA.find("ZCARD")
+    assert zscore_at != -1, "acquire must check token membership before capacity"
+    assert zscore_at < zcard_at, "membership fast-path must precede the ceiling test"
+    # The fast-path must re-arm the member's expiry rather than returning a
+    # stale score, so a waiting retry cannot inherit an about-to-expire slot.
+    assert "ZADD" in _ACQUIRE_LUA[zscore_at:zcard_at]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_lotek_connections.py::test_reacquire_with_same_token_is_idempotent -v`
+Expected: FAIL — `AssertionError: acquire must check token membership before capacity`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `_ACQUIRE_LUA` in `app/services/lotek_connections.py`:
+
+```python
+# Atomic acquire: purge expired slots, re-grant to an existing holder, then add
+# a new slot only if under the ceiling. KEYS[1]=zset key.
+# ARGV: now, expiry, ceiling, token, key_ttl.
+# Returns 1 if acquired (or already held), 0 if at capacity.
+#
+# The ZSCORE fast-path makes the script idempotent for a given token. Without
+# it, a lost reply on the acquire that filled the last slot made the stamina
+# retry refuse the very caller that owns the slot, stranding it for the full
+# TTL (review finding). Re-granting also refreshes the expiry so a retried
+# holder does not inherit an about-to-expire slot.
+#
+# The key itself gets a TTL on every path: members carry logical expiry in
+# their score but are only purged by a LATER acquire, so an account that stops
+# being used would leave its zset behind forever. The TTL comfortably outlives
+# the longest-lived member, so it can never expire a key with live holders.
+_ACQUIRE_LUA = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
+if redis.call('ZSCORE', KEYS[1], ARGV[4]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    return 1
+end
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    return 1
+end
+return 0
+"""
+```
+
+- [ ] **Step 4: Run the file's tests to verify all pass**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_lotek_connections.py -v`
+Expected: PASS — the new test plus all 7 pre-existing ones (the ARGV order is unchanged, so `args[-2]` still resolves to the token).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/lotek_connections.py app/services/tests/test_lotek_connections.py
+git commit -m "fix: make the Lotek slot acquire idempotent for a retried token"
+```
+
+---
+
+### Task 2: Adopt the codebase's shared Redis retry policy
+
+**Files:**
+- Modify: `app/services/lotek_connections.py` (the `stamina.retry_context` call, ~line 95)
+- Test: `app/services/tests/test_lotek_connections.py`
+
+**Interfaces:**
+- Consumes: Task 1's `_ACQUIRE_LUA`
+- Produces: module constant `SLOT_REDIS_RETRY = dict(attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)`, importable by tests to patch.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_slot_retry_policy_matches_state_manager(fake_redis):
+    """A Redis brownout that every IntegrationStateManager op survives must not
+    escape from the slot acquire as a fake per-device Lotek failure. The policy
+    here has to match state.py's, not undercut it.
+    """
+    from app.services.lotek_connections import SLOT_REDIS_RETRY
+
+    assert SLOT_REDIS_RETRY == {
+        "attempts": 5, "wait_initial": 1.0, "wait_max": 30, "wait_jitter": 3.0,
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_lotek_connections.py::test_slot_retry_policy_matches_state_manager -v`
+Expected: FAIL — `ImportError: cannot import name 'SLOT_REDIS_RETRY'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/services/lotek_connections.py`, add near the top after `logger`:
+
+```python
+# The uniform Redis retry policy used by every IntegrationStateManager and
+# config-manager op (app/services/state.py). Kept identical on purpose: the
+# slot acquire previously used attempts=3/wait_initial=0.1/wait_max=2.0, so a
+# multi-second Redis brownout that every get_state around it survived exhausted
+# this budget and escaped as RedisError into the generic per-device handler —
+# a fabricated Lotek failure caused by our own Redis (review finding).
+SLOT_REDIS_RETRY = dict(attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0)
+```
+
+Then replace the retry call inside `lotek_slot`:
+
+```python
+    async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
+```
+
+- [ ] **Step 4: Run the file's tests to verify all pass**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_lotek_connections.py -v`
+Expected: PASS (all tests; none of them exercise a RedisError retry path, so no timing change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/lotek_connections.py app/services/tests/test_lotek_connections.py
+git commit -m "fix: put the slot acquire on the shared Redis retry policy"
+```
+
+---
+
+### Task 3: Make the slot wait for capacity instead of refusing
+
+This is the fix for the PR #20 review's top finding. Read spec section **D2** before starting.
+
+**Files:**
+- Modify: `app/services/lotek_connections.py` (`lotek_slot`, ~lines 68-119)
+- Modify: `app/actions/handlers.py` (the `lotek_slot` call in `_fetch_window` ~line 929, and in `action_backfill_observations`' device listing ~line 1225)
+- Test: `app/services/tests/test_lotek_connections.py`
+
+**Interfaces:**
+- Consumes: `SLOT_REDIS_RETRY` (Task 2), idempotent `_ACQUIRE_LUA` (Task 1)
+- Produces:
+  - `lotek_slot(username, *, ttl_seconds=300, max_wait_seconds=0.0)` — async context manager. When `max_wait_seconds > 0`, polls the acquire until a slot frees or the budget elapses, then raises `NoConnectionSlot`. `max_wait_seconds=0.0` preserves today's fail-fast behaviour (used by callers with no deadline to reason about).
+  - Module constants `SLOT_WAIT_POLL_INITIAL = 0.25`, `SLOT_WAIT_POLL_MAX = 2.0`, `SLOT_WAIT_JITTER = 0.25`.
+  - `handlers.py` gains `def _slot_wait_budget(run_started_at) -> float`, returning the seconds left before the run deadline, floored at 0.0.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_slot_waits_then_acquires_when_capacity_frees(fake_redis, monkeypatch):
+    """Oversubscription must queue, not refuse: with shards x FETCH_CONCURRENCY
+    well above the ceiling, a caller that waits a moment gets a slot instead of
+    deferring its whole tail (spec D2)."""
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_INITIAL", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_MAX", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_JITTER", 0)
+    # Refused twice (account saturated), then a peer releases.
+    fake_redis.eval = AsyncMock(side_effect=[0, 0, 1])
+
+    async with lotek_slot("user@example.com", max_wait_seconds=5.0):
+        pass
+
+    assert fake_redis.eval.await_count == 3
+    fake_redis.zrem.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slot_gives_up_when_wait_budget_exhausted(fake_redis, monkeypatch):
+    """Waiting must never eat the caller's action deadline: once the budget is
+    spent the slot raises, and the caller defers as before."""
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_INITIAL", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_POLL_MAX", 0)
+    monkeypatch.setattr(lc, "SLOT_WAIT_JITTER", 0)
+    fake_redis.eval = AsyncMock(return_value=0)
+
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com", max_wait_seconds=0.05):
+            pytest.fail("body must not run when the account stays saturated")
+
+    assert fake_redis.eval.await_count >= 1
+    fake_redis.zrem.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_slot_without_wait_budget_still_fails_fast(fake_redis):
+    """Default stays fail-fast for callers with no deadline to reason about."""
+    fake_redis.eval = AsyncMock(return_value=0)
+    with pytest.raises(NoConnectionSlot):
+        async with lotek_slot("user@example.com"):
+            pytest.fail("body must not run")
+    assert fake_redis.eval.await_count == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_lotek_connections.py -k "wait" -v`
+Expected: FAIL — `TypeError: lotek_slot() got an unexpected keyword argument 'max_wait_seconds'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/services/lotek_connections.py`, add the constants next to `SLOT_REDIS_RETRY`:
+
+```python
+# Backpressure poll schedule for a saturated account budget. Jittered so that
+# N shards refused in the same millisecond do not retry in lockstep.
+SLOT_WAIT_POLL_INITIAL = 0.25
+SLOT_WAIT_POLL_MAX = 2.0
+SLOT_WAIT_JITTER = 0.25
+```
+
+Add `import asyncio` and `import random` to the imports. Replace the acquire section of `lotek_slot` (everything from `client = _client()` down to and including the `if not acquired: raise ...`) with:
+
+```python
+    client = _client()
+    key = connection_key(username)
+    # One token for the whole acquire, including every wait poll: the Lua's
+    # ZSCORE fast-path re-grants an already-held slot, so re-using the token is
+    # what makes a lost reply safe (Task 1).
+    token = str(uuid.uuid4())
+    deadline = time.monotonic() + max(0.0, max_wait_seconds)
+    backoff = SLOT_WAIT_POLL_INITIAL
+    acquired = 0
+    while True:
+        async for attempt in stamina.retry_context(on=redis.RedisError, **SLOT_REDIS_RETRY):
+            with attempt:
+                now = time.time()
+                acquired = await client.eval(
+                    _ACQUIRE_LUA, 1, key, now, now + ttl_seconds,
+                    settings.LOTEK_MAX_CONNECTIONS, token, ttl_seconds * 2,
+                )
+        if acquired:
+            break
+        # Saturated. Wait for a peer to release rather than aborting the
+        # caller's whole tail (spec D2/D3) — but never past the budget the
+        # caller can afford to spend.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise NoConnectionSlot(
+                f"No Lotek connection slot available within "
+                f"{max_wait_seconds:.1f}s (limit {settings.LOTEK_MAX_CONNECTIONS})."
+            )
+        pause = min(backoff + random.uniform(0, SLOT_WAIT_JITTER), remaining)
+        if pause > 0:
+            await asyncio.sleep(pause)
+        backoff = min(backoff * 2 or SLOT_WAIT_POLL_INITIAL, SLOT_WAIT_POLL_MAX)
+```
+
+Update the docstring's first paragraph to describe waiting:
+
+```python
+    """Acquire one Lotek connection slot for `username`, shared across every
+    shard/backfill invocation on the same Redis.
+
+    With `max_wait_seconds > 0` a saturated budget makes the caller QUEUE
+    (jittered poll) rather than fail: fan-out deliberately oversubscribes the
+    ceiling, so refusing on first contention aborted whole shards and turned
+    ordinary large-fleet ticks into zero-progress churn (spec D2). The wait is
+    capped by the caller's remaining action budget, so queueing can never cause
+    a timeout that failing fast would have avoided. NoConnectionSlot now means
+    "saturated for longer than I can afford to wait".
+    """
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_lotek_connections.py -v`
+Expected: PASS (all, including the three new ones).
+
+- [ ] **Step 5: Pass the deadline in from both call sites**
+
+In `app/actions/handlers.py`, add next to `_deadline_exceeded`:
+
+```python
+def _slot_wait_budget(run_started_at):
+    """Seconds this run can still afford to spend queueing for a connection
+    slot. Mirrors _deadline_exceeded's fraction so waiting stops exactly when
+    the traversal would have stopped anyway."""
+    elapsed = (datetime.now(tz=timezone.utc) - run_started_at).total_seconds()
+    return max(0.0, DEADLINE_FRACTION * app_settings.MAX_ACTION_EXECUTION_TIME - elapsed)
+```
+
+In `_fetch_window`, change the slot acquire to pass the budget:
+
+```python
+                async with lotek_slot(
+                    auth.username,
+                    max_wait_seconds=_slot_wait_budget(guards.run_started_at),
+                ):
+                    positions = await client.get_positions(device_id, auth, integration, lower_date, upper_date, True)
+```
+
+In `action_backfill_observations`' device-listing block, do the same:
+
+```python
+                    async with lotek_slot(
+                        auth.username, max_wait_seconds=_slot_wait_budget(run_started)
+                    ):
+                        device_list = await client.get_devices(integration, auth)
+```
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS. If any existing test asserted immediate `NoConnectionSlot` from a handler path, it now needs `max_wait_seconds` patched to 0 or the `lotek_slot` mock unchanged — fix by patching `lc.SLOT_WAIT_POLL_INITIAL`/`_MAX`/`SLOT_WAIT_JITTER` to 0, never by adding a sleep.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/lotek_connections.py app/services/tests/test_lotek_connections.py app/actions/handlers.py
+git commit -m "fix: make the connection budget apply backpressure instead of refusing"
+```
+
+---
+
+### Task 4: Defer only the devices that actually starved
+
+**Files:**
+- Modify: `app/actions/handlers.py` (shard starvation block ~lines 696-717; backfill starvation block ~lines 1337-1350)
+- Test: `app/actions/tests/test_sharding.py`
+
+**Interfaces:**
+- Consumes: `lotek_slot` waiting behaviour (Task 3)
+- Produces: no new symbols. Both starvation blocks stop appending the un-processed tail; the loop `continue`s instead of `break`ing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `app/actions/tests/test_sharding.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_starved_device_does_not_abort_the_whole_shard(
+    mocker, mock_gundi_client_v2, mock_state_manager, lotek_devices_response
+):
+    """One device losing the slot race must defer THAT device, not the shard's
+    entire remaining tail (spec D3). Its in-chunk peers keep their results and
+    the loop carries on to later chunks."""
+    from app.actions.handlers import action_pull_observations_shard
+    from app.actions.configurations import PullObservationsShardConfig
+    from app.services.lotek_connections import NoConnectionSlot
+
+    devices = [f"dev{i}" for i in range(10)]
+    calls = []
+
+    async def fake_head_pass(device_id, *args, **kwargs):
+        calls.append(device_id)
+        if device_id == "dev0":
+            raise NoConnectionSlot("saturated")
+        return (5, False, False)
+
+    mocker.patch("app.actions.handlers._head_pass_device", side_effect=fake_head_pass)
+    mocker.patch("app.actions.handlers._retrigger_shard", return_value="handed_off")
+
+    result = await action_pull_observations_shard(
+        mock_gundi_client_v2.get_integration_details.return_value,
+        PullObservationsShardConfig(devices=devices),
+    )
+
+    # Every device was attempted, not just the first chunk.
+    assert len(calls) == 10
+    # Only the starved one is deferred.
+    assert result["devices_deferred"] == ["dev0"]
+    # The other nine still delivered.
+    assert result["observations_extracted"] == 45
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_sharding.py::test_starved_device_does_not_abort_the_whole_shard -v`
+Expected: FAIL — `assert len(calls) == 10` gets 5 (the shard broke after the first chunk), and `devices_deferred` contains the whole tail.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `action_pull_observations_shard`, replace the `if slot_starved:` block with:
+
+```python
+        if slot_starved:
+            # Defer ONLY the devices that lost the slot race — their in-chunk
+            # peers keep their results and later chunks still run (spec D3).
+            # Before this, one starved device aborted the shard's entire tail,
+            # which on an oversubscribed fan-out made mass deferral the normal
+            # outcome rather than an exceptional one (review finding).
+            deferred_devices.extend(slot_starved)
+            budget_starved = True
+```
+
+Apply the same change in `action_backfill_observations`:
+
+```python
+            if slot_starved:
+                # Defer only the starved devices (spec D3); see the head pass.
+                deferred_devices.extend(slot_starved)
+                budget_starved = True
+```
+
+Then move the deferral *log* out of the loop, so a run reports its starvation once. Immediately after the `for chunk_start in ...` loop ends in each handler, add:
+
+```python
+    if budget_starved:
+        await _log_deferral(
+            integration, "pull_observations_shard", "connection budget exhausted",
+            deferred_devices, disposition="to the next scheduled run",
+        )
+```
+
+(For the backfill use `action_id="backfill_observations"` and `disposition="to the next backfill trigger"`.)
+
+Note: `deferred_devices` must be initialised to `[]` before the loop in both handlers — it already is.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_sharding.py app/actions/tests/test_backfill.py -v`
+Expected: PASS. Existing tests that asserted a starved shard re-triggered its tail will now fail — that is the intended behaviour change; update them to assert narrow deferral and delete the re-trigger assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_sharding.py app/actions/tests/test_backfill.py
+git commit -m "fix: defer only slot-starved devices instead of the whole tail"
+```
+
+---
+
+### Task 5: Document and pin the single-governor model
+
+**Files:**
+- Modify: `app/actions/handlers.py` (constants block ~lines 41-90)
+- Modify: `app/settings/integration.py` (the `LOTEK_MAX_CONNECTIONS` comment)
+- Test: `app/actions/tests/test_sharding.py`
+
+**Interfaces:**
+- Consumes: Tasks 3-4
+- Produces: no new symbols — comments plus one regression test.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_partitioning_constants_may_oversubscribe_the_budget():
+    """Guards the spec-D1 contract: SHARD_SIZE and FETCH_CONCURRENCY are
+    work-partitioning parameters, NOT concurrency limits, so they are ALLOWED
+    to exceed the account budget — the budget applies backpressure (Task 3).
+
+    This test exists so nobody 'fixes' the arithmetic by shrinking the
+    partitioning constants: that would reintroduce the coupling spec D1
+    removed. If you need to bound concurrency, change LOTEK_MAX_CONNECTIONS.
+    """
+    from app.actions.handlers import FETCH_CONCURRENCY, SHARD_SIZE
+    from app.services.lotek_connections import lotek_slot
+    import inspect
+
+    assert FETCH_CONCURRENCY > 0 and SHARD_SIZE > 0
+    # The budget must be a WAITING primitive for oversubscription to be safe.
+    assert "max_wait_seconds" in inspect.signature(lotek_slot).parameters
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_sharding.py::test_partitioning_constants_may_oversubscribe_the_budget -v`
+Expected: PASS if Task 3 landed. **If it passes immediately, that is correct** — this is a regression guard, not a red-green cycle. Confirm it is meaningful by flip-verifying: temporarily rename `max_wait_seconds`, watch it fail, restore.
+
+- [ ] **Step 3: Write the documentation**
+
+In `app/actions/handlers.py`, replace the comments above `FETCH_CONCURRENCY` and `SHARD_SIZE`:
+
+```python
+# How many devices one invocation processes per chunk. WORK PARTITIONING, not a
+# concurrency limit: the account-wide ceiling is LOTEK_MAX_CONNECTIONS, enforced
+# in Redis by lotek_slot, which now WAITS rather than refusing. Chunk size may
+# freely oversubscribe that ceiling — the budget applies backpressure (spec D1).
+FETCH_CONCURRENCY = 5
+```
+
+```python
+# How much work fits in one action budget, i.e. how the dispatcher partitions
+# the fleet across sub-actions. WORK PARTITIONING, not a concurrency limit —
+# see FETCH_CONCURRENCY. Do not shrink this to "fit" LOTEK_MAX_CONNECTIONS;
+# that reintroduces the coupling spec D1 removed.
+SHARD_SIZE = 25
+```
+
+In `app/settings/integration.py`, replace the `LOTEK_MAX_CONNECTIONS` comment:
+
+```python
+# THE account-wide ceiling on simultaneous Lotek requests, enforced in Redis
+# across all concurrently-running shard/backfill invocations (shards fan out via
+# pubsub, so an in-process semaphore cannot bound them). This is the ONLY
+# concurrency governor in the connector: SHARD_SIZE and FETCH_CONCURRENCY are
+# work-partitioning parameters that may oversubscribe it, because lotek_slot
+# queues on a saturated budget instead of refusing. Raise this to allow more
+# parallelism against one Lotek account; do not tune the partitioning constants
+# for that purpose.
+LOTEK_MAX_CONNECTIONS = env.int("LOTEK_MAX_CONNECTIONS", 20)
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/settings/integration.py app/actions/tests/test_sharding.py
+git commit -m "docs: name the single concurrency governor and pin the contract"
+```
+
+---
+
+### Task 6: Extract `DeviceTraversal` and convert the head pass to it
+
+The core consolidation. Read spec section **D6** before starting — the seam (mechanics in the traversal, policy in the caller) is the whole point, and blurring it produces a worse file than the duplication did.
+
+**Files:**
+- Create: `app/actions/traversal.py`
+- Modify: `app/actions/core.py` (gains `describe_exception`, moved in Step 3)
+- Modify: `app/actions/handlers.py` (`action_pull_observations_shard`, ~lines 601-717; `describe_exception` moves out)
+- Test: `app/actions/tests/test_traversal.py`
+
+**Interfaces:**
+- Consumes: `RunGuards` and `_log_deferral` from `handlers.py`. To avoid a circular import, `DeviceTraversal` takes the already-built `guards` object and does **no** logging of deferrals itself — it only records what happened.
+- Produces:
+
+```python
+class DeviceTraversal:
+    """Shared chunked-device-loop mechanics for the head pass and the backfill.
+
+    Owns: chunking, gather-with-return_exceptions, fatal re-raise, per-device
+    failure logging, slot-starvation collection, guard-stop detection.
+    Does NOT own: re-trigger decisions, deferral wording, zero-progress policy.
+    """
+    def __init__(self, integration, action_id, guards, *, concurrency): ...
+
+    async def run(self, work, key, process):
+        """Async-iterates (item, value) for every device that produced a result.
+        `key(item) -> device_id` (logging/deferral ids), `process(item) -> awaitable`."""
+
+    # Populated during/after run():
+    failed_devices: list      # per-device failures, already logged at ERROR
+    deferred_devices: list    # starved devices + un-reached tail on a guard stop
+    serviced_devices: int     # results yielded that the caller did not mark failed
+    stop_reason: Optional[str]  # None | "deadline" | "circuit breaker"
+    budget_starved: bool      # at least one device lost the slot race
+
+    @property
+    def deferred_cleanly(self) -> bool:
+        """True when the tail was handed off or backed off deliberately, i.e. the
+        run's lack of progress is explained. Replaces the retriggered /
+        budget_starved / cap_reached boolean trio (review finding: one copy of
+        that trio had already drifted)."""
+```
+
+- `serviced_devices` cannot be counted by the traversal (only the caller knows whether a yielded result means success), so `run()` exposes `mark_failed(device_id)` for the caller to call inside the loop; `serviced_devices` is derived as `yielded - len(failed_devices)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/actions/tests/test_traversal.py`:
+
+```python
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from app.actions.traversal import DeviceTraversal
+from app.actions.client import LotekUnauthorizedException
+from app.services.lotek_connections import NoConnectionSlot
+
+
+class FakeGuards:
+    """RunGuards stand-in: stops when told, records transport failures."""
+    def __init__(self, stop_after=None):
+        self.stop_after = stop_after
+        self.calls = 0
+        self.recorded = []
+    def should_stop(self):
+        self.calls += 1
+        if self.stop_after is not None and self.calls > self.stop_after:
+            return "deadline"
+        return None
+    def record(self, transport_failure):
+        self.recorded.append(transport_failure)
+
+
+@pytest.fixture
+def integration(mocker):
+    return mocker.Mock(id="11111111-1111-1111-1111-111111111111")
+
+
+@pytest.mark.asyncio
+async def test_yields_every_successful_result(integration):
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=2)
+    seen = []
+    async for item, value in t.run([1, 2, 3], key=str, process=lambda i: _ok(i)):
+        seen.append((item, value))
+    assert seen == [(1, "r1"), (2, "r2"), (3, "r3")]
+    assert t.failed_devices == []
+    assert t.serviced_devices == 3
+
+
+async def _ok(i):
+    return f"r{i}"
+
+
+@pytest.mark.asyncio
+async def test_per_device_failure_is_isolated_and_logged(integration, mocker):
+    log = mocker.patch("app.actions.traversal.log_action_activity", new=AsyncMock())
+
+    async def process(i):
+        if i == 2:
+            raise ValueError("boom")
+        return f"r{i}"
+
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=3)
+    seen = [item async for item, _ in t.run([1, 2, 3], key=str, process=process)]
+
+    assert seen == [1, 3]              # device 2 did not stop its peers
+    assert t.failed_devices == ["2"]
+    assert log.await_count == 1
+    assert log.await_args.kwargs["level"].value == "ERROR"
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_propagates(integration):
+    async def process(i):
+        raise LotekUnauthorizedException("refused")
+
+    t = DeviceTraversal(integration, "act", FakeGuards())
+    with pytest.raises(LotekUnauthorizedException):
+        async for _ in t.run([1], key=str, process=process):
+            pytest.fail("must not yield")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates(integration):
+    async def process(i):
+        raise asyncio.CancelledError()
+
+    t = DeviceTraversal(integration, "act", FakeGuards())
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in t.run([1], key=str, process=process):
+            pytest.fail("must not yield")
+
+
+@pytest.mark.asyncio
+async def test_slot_starvation_records_narrowly(integration):
+    async def process(i):
+        if i == 1:
+            raise NoConnectionSlot("saturated")
+        return f"r{i}"
+
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=3)
+    seen = [item async for item, _ in t.run([1, 2, 3], key=str, process=process)]
+
+    assert seen == [2, 3]                 # peers unaffected (spec D3)
+    assert t.deferred_devices == ["1"]
+    assert t.budget_starved is True
+    assert t.deferred_cleanly is True
+    assert t.failed_devices == []         # starvation is not a device failure
+
+
+@pytest.mark.asyncio
+async def test_guard_stop_defers_the_unreached_tail(integration):
+    t = DeviceTraversal(integration, "act", FakeGuards(stop_after=1), concurrency=2)
+    seen = [item async for item, _ in t.run([1, 2, 3, 4], key=str, process=_ok)]
+
+    assert seen == [1, 2]                 # first chunk only
+    assert t.stop_reason == "deadline"
+    assert t.deferred_devices == ["3", "4"]
+    assert t.deferred_cleanly is True
+
+
+@pytest.mark.asyncio
+async def test_clean_completion_is_not_a_clean_deferral(integration):
+    t = DeviceTraversal(integration, "act", FakeGuards(), concurrency=2)
+    _ = [item async for item, _ in t.run([1], key=str, process=_ok)]
+    assert t.stop_reason is None
+    assert t.deferred_cleanly is False    # nothing was deferred at all
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_traversal.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.actions.traversal'`
+
+- [ ] **Step 3: Move `describe_exception` to the shared module**
+
+`traversal.py` needs it too, and copying it would duplicate a helper in the very
+PR that exists to remove duplication — with a subtle behaviour change, since the
+naive `f"{type(exc).__name__}: {exc}"` form loses the empty-message handling that
+comment in `handlers.py` exists to explain.
+
+`app/actions/core.py` is the right home: `handlers.py` already imports from it,
+and `core.py` only imports `app.services.utils` at module scope (its one
+`handlers` reference is a lazy `importlib` call inside `discover_actions`), so
+there is no circular import.
+
+Cut this function out of `app/actions/handlers.py` and paste it into
+`app/actions/core.py`, byte-identical:
+
+```python
+def describe_exception(exc):
+    # httpx timeout exceptions carry an empty message, which used to render as a bare
+    # "Exception: " in the activity log and told operators nothing.
+    return str(exc) or type(exc).__name__
+```
+
+Then add it to `handlers.py`'s existing import from that module:
+
+```python
+from app.actions.core import describe_exception
+```
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS — a pure move, no behaviour change.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `app/actions/traversal.py`:
+
+```python
+import asyncio
+import logging
+from typing import Optional
+
+from gundi_core.events import LogLevel
+
+from app.actions.client import LotekUnauthorizedException
+from app.actions.core import describe_exception
+from app.services.activity_logger import log_action_activity
+from app.services.lotek_connections import NoConnectionSlot
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceTraversal:
+    """Shared chunked-device-loop mechanics for the head pass and the backfill.
+
+    Owns: chunking, gather-with-return_exceptions, fatal re-raise, per-device
+    failure logging, slot-starvation collection, guard-stop detection, and the
+    deferred-tail computation.
+
+    Deliberately does NOT own: whether to re-trigger, what the deferral message
+    says, or what zero progress means. Those differ between the head pass and
+    the backfill and stay in the handlers (spec D6). Keeping policy out is what
+    makes one traversal serve both without a flag soup.
+    """
+
+    def __init__(self, integration, action_id, guards, *, concurrency):
+        self.integration = integration
+        self.integration_id = str(integration.id)
+        self.action_id = action_id
+        self.guards = guards
+        self.concurrency = concurrency
+        self.failed_devices = []
+        self.deferred_devices = []
+        self.stop_reason: Optional[str] = None
+        self.budget_starved = False
+        self._yielded = 0
+
+    @property
+    def serviced_devices(self):
+        # Only the caller knows whether a yielded result counts as success, so
+        # it calls mark_failed() for the ones that don't.
+        return self._yielded - len(self.failed_devices)
+
+    @property
+    def deferred_cleanly(self):
+        """True when the run's lack of progress is explained by a deliberate
+        hand-off or back-off. Replaces the retriggered/budget_starved/
+        cap_reached boolean trio, one copy of which had already drifted."""
+        return bool(self.stop_reason) or self.budget_starved
+
+    def mark_failed(self, device_id):
+        """Caller-side failure: the device produced a result, but the result
+        says it failed (e.g. delivery rejected)."""
+        self.failed_devices.append(device_id)
+
+    async def run(self, work, key, process):
+        work = list(work)
+        for chunk_start in range(0, len(work), self.concurrency):
+            if reason := self.guards.should_stop():
+                self.stop_reason = reason
+                self.deferred_devices.extend(key(item) for item in work[chunk_start:])
+                return
+            chunk = work[chunk_start:chunk_start + self.concurrency]
+            results = await asyncio.gather(
+                *(process(item) for item in chunk),
+                # Collect every task's outcome rather than aborting the chunk on
+                # the first exception: per-device failures must stay per-device.
+                return_exceptions=True,
+            )
+            # Credentials refused is integration-wide and fatal; re-raise it over
+            # any per-device outcomes in the same chunk. Cancellation must also
+            # propagate: with return_exceptions=True a task's CancelledError
+            # comes back as a result, and treating it as a device failure would
+            # swallow shutdown/timeout cancellation and keep the run going.
+            for res in results:
+                if isinstance(res, (LotekUnauthorizedException, asyncio.CancelledError)):
+                    raise res
+            for item, res in zip(chunk, results):
+                device_id = key(item)
+                if isinstance(res, NoConnectionSlot):
+                    # Account budget saturated for longer than this run can wait:
+                    # not a device failure and not evidence about Lotek. Defer
+                    # THIS device only; peers and later chunks continue (D3).
+                    self.deferred_devices.append(device_id)
+                    self.budget_starved = True
+                    continue
+                if isinstance(res, BaseException):
+                    message = (
+                        f"Failed to process device {device_id} for integration "
+                        f"{self.integration.id}: {describe_exception(res)}"
+                    )
+                    logger.error(message, exc_info=res)
+                    await log_action_activity(
+                        integration_id=self.integration_id,
+                        action_id=self.action_id,
+                        title=message,
+                        level=LogLevel.ERROR,
+                    )
+                    self.failed_devices.append(device_id)
+                    self.guards.record(transport_failure=False)
+                    continue
+                self._yielded += 1
+                yield item, res
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_traversal.py -v`
+Expected: PASS (all 7)
+
+- [ ] **Step 6: Convert the head pass to use it**
+
+In `app/actions/handlers.py`, add the import:
+
+```python
+from app.actions.traversal import DeviceTraversal
+```
+
+Replace the whole loop body in `action_pull_observations_shard` — from `guards = RunGuards(run_started)` through the end of the `for chunk_start in ...` loop — with:
+
+```python
+    guards = RunGuards(run_started)
+    traversal = DeviceTraversal(
+        integration, "pull_observations_shard", guards, concurrency=FETCH_CONCURRENCY
+    )
+    observations_extracted = 0
+    stale_drops = []
+    # Only reflects devices actually processed this run — a device deferred by
+    # the rails before its gap status is checked doesn't trigger backfill this
+    # cycle. Self-correcting: the re-triggered tail (or the next tick) reaches it.
+    any_open_gap = False
+
+    async for (device_id, state, is_new), res in traversal.run(
+        device_states,
+        key=lambda entry: entry[0],
+        process=lambda entry: _head_pass_device(
+            entry[0], entry[1], entry[2], integration, auth, pull_config,
+            present_time, guards, stale_drops=stale_drops,
+        ),
+    ):
+        sent, device_failed, transport_failure = res
+        # Single recording site: transport failures arm the breaker, anything
+        # else (success included) breaks the consecutive streak.
+        guards.record(transport_failure=transport_failure)
+        observations_extracted += sent
+        if state.has_gap:
+            any_open_gap = True
+        if device_failed:
+            traversal.mark_failed(device_id)
+
+    failed_devices = traversal.failed_devices
+    deferred_devices = traversal.deferred_devices
+
+    # Policy, deliberately NOT in the traversal (spec D6): a deadline cut gets a
+    # fresh budget immediately; a hot breaker does NOT re-trigger — that would
+    # defeat the pause the breaker exists to buy. Its devices wait for the next
+    # scheduled tick.
+    retrigger_outcome = None
+    if traversal.stop_reason == "deadline" and deferred_devices:
+        retrigger_outcome = await _retrigger_shard(
+            integration, deferred_devices, action_config.generation,
+            manual_run=action_config.manual_run,
+        )
+    if traversal.stop_reason:
+        await _log_deferral(
+            integration, "pull_observations_shard", traversal.stop_reason,
+            deferred_devices,
+            disposition=(
+                "to an immediately re-triggered shard"
+                if retrigger_outcome == RETRIGGER_HANDED_OFF
+                else "to the next scheduled run"
+            ),
+        )
+    if traversal.budget_starved:
+        # Portal WARNING like every other deferral cause: a starved tail must
+        # not park with zero portal visibility (review finding).
+        await _log_deferral(
+            integration, "pull_observations_shard", "connection budget exhausted",
+            deferred_devices, disposition="to the next scheduled run",
+        )
+```
+
+Then replace the `zero_progress` computation with the traversal-backed form:
+
+```python
+    zero_progress = (
+        device_states and traversal.serviced_devices == 0
+        and observations_extracted == 0 and not traversal.deferred_cleanly
+    )
+```
+
+Delete the now-unused `retriggered`, `budget_starved`, `cap_reached`, and `serviced_devices` locals, and the old `slot_starved` handling. Leave the `if failed_devices:` summary, `stale_drops` summary, zero-progress ERROR event, backfill trigger, and result dict exactly as they are.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `./venv/bin/python -m pytest app -q`
+Expected: PASS. Tests asserting the old cap-reached suppression now exercise `deferred_cleanly`; if one fails on the `cap_reached` path specifically, note that `_retrigger_shard` already emits its own ERROR on cap, and `stop_reason` being set makes `deferred_cleanly` true — same suppression, one fewer boolean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/actions/traversal.py app/actions/tests/test_traversal.py app/actions/handlers.py app/actions/tests/
+git commit -m "refactor: extract DeviceTraversal and put the head pass on it"
+```
+
+---
+
+### Task 7: Put the backfill on the shared traversal and stop it raising
+
+**Files:**
+- Modify: `app/actions/handlers.py` (`action_backfill_observations`, ~lines 1279-1400)
+- Test: `app/actions/tests/test_backfill.py`
+
+**Interfaces:**
+- Consumes: `DeviceTraversal` (Task 6)
+- Produces: `action_backfill_observations` gains `result['zero_progress'] = True` on the bad path, matching the shard contract. It no longer raises `LotekException` for zero progress.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_zero_progress_backfill_reports_instead_of_raising(
+    mocker, mock_gundi_client_v2, mock_state_manager
+):
+    """Raising routed through the runner's generic _handle_error, which
+    publishes config_data containing the integration's plaintext auth
+    (GUNDI-5628). Backfill adopts the head pass's ERROR-event + result-flag
+    contract instead (spec D7), and must still suppress the self-retrigger."""
+    from app.actions.handlers import action_backfill_observations
+    from app.actions.configurations import BackfillObservationsConfig
+
+    mocker.patch("app.actions.handlers._backfill_device", side_effect=ValueError("boom"))
+    trigger = mocker.patch("app.actions.handlers.trigger_action", new=AsyncMock())
+    try_log = mocker.patch("app.actions.handlers._try_log_activity", new=AsyncMock())
+
+    result = await action_backfill_observations(
+        mock_gundi_client_v2.get_integration_details.return_value,
+        BackfillObservationsConfig(triggered_by="test"),
+    )
+
+    assert result["zero_progress"] is True
+    # ERROR activity event carries the health signal...
+    assert try_log.await_args.args[3].value == "ERROR"
+    # ...and the cascade stays broken, exactly as the raise used to guarantee.
+    trigger.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_backfill.py::test_zero_progress_backfill_reports_instead_of_raising -v`
+Expected: FAIL — `LotekException` is raised instead of returning a result.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `action_backfill_observations`, replace the loop (from `guards = RunGuards(run_started)` through the end of the `for chunk_start in ...` loop) with:
+
+```python
+        guards = RunGuards(run_started)
+        traversal = DeviceTraversal(
+            integration, "backfill_observations", guards, concurrency=FETCH_CONCURRENCY
+        )
+        observations_extracted = 0
+        gaps_closed = 0
+        windows_advanced_total = 0
+
+        async for (device, state), res in traversal.run(
+            gapped,
+            key=lambda pair: pair[0].nDeviceID,
+            process=lambda pair: _backfill_device(
+                pair[0], pair[1], integration, auth, pull_config, guards
+            ),
+        ):
+            sent, device_failed, transport_failure, gap_closed, windows_advanced = res
+            # Single recording site, mirroring the head pass.
+            guards.record(transport_failure=transport_failure)
+            observations_extracted += sent
+            gaps_closed += int(gap_closed)
+            windows_advanced_total += windows_advanced
+            if device_failed:
+                traversal.mark_failed(device.nDeviceID)
+
+        failed_devices = traversal.failed_devices
+        deferred_devices = traversal.deferred_devices
+
+        # Policy: unlike the shard, backfill never re-triggers its own tail from
+        # here — the cascade below owns that, throttled by gaps_remaining.
+        if traversal.stop_reason:
+            await _log_deferral(
+                integration, "backfill_observations", traversal.stop_reason,
+                deferred_devices,
+            )
+        if traversal.budget_starved:
+            await _log_deferral(
+                integration, "backfill_observations", "connection budget exhausted",
+                deferred_devices, disposition="to the next backfill trigger",
+            )
+```
+
+Replace the zero-progress `raise` block with:
+
+```python
+        zero_progress = (
+            gapped and traversal.serviced_devices == 0
+            and observations_extracted == 0 and not traversal.deferred_cleanly
+        )
+        if zero_progress:
+            # Same systemic-degradation contract as the head pass. Reported, NOT
+            # raised: raising routes through the runner's generic _handle_error,
+            # which publishes config_data containing every integration
+            # configuration — the auth action's plaintext Lotek password
+            # included (GUNDI-5628). An ERROR activity event carries the same
+            # health signal without the credential exposure (spec D7).
+            message = (
+                f"No devices could be backfilled for integration {integration_id}: "
+                f"{len(failed_devices)} failed, {len(deferred_devices)} deferred of "
+                f"{len(gapped)}. See the per-device errors in this action's activity log."
+            )
+            logger.error(message)
+            await _try_log_activity(
+                integration_id, "backfill_observations", message, LogLevel.ERROR
+            )
+```
+
+Add `zero_progress` to the cascade gate — the raise used to break the cascade implicitly, so this must now be explicit:
+
+```python
+        breaker_hot = guards.consecutive_transport_failures >= BREAKER_THRESHOLD
+        gaps_remaining = (
+            any(state.has_gap for _, state in gapped)
+            and not breaker_hot
+            and windows_advanced_total > 0
+            and not traversal.budget_starved
+            # A wholly-failing backfill must not re-trigger itself forever. The
+            # removed raise used to guarantee this by unwinding; now explicit.
+            and not zero_progress
+        )
+```
+
+And add the flag to the result dict:
+
+```python
+        result = {
+            'observations_extracted': observations_extracted,
+            'devices_failed': failed_devices,
+            'devices_deferred': deferred_devices,
+            'gaps_closed': gaps_closed,
+        }
+        if zero_progress:
+            # Only present on the bad path, matching the shard contract.
+            result['zero_progress'] = True
+```
+
+Delete the now-unused `serviced_devices` and `budget_starved` locals and the old `slot_starved` block.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_backfill.py -v`
+Expected: PASS. Any existing test using `pytest.raises(LotekException)` for backfill zero-progress must be rewritten to assert the result flag — that is the intended D7 change. Keep the `LotekException` import only if other tests still use it.
+
+- [ ] **Step 5: Verify the consolidation actually shrank the file**
+
+Run: `wc -l app/actions/handlers.py`
+Expected: **≤ 1,240 lines** (from 1,443 — the spec's ≥200-line success criterion). If it is above that, the traversal seam leaked policy; re-read spec D6 and move it back into the handlers rather than adding traversal flags.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_backfill.py
+git commit -m "refactor: put backfill on the shared traversal and stop it raising"
+```
+
+---
+
+### Task 8: Roll back the backfill claim when no command is published
+
+**Files:**
+- Modify: `app/actions/handlers.py` (backfill-trigger block, ~lines 788-817)
+- Test: `app/actions/tests/test_backfill_trigger_e2e.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (independent; ordered here to keep the refactor commits clean)
+- Produces: no new symbols.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_claim_is_released_when_the_trigger_publish_fails(
+    mocker, mock_gundi_client_v2, mock_state_manager
+):
+    """The claim (TTL 540s) is taken before the publish. If the publish fails,
+    a stale claim suppresses backfill for every other shard this tick AND the
+    next — pre-PR-#20 a lost trigger self-healed on the next run. Roll back."""
+    from app.actions.handlers import action_pull_observations_shard, BACKFILL_TRIGGER_CLAIM_SOURCE
+    from app.actions.configurations import PullObservationsShardConfig
+
+    mock_state_manager.set_if_absent = AsyncMock(return_value=True)
+    mock_state_manager.get_state = AsyncMock(return_value=None)
+    mock_state_manager.delete_state = AsyncMock()
+    mocker.patch("app.actions.handlers.trigger_action", side_effect=RuntimeError("pubsub down"))
+    mocker.patch(
+        "app.actions.handlers._head_pass_device",
+        return_value=(3, False, False),
+    )
+    mocker.patch("app.actions.handlers._load_device_state", return_value=(_gapped_state(), False))
+
+    await action_pull_observations_shard(
+        mock_gundi_client_v2.get_integration_details.return_value,
+        PullObservationsShardConfig(devices=["dev1"]),
+    )
+
+    mock_state_manager.delete_state.assert_awaited_once()
+    assert mock_state_manager.delete_state.await_args.args[1] == "backfill_observations"
+    assert mock_state_manager.delete_state.await_args.kwargs["source_id"] == BACKFILL_TRIGGER_CLAIM_SOURCE
+```
+
+Add the helper at module scope in that test file if it is not already present:
+
+```python
+def _gapped_state():
+    from datetime import datetime, timezone, timedelta
+    from app.actions.device_state import DeviceState
+    now = datetime.now(tz=timezone.utc)
+    return DeviceState(
+        high_water=now, gap_start=now - timedelta(days=3), gap_end=now - timedelta(days=1)
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_backfill_trigger_e2e.py::test_claim_is_released_when_the_trigger_publish_fails -v`
+Expected: FAIL — `AssertionError: Expected 'delete_state' to have been awaited once. Awaited 0 times.`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Restructure the backfill-trigger block in `action_pull_observations_shard`:
+
+```python
+    if any_open_gap and not zero_progress:
+        claimed = False
+        published = False
+        try:
+            # Atomic per-window claim first: concurrent shards all reach this
+            # point within seconds of each other, and the lease below is only
+            # created a pubsub hop later (when the backfill handler runs), so a
+            # plain lease read let every shard publish its own command (review
+            # finding). Exactly one shard wins the claim per window.
+            claimed = await state_manager.set_if_absent(
+                integration_id, "backfill_observations",
+                ttl_seconds=app_settings.MAX_ACTION_EXECUTION_TIME,
+                source_id=BACKFILL_TRIGGER_CLAIM_SOURCE,
+            )
+            lease = await state_manager.get_state(
+                integration_id, "backfill_observations", BACKFILL_LEASE_SOURCE
+            )
+            if claimed and not lease:
+                # backfill_observations is an InternalActionConfiguration with no
+                # persisted portal config, so this MUST carry a non-empty config
+                # override — a bare trigger_action publishes an empty
+                # config_overrides, which execute_action reads as "no config at
+                # all" and 404s before the handler ever runs.
+                await trigger_action(
+                    integration_id, "backfill_observations",
+                    config=BackfillObservationsConfig(
+                        triggered_by="pull_observations_shard",
+                        # Carry the manual marker: without it a Trigger on a
+                        # paused integration pulled head data but its backfill
+                        # skipped on the pause, silently importing no history.
+                        manual_run=action_config.manual_run,
+                    )
+                )
+                published = True
+        except Exception as e:
+            # The shard succeeded; a failed trigger must not fail the run.
+            logger.warning(
+                f"Could not trigger backfill for integration {integration.id}: {describe_exception(e)}"
+            )
+        finally:
+            if claimed and not published:
+                # We consumed the per-window claim but never published, so no
+                # backfill command exists. Leaving the claim would suppress
+                # every other shard this tick AND the next (TTL is a full action
+                # budget); pre-sharding a lost trigger self-healed on the next
+                # run. Give the claim back (review finding).
+                try:
+                    await state_manager.delete_state(
+                        integration_id, "backfill_observations",
+                        source_id=BACKFILL_TRIGGER_CLAIM_SOURCE,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Could not release the backfill trigger claim for integration "
+                        f"{integration.id} (the TTL will expire it): {describe_exception(e)}"
+                    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_backfill_trigger_e2e.py app/actions/tests/test_sharding.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_backfill_trigger_e2e.py
+git commit -m "fix: release the backfill claim when the trigger never publishes"
+```
+
+---
+
+### Task 9: Make the dispatcher skip-streak atomic
+
+**Files:**
+- Modify: `app/services/state.py` (add `increment_counter`)
+- Modify: `app/actions/handlers.py` (`_bump_dispatcher_skip_streak`, ~lines 472-489)
+- Test: `app/services/tests/test_state_manager.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks
+- Produces: `IntegrationStateManager.increment_counter(integration_id, action_id, source_id, ttl_seconds) -> int` — atomic `INCR` plus `EXPIRE`, returning the new value.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_increment_counter_is_atomic_and_expires(state_manager, mock_redis):
+    """Client-side get/int+1/set loses increments under concurrency — the same
+    reason merge_state_fields exists. INCR is atomic; EXPIRE stops abandoned
+    counters leaking keys."""
+    mock_redis.incr = AsyncMock(return_value=3)
+    mock_redis.expire = AsyncMock(return_value=True)
+
+    value = await state_manager.increment_counter(
+        "int-1", "pull_observations", source_id="slot_skip_streak", ttl_seconds=3600
+    )
+
+    assert value == 3
+    mock_redis.incr.assert_awaited_once()
+    mock_redis.expire.assert_awaited_once()
+    assert mock_redis.expire.await_args.args[1] == 3600
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_state_manager.py::test_increment_counter_is_atomic_and_expires -v`
+Expected: FAIL — `AttributeError: 'IntegrationStateManager' object has no attribute 'increment_counter'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `IntegrationStateManager` in `app/services/state.py`, following the retry style of its neighbours:
+
+```python
+    async def increment_counter(
+        self, integration_id: str, action_id: str, source_id: str = "no-source",
+        ttl_seconds: int = 3600,
+    ) -> int:
+        """Atomically increment a small counter and refresh its TTL.
+
+        Used for streak counters. A client-side get / int+1 / set loses
+        increments when two runs overlap — the same race merge_state_fields was
+        added to close — and an untimed key leaks for anything abandoned
+        mid-streak.
+        """
+        key = self._get_key(integration_id, action_id, source_id)
+        for attempt in stamina.retry_context(on=redis.RedisError, attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0):
+            with attempt:
+                value = await self.db_client.incr(key)
+                await self.db_client.expire(key, ttl_seconds)
+        return int(value)
+```
+
+If the private key builder is not named `_get_key`, use whatever the neighbouring methods use — match them exactly.
+
+Then replace `_bump_dispatcher_skip_streak` in `app/actions/handlers.py`:
+
+```python
+async def _bump_dispatcher_skip_streak(integration_id):
+    """Count consecutive dispatcher runs that pulled nothing because the account
+    connection budget was saturated. Atomic INCR: two dispatcher runs in the
+    same window (schedule tick plus a redelivery or manual trigger) both
+    starving would lose an increment under a client-side read-modify-write, and
+    the counter would silently never reach DISPATCHER_SKIP_WARN_AFTER."""
+    return await state_manager.increment_counter(
+        integration_id, "pull_observations",
+        source_id=DISPATCHER_SKIP_STREAK_SOURCE,
+        ttl_seconds=24 * 3600,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/services/tests/test_state_manager.py app/actions/tests/test_sharding.py -v`
+Expected: PASS. Tests that stubbed `get_state`/`set_state` for the streak now need `increment_counter` stubbed instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/state.py app/actions/handlers.py app/services/tests/test_state_manager.py app/actions/tests/test_sharding.py
+git commit -m "fix: make the dispatcher skip-streak counter atomic and self-expiring"
+```
+
+---
+
+### Task 10: Batch the shard's device-state reads
+
+**Files:**
+- Modify: `app/actions/handlers.py` (`action_pull_observations_shard` state-loading loop, ~lines 592-597)
+- Test: `app/actions/tests/test_sharding.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks
+- Produces: no new symbols — reuses the dispatcher's `generate_batches` + `asyncio.gather` pattern and the existing `STATE_READ_CONCURRENCY`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_shard_loads_device_states_concurrently(mocker, mock_gundi_client_v2, mock_state_manager):
+    """The following .sort() forces every state eager, so these reads are a
+    serial startup tax with no network I/O to hide behind — paid again on every
+    re-trigger hop. The dispatcher's identical pattern was batched in PR #20."""
+    from app.actions.handlers import action_pull_observations_shard, STATE_READ_CONCURRENCY
+    from app.actions.configurations import PullObservationsShardConfig
+
+    in_flight = 0
+    peak = 0
+
+    async def slow_load(*args, **kwargs):
+        nonlocal in_flight, peak
+        in_flight += 1
+        peak = max(peak, in_flight)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return (_plain_state(), False)
+
+    mocker.patch("app.actions.handlers._load_device_state", side_effect=slow_load)
+    mocker.patch("app.actions.handlers._head_pass_device", return_value=(0, False, False))
+
+    await action_pull_observations_shard(
+        mock_gundi_client_v2.get_integration_details.return_value,
+        PullObservationsShardConfig(devices=[f"dev{i}" for i in range(10)]),
+    )
+
+    assert peak > 1, "state reads must overlap, not run one-at-a-time"
+```
+
+Add the helper if absent:
+
+```python
+def _plain_state():
+    from datetime import datetime, timezone
+    from app.actions.device_state import DeviceState
+    return DeviceState(high_water=datetime.now(tz=timezone.utc))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_sharding.py::test_shard_loads_device_states_concurrently -v`
+Expected: FAIL — `AssertionError: state reads must overlap, not run one-at-a-time` (peak is 1)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the sequential loading loop in `action_pull_observations_shard`:
+
+```python
+    present_time = datetime.now(tz=timezone.utc)
+    # Batched like the dispatcher's fleet-ordering reads: the sort below forces
+    # every state eager anyway, so sequential awaits were a flat ~SHARD_SIZE
+    # round-trip startup tax per invocation and per re-trigger hop.
+    # _load_device_state performs no Redis write (its legacy-migration branch
+    # only mutates the in-memory state and returns is_new=True for a later
+    # save), so it is side-effect-free and order-independent.
+    device_states = []
+    for batch in generate_batches(list(action_config.devices), STATE_READ_CONCURRENCY):
+        loaded = await asyncio.gather(
+            *(
+                _load_device_state(integration_id, device_id, present_time, pull_config)
+                for device_id in batch
+            )
+        )
+        device_states.extend(
+            (device_id, state, is_new)
+            for device_id, (state, is_new) in zip(batch, loaded)
+        )
+    # Least-fresh first within the shard too: a rail cut defers the freshest tail.
+    device_states.sort(key=lambda entry: entry[1].high_water)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./venv/bin/python -m pytest app/actions/tests/test_sharding.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_sharding.py
+git commit -m "perf: batch the shard's device-state reads like the dispatcher's"
+```
+
+---
+
+### Task 11: Verify the whole consolidation
+
+**Files:**
+- Modify: none expected (fix-ups only if verification fails)
+
+- [ ] **Step 1: Full suite, with timing**
+
+Run: `./venv/bin/python -m pytest app -q --durations=10`
+Expected: PASS, wall time **< 2 s**. If any test now sleeps, patch `SLOT_WAIT_POLL_INITIAL` / `SLOT_WAIT_POLL_MAX` / `SLOT_WAIT_JITTER` to 0 in it.
+
+- [ ] **Step 2: Confirm the test count did not regress**
+
+Run: `./venv/bin/python -m pytest app -q 2>&1 | tail -3`
+Expected: **≥ 263 tests** (PR #20's count) — Tasks 1-10 add roughly 15 and rewrite a handful; none should be net deleted except the backfill `pytest.raises(LotekException)` zero-progress cases replaced in Task 7.
+
+- [ ] **Step 3: Confirm the success criteria from the spec**
+
+```bash
+wc -l app/actions/handlers.py                    # target: <= 1240 (was 1443)
+grep -c "^[A-Z_]* = " app/actions/handlers.py    # constants: expect <= 20 (was 22)
+grep -n "raise LotekException" app/actions/handlers.py   # expect: no zero-progress hit
+grep -rn "config_data" app/actions/handlers.py   # expect: no matches
+```
+
+Expected: all four hold. The last two are the spec's criterion 4 — no `raise`-based leak surface left in the file.
+
+- [ ] **Step 4: Confirm the duplication is actually gone**
+
+```bash
+grep -c "return_exceptions=True" app/actions/handlers.py   # expect 0 (moved to traversal.py)
+grep -c "LotekUnauthorizedException, asyncio.CancelledError" app/actions/handlers.py  # expect 0
+```
+
+Expected: both 0 — the chunked-loop mechanics now exist in exactly one place. If either is non-zero, a handler kept its own copy and Task 6/7 is incomplete.
+
+- [ ] **Step 5: Commit any fix-ups and push**
+
+```bash
+git add -A
+git commit -m "test: verify rail consolidation end to end"
+git push -u origin feat/GUNDI-5626-rail-consolidation
+```
+
+- [ ] **Step 6: Stage verification before the large-fleet rollout**
+
+This plan changes concurrency behaviour, and the unit suite cannot prove the queueing arithmetic. Before rolling out to the 616/424/302-device accounts, on stage:
+
+1. Point a stage integration at an account with **more devices than `SHARD_SIZE * (LOTEK_MAX_CONNECTIONS / FETCH_CONCURRENCY)`** — i.e. genuinely oversubscribed. Temporarily lower `SHARD_SIZE` to 5 and `LOTEK_MAX_CONNECTIONS` to 4 to force it on a small account.
+2. Confirm in the logs: shards **queue and complete** rather than mass-deferring; zero `cap_reached` ERROR events; `devices_deferred` empty or tiny; every cursor advanced.
+3. Confirm exactly **one** backfill invocation across the concurrent shards (the claim still works, and Task 8 did not make it releasable too eagerly).
+4. Record the observed queueing time per shard. If it approaches `DEADLINE_FRACTION * MAX_ACTION_EXECUTION_TIME`, raise `LOTEK_MAX_CONNECTIONS` rather than shrinking the partitioning constants (spec D1).

--- a/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
+++ b/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
@@ -103,8 +103,16 @@ their own accumulators inline via `async for`, so `gaps_closed` / `windows_advan
 `any_open_gap` need no callback plumbing.
 
 This also retires the three parallel booleans (`retriggered` / `budget_starved` /
-`cap_reached`) in favour of traversal attributes plus one `deferred_cleanly` property, which
-is what drifted in symptom 2.
+`cap_reached`) in favour of traversal attributes plus one locally-computed
+`deferred_cleanly` expression per caller, which is what drifted in symptom 2.
+
+The suppression expression stays in the **caller**, not the traversal: the two handlers
+genuinely disagree about what counts as a clean deferral. The shard suppresses its
+zero-progress ERROR on a successful hand-off, a cap-reached deferral, or starvation, but
+*not* on a breaker stop; the backfill suppresses on starvation only. Hoisting a single
+`deferred_cleanly` onto the traversal would silently suppress outage alerts in both — and
+the cdip health metric counts ERROR events, so that would make a real Lotek outage look
+healthier than it is. Alerting behaviour must be unchanged by this refactor.
 
 ### D7. Backfill zero-progress stops raising
 

--- a/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
+++ b/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
@@ -1,0 +1,157 @@
+# Lotek connector: consolidate the accumulated safety rails
+
+**Ticket**: GUNDI-5626 (proposed) · **Status**: draft 2026-08-20 · **Repo**: gundi-integration-lotek
+
+## Problem
+
+Seven PRs (#14–#20) landed on `app/actions/handlers.py` between 2026-08-12 and 2026-08-17,
+each a locally correct response to a real production symptom. The file went from **354 lines
+on `main` to 1,443 lines at PR #20's head — 4.1x**. It now carries 22 module-level constants
+and eight distinct coordination mechanisms (backfill lease, backfill trigger claim, dispatcher
+skip streak, Redis connection slot, re-trigger generation counter, in-memory breaker, deadline
+fraction, per-device gap fields).
+
+Nothing in that history was gold-plating. The problem is that each fix **added a governor
+without reconciling it against the existing ones**, so the intermediate scaffolding is all
+still present and the mechanisms now interact in ways no single-mechanism review catches.
+
+Two concrete symptoms:
+
+1. **Un-reconciled concurrency arithmetic.** The PR #20 review's top finding is not a bug
+   inside any one mechanism — it is a bug in their composition. A 616-device account fans
+   out 25 shards, each opening a `FETCH_CONCURRENCY = 5` chunk, so ~125 slot acquires race a
+   `LOTEK_MAX_CONNECTIONS = 20` ceiling. `lotek_slot` is fail-fast, and a *single* refused
+   device defers that shard's **entire remaining tail** and re-triggers with no backoff. On
+   exactly the fleets sharding was built to serve, zero-progress churn and cap-reached portal
+   ERRORs become steady state.
+
+2. **A ~270-line traversal, twice.** `action_pull_observations_shard` (273 lines) and
+   `action_backfill_observations` (272 lines) implement the same chunked device loop —
+   `RunGuards`, `should_stop`, `asyncio.gather(..., return_exceptions=True)`, fatal re-raise,
+   `slot_starved` collection, per-device failure logging, deferred-tail computation. The two
+   copies have already drifted once (`cap_reached` is tracked in one and not the other;
+   harmless today only because a different boolean happens to suppress the same branch).
+
+## Design
+
+### D1. Exactly one concurrency governor
+
+The three constants that look like concurrency knobs have distinct jobs, and conflating them
+is the root of symptom 1. After this change:
+
+| Constant | Role | Is it a concurrency limit? |
+|---|---|---|
+| `LOTEK_MAX_CONNECTIONS` (20) | Account-wide ceiling on simultaneous Lotek requests, enforced in Redis across invocations | **Yes — the only one** |
+| `FETCH_CONCURRENCY` (5) | How many devices one invocation processes per chunk | No — in-process batching |
+| `SHARD_SIZE` (25) | How much work fits in one action budget | No — work partitioning |
+
+`FETCH_CONCURRENCY` and `SHARD_SIZE` become *work-partitioning* parameters that may
+oversubscribe the budget freely, because the budget itself now applies backpressure instead
+of refusing. This is documented at the constants and pinned by a test.
+
+### D2. The slot waits instead of refusing
+
+`lotek_slot` becomes a **bounded, deadline-aware wait**: poll the acquire with jittered
+backoff until a slot frees, giving up only when waiting longer would eat the caller's own
+action deadline. `NoConnectionSlot` is then a genuine "the account is saturated for longer
+than my remaining budget" signal rather than "someone else got there first this millisecond".
+
+Rationale: with 20 slots and per-request latencies of ~1–3s, a 616-device fleet's ~616
+requests drain in ~30–90s of queueing, comfortably inside a 540s budget. Waiting converts
+starvation from a whole-tail abort into a short queue. The deadline guard still protects the
+budget, so the change cannot cause a timeout that fail-fast would have avoided.
+
+Rejected alternative: have the dispatcher fan out in waves sized to the budget. The dispatcher
+publishes fire-and-forget pubsub messages and never learns when a shard finishes, so it cannot
+sequence waves. Backpressure has to live at the resource.
+
+### D3. Starvation defers only the starved devices
+
+Even with D2, a genuine saturation must not abort a whole shard. The deferral narrows to the
+devices that actually failed to get a slot; their in-chunk peers keep their results and the
+loop continues.
+
+### D4. The slot acquire becomes idempotent
+
+The acquire token is generated once *outside* the retry loop and the Lua gates purely on
+`ZCARD`, so a lost reply on the acquire that takes the last slot refuses the very caller that
+owns it and leaks that slot for the full 300s TTL. A `ZSCORE` membership fast-path returning 1
+for an already-present token makes the retry idempotent. This is a **prerequisite** for D2:
+waiting means more acquire attempts, which makes the lost-reply window materially more likely.
+
+### D5. The slot uses the codebase's Redis retry policy
+
+`lotek_connections.py` re-implements the retry policy as `attempts=3, wait_initial=0.1,
+wait_max=2.0` under a comment claiming parity with `IntegrationStateManager`, whose fourteen
+Redis call sites all use `attempts=5, wait_initial=1.0, wait_max=30, wait_jitter=3.0`. A
+multi-second Redis brownout that every `get_state` survives exhausts the slot's sub-second
+budget and escapes as `RedisError` into the generic per-device handler — a **fabricated Lotek
+failure caused by our own Redis**, which is exactly what the comment claims to prevent. Adopt
+the shared policy.
+
+### D6. One device traversal
+
+Extract the shared mechanics into a `DeviceTraversal` helper that owns: chunking, the
+`gather` with `return_exceptions=True`, fatal re-raise of `LotekUnauthorizedException` /
+`CancelledError`, per-device failure logging, slot-starvation collection, guard-stop
+detection, and deferred-tail computation.
+
+The seam is deliberate: **mechanics in the traversal, policy in the caller.** The traversal
+does not decide whether to re-trigger, what the deferral message says, or what zero progress
+means — those differ between head pass and backfill and stay in the handlers. Callers fold
+their own accumulators inline via `async for`, so `gaps_closed` / `windows_advanced_total` /
+`any_open_gap` need no callback plumbing.
+
+This also retires the three parallel booleans (`retriggered` / `budget_starved` /
+`cap_reached`) in favour of traversal attributes plus one `deferred_cleanly` property, which
+is what drifted in symptom 2.
+
+### D7. Backfill zero-progress stops raising
+
+`action_backfill_observations` still `raise`s `LotekException` on zero progress. That routes
+through the runner's generic `_handle_error`, which publishes `config_data` containing every
+integration configuration — the auth action's plaintext Lotek password included (see
+**GUNDI-5628**). The head pass already replaced this with an ERROR activity event plus a
+machine-readable result flag; backfill adopts the same form. This removes the last credential-
+leak-by-`raise` in the file and makes the two handlers' zero-progress contract identical,
+which is a precondition for them sharing the traversal cleanly.
+
+Behaviour change to note: the raise previously also broke the self-retrigger cascade. The
+replacement must keep that property explicitly — `zero_progress` suppresses `gaps_remaining`.
+
+### D8. Small fixes folded in
+
+- **Backfill claim rollback.** The `set_if_absent` claim (TTL 540s) is taken *before* the
+  lease check and the publish, and is never rolled back, so a swallowed publish failure
+  suppresses backfill for every other shard this tick and the next. Delete the claim when the
+  publish does not happen.
+- **Skip-streak counter.** Client-side get/increment/set with no TTL, in the same file whose
+  state manager added atomic Lua merge because client-side read-modify-write loses updates.
+  Move to `INCR` + `EXPIRE`.
+- **Shard state batching.** The shard loads its 25 device states with sequential awaits, and
+  the following `.sort()` forces them all eager, while the dispatcher's identical pattern was
+  converted to bounded-concurrency `gather` in PR #20. Reuse that pattern.
+
+## Non-goals
+
+- **Per-shard portal reload.** `execute_action` always resolves the action config, and the
+  internal `pull_observations_shard` key is never cached, so every shard forces a full Gundi
+  portal round trip (~25/tick on a large account). The fix belongs in `config_manager`
+  (negative caching for internal actions), which is vendored template code — tracked with
+  **GUNDI-5628** rather than diverging this repo's copy.
+- **`TRIGGER_ACTIONS_ALWAYS_SYNC` nested budgets.** Real, but the flag is dev-only, defaults
+  false, and appears in no env file, compose file, or CI workflow.
+- **Dispatcher demand shaping on healthy ticks.** D2 makes it unnecessary; revisit only if
+  the 616-device rollout shows queueing dominating the budget.
+- **Behaviour changes to what gets fetched or delivered.** This is a structural consolidation.
+  Observation output must be byte-identical.
+
+## Success criteria
+
+1. `handlers.py` drops by **≥ 200 lines** with no loss of behaviour.
+2. A test pins that oversubscribed fan-out (shards × `FETCH_CONCURRENCY` > `LOTEK_MAX_CONNECTIONS`)
+   makes progress rather than mass-deferring.
+3. A test pins that a lost acquire reply does not strand a slot.
+4. No `raise` in either action's zero-progress path; no `config_data` leak surface left in
+   `handlers.py`.
+5. Full suite green, still under the 2s budget, with no net loss of test count.

--- a/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
+++ b/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
@@ -178,8 +178,11 @@ into the traversal to chase a line count.
 4. A test pins that oversubscribed fan-out (shards × `FETCH_CONCURRENCY` > `LOTEK_MAX_CONNECTIONS`)
    makes progress rather than mass-deferring.
 5. A test pins that a lost acquire reply does not strand a slot.
-6. No `raise` in either action's zero-progress path; no `config_data` leak surface left in
-   `handlers.py`.
+6. No `raise` in either action's zero-progress path (`grep -n "raise LotekException"` over
+   `handlers.py` returns nothing), and therefore no route from a zero-progress run into the
+   runner's `_handle_error` `config_data` publish. Note the literal `config_data` string
+   still appears in `handlers.py` inside explanatory comments that name the leak being
+   avoided — the criterion is about the code path, not the token.
 7. Full suite green, under 3.0s, with no net loss of test count.
 8. **Alerting is unchanged.** Which runs emit a zero-progress ERROR must be identical
    before and after: the shard suppresses on hand-off / cap-reached / starvation but not on

--- a/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
+++ b/docs/superpowers/specs/2026-08-20-lotek-consolidation-design.md
@@ -156,10 +156,31 @@ replacement must keep that property explicitly — `zero_progress` suppresses `g
 
 ## Success criteria
 
-1. `handlers.py` drops by **≥ 200 lines** with no loss of behaviour.
-2. A test pins that oversubscribed fan-out (shards × `FETCH_CONCURRENCY` > `LOTEK_MAX_CONNECTIONS`)
+**Amended 2026-08-20, mid-execution.** Criterion 1 originally read "`handlers.py` drops by
+≥ 200 lines". That was a bad proxy and is corrected here rather than quietly re-banded.
+Extracting shared mechanics into a new module **relocates** lines and adds a class scaffold,
+docstrings, and imports; it does not delete 200 of them. This plan also deliberately *adds*
+code (D1's comments, the per-caller suppression expressions, D8's claim-rollback `finally`).
+Measured after the head-pass conversion: `handlers.py` 1443 → 1398, with a new 107-line
+`traversal.py`, so combined lines went *up* by 62. The consolidation's value is that the
+loop logic exists **once** instead of twice — which shows up in the duplication greps and in
+the per-handler length, not in a whole-file total. Do not cut behaviour or move policy back
+into the traversal to chase a line count.
+
+1. The two duplication greps over `handlers.py` both return **0**: `return_exceptions=True`
+   and `LotekUnauthorizedException, asyncio.CancelledError`. This is the binding criterion —
+   it is what proves the chunked-loop mechanics exist in exactly one place.
+2. Each of the two loop-bearing handlers drops by roughly **45-55 lines**:
+   `action_pull_observations_shard` 273 → ~225 (measured: 225), and
+   `action_backfill_observations` 274 → ~226.
+3. `handlers.py` lands near **1,350** lines (a ~6% reduction), and `handlers.py` +
+   `traversal.py` combined stays roughly flat against the 1,443 baseline.
+4. A test pins that oversubscribed fan-out (shards × `FETCH_CONCURRENCY` > `LOTEK_MAX_CONNECTIONS`)
    makes progress rather than mass-deferring.
-3. A test pins that a lost acquire reply does not strand a slot.
-4. No `raise` in either action's zero-progress path; no `config_data` leak surface left in
+5. A test pins that a lost acquire reply does not strand a slot.
+6. No `raise` in either action's zero-progress path; no `config_data` leak surface left in
    `handlers.py`.
-5. Full suite green, still under the 2s budget, with no net loss of test count.
+7. Full suite green, under 3.0s, with no net loss of test count.
+8. **Alerting is unchanged.** Which runs emit a zero-progress ERROR must be identical
+   before and after: the shard suppresses on hand-off / cap-reached / starvation but not on
+   a breaker stop; the backfill suppresses on starvation only.


### PR DESCRIPTION
## GUNDI-5620: shard the head pass so large accounts stop hitting the 540s ceiling

After the shared HTTP client (#17) and concurrent fetching (#19), the remaining timeouts on large accounts (616/424/302 devices) are structural: one action still services an entire fleet inside one 540s budget. This PR adopts the Movebank connector's execution model instead.

### What changed

- **`pull_observations` is now a dispatcher**: lists devices, orders them least-fresh first, triggers one `pull_observations_shard` sub-action per 25 devices. Each shard gets its own full action budget. Publish failures are per-shard, never fatal to the fan-out.
- **`pull_observations_shard`** carries the previous per-device loop. A deadline-cut shard re-triggers its tail immediately (fresh budget, capped at 3 hops → then next tick + ERROR); a hot breaker deliberately does not re-trigger; connection-budget starvation defers, re-triggers and reports a WARNING, never a failure.
- **`lotek_slot`**: Redis per-account connection semaphore (`LOTEK_MAX_CONNECTIONS=20`). Shards run as separate invocations, so only an out-of-process cap can bound concurrent requests against one Lotek account. Backfill honors it too and throttles its own cascade when starved.
- **`manual_run`** flows dispatcher → shard → backfill, so the portal's Trigger button still pulls (and imports history) on a paused integration.

### Movebank parity

| Behavior | Movebank | Lotek (this PR) |
|---|---|---|
| Work per action budget | 1 individual per sub-action | 1 shard of ≤25 devices |
| Scheduled action | Lists + triggers sub-actions | Same (dispatcher only) |
| Budget exhausted mid-run | Persist cursor, self-retrigger | Re-trigger tail (capped at 3 hops) |
| Connection cap across invocations | `movebank_slot` Redis semaphore | `lotek_slot` Redis semaphore |
| Budget exhaustion semantics | Clean skip/re-trigger, never a failure | Same |

Deliberate divergence: 25-device shards instead of Movebank's 1-source sub-actions — Lotek accounts have hundreds of devices, and per-device pubsub messages would recreate GUNDI-5602's publish congestion.

### Result-contract change

`pull_observations` no longer does the fetching, so it no longer returns `observations_extracted` / `devices_failed` / `devices_deferred` — those now belong to each `pull_observations_shard` result and its completion event. The dispatcher returns `devices_found` and `shards_triggered` (plus `devices_undispatched` on a publish failure). **Anything aggregating per-tick throughput must sum the shard results.**

### Review rounds (all fixed in this branch)

Three review passes ran before human review — two adversarial agents, this repo's `/code-review`, and Copilot. Notable outcomes:

- **Credential exposure**: the zero-progress path used to `raise`, which routes through the runner's generic `_handle_error` — and that publishes every integration configuration, auth included (plaintext Lotek password), into the failure event. Fan-out would have leaked it once per shard, up to 25× per outage tick. Both that path and the dispatcher's failure path now emit an ERROR activity event plus a result flag, which carries the same health signal without the exposure.
- **Publish volume**: shards run with `@activity_logger(on_start=False)`, and an atomic `set_if_absent` claim means one backfill command per window instead of one per shard — both aimed at the aiohttp/pubsub path GUNDI-5620 blamed for ~700 of ~2000 ERROR entries.
- **Governors**: re-trigger generation cap; starvation and cap-reached deferrals never raise and never double-alert; deferral WARNINGs on every cut cause; per-device errors attributed to the shard action; skip-streak accuracy.
- **Hygiene**: slot keys get a refreshed TTL (idle accounts no longer leak keys); the slot Redis client is closed on shutdown; bounded-concurrency cursor reads in the dispatcher.

### Verified

- **263 tests passing**, including sharding, the re-trigger governor, the slot semaphore, and the manual-run/backfill-claim paths.
- **Stage, production sizing** (`SHARD_SIZE=25`, 20-device account): dispatcher → shard → 20 devices serviced → backfill triggered once → gaps closed, all cursors advanced, 6 batches delivered, no leftover slots, zero errors.
- **Stage, multi-shard** (`SHARD_SIZE` temporarily lowered to 5): 4 shards × 5 devices and **exactly one** backfill invocation across 4 concurrent shards — the atomic claim doing its job. Zero errors, zero deferrals.

Known follow-ups (not blockers): distributed token single-flight before the 616-device rollout (`_token_locks` is per-process while shards run cross-pod); dispatch demand-shaping on healthy ticks; a monotonic `max()` for `high_water` in the state-manager Lua (template file, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
